### PR TITLE
Add JSON formatting tests for models

### DIFF
--- a/models/cambioshorario_test.go
+++ b/models/cambioshorario_test.go
@@ -1,0 +1,33 @@
+package models
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestCambiosHorarioMarshalJSON(t *testing.T) {
+	fecha := time.Date(2024, time.January, 2, 0, 0, 0, 0, time.UTC)
+	c := CambiosHorario{FECHA: fecha}
+
+	b, err := json.Marshal(c)
+	if err != nil {
+		t.Fatalf("json.Marshal returned error: %v", err)
+	}
+
+	var data map[string]interface{}
+	if err := json.Unmarshal(b, &data); err != nil {
+		t.Fatalf("json.Unmarshal returned error: %v", err)
+	}
+
+	if data["fechaCambioHorario"] != "02-01-2024" {
+		t.Errorf("expected fechaCambioHorario 02-01-2024, got %v", data["fechaCambioHorario"])
+	}
+}
+
+func TestCambiosHorarioTableName(t *testing.T) {
+	c := CambiosHorario{}
+	if c.TableName() != "CAMBIOS_HORARIO" {
+		t.Errorf("expected table name CAMBIOS_HORARIO, got %s", c.TableName())
+	}
+}

--- a/models/domicilio_test.go
+++ b/models/domicilio_test.go
@@ -1,0 +1,45 @@
+package models
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestDomicilioMarshalJSON(t *testing.T) {
+	fecha := time.Date(2024, time.August, 10, 0, 0, 0, 0, time.UTC)
+	created := time.Date(2024, time.August, 9, 14, 30, 0, 0, time.UTC)
+	updated := time.Date(2024, time.August, 11, 15, 45, 0, 0, time.UTC)
+	d := Domicilio{
+		FECHA:      fecha,
+		CREATED_AT: created,
+		UPDATED_AT: updated,
+	}
+
+	b, err := json.Marshal(d)
+	if err != nil {
+		t.Fatalf("json.Marshal returned error: %v", err)
+	}
+
+	var data map[string]interface{}
+	if err := json.Unmarshal(b, &data); err != nil {
+		t.Fatalf("json.Unmarshal returned error: %v", err)
+	}
+
+	if data["fechaDomicilio"] != "10-08-2024" {
+		t.Errorf("expected fechaDomicilio 10-08-2024, got %v", data["fechaDomicilio"])
+	}
+	if data["createdAt"] != "09-08-2024 14:30:00" {
+		t.Errorf("expected createdAt 09-08-2024 14:30:00, got %v", data["createdAt"])
+	}
+	if data["updatedAt"] != "11-08-2024 15:45:00" {
+		t.Errorf("expected updatedAt 11-08-2024 15:45:00, got %v", data["updatedAt"])
+	}
+}
+
+func TestDomicilioTableName(t *testing.T) {
+	d := Domicilio{}
+	if d.TableName() != "DOMICILIO" {
+		t.Errorf("expected table name DOMICILIO, got %s", d.TableName())
+	}
+}

--- a/models/incidencia_test.go
+++ b/models/incidencia_test.go
@@ -1,0 +1,33 @@
+package models
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestIncidenciaMarshalJSON(t *testing.T) {
+	fecha := time.Date(2024, time.June, 3, 0, 0, 0, 0, time.UTC)
+	i := Incidencia{FECHA: fecha}
+
+	b, err := json.Marshal(i)
+	if err != nil {
+		t.Fatalf("json.Marshal returned error: %v", err)
+	}
+
+	var data map[string]interface{}
+	if err := json.Unmarshal(b, &data); err != nil {
+		t.Fatalf("json.Unmarshal returned error: %v", err)
+	}
+
+	if data["fechaIncidencia"] != "03-06-2024" {
+		t.Errorf("expected fechaIncidencia 03-06-2024, got %v", data["fechaIncidencia"])
+	}
+}
+
+func TestIncidenciaTableName(t *testing.T) {
+	i := Incidencia{}
+	if i.TableName() != "INCIDENCIA" {
+		t.Errorf("expected table name INCIDENCIA, got %s", i.TableName())
+	}
+}

--- a/models/nomina_test.go
+++ b/models/nomina_test.go
@@ -1,0 +1,33 @@
+package models
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestNominaMarshalJSON(t *testing.T) {
+	fecha := time.Date(2024, time.July, 5, 0, 0, 0, 0, time.UTC)
+	n := Nomina{FECHA: fecha}
+
+	b, err := json.Marshal(n)
+	if err != nil {
+		t.Fatalf("json.Marshal returned error: %v", err)
+	}
+
+	var data map[string]interface{}
+	if err := json.Unmarshal(b, &data); err != nil {
+		t.Fatalf("json.Unmarshal returned error: %v", err)
+	}
+
+	if data["fechaNomina"] != "05-07-2024" {
+		t.Errorf("expected fechaNomina 05-07-2024, got %v", data["fechaNomina"])
+	}
+}
+
+func TestNominaTableName(t *testing.T) {
+	n := Nomina{}
+	if n.TableName() != "NOMINA" {
+		t.Errorf("expected table name NOMINA, got %s", n.TableName())
+	}
+}

--- a/models/pedido_test.go
+++ b/models/pedido_test.go
@@ -1,0 +1,37 @@
+package models
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestPedidoMarshalJSON(t *testing.T) {
+	fecha := time.Date(2024, time.May, 1, 0, 0, 0, 0, time.UTC)
+	updated := time.Date(2024, time.May, 2, 12, 0, 0, 0, time.UTC)
+	p := Pedido{FECHA: fecha, UPDATED_AT: updated}
+
+	b, err := json.Marshal(p)
+	if err != nil {
+		t.Fatalf("json.Marshal returned error: %v", err)
+	}
+
+	var data map[string]interface{}
+	if err := json.Unmarshal(b, &data); err != nil {
+		t.Fatalf("json.Unmarshal returned error: %v", err)
+	}
+
+	if data["fechaPedido"] != "01-05-2024" {
+		t.Errorf("expected fechaPedido 01-05-2024, got %v", data["fechaPedido"])
+	}
+	if data["updatedAt"] != "02-05-2024 12:00:00" {
+		t.Errorf("expected updatedAt 02-05-2024 12:00:00, got %v", data["updatedAt"])
+	}
+}
+
+func TestPedidoTableName(t *testing.T) {
+	p := Pedido{}
+	if p.TableName() != "PEDIDO" {
+		t.Errorf("expected table name PEDIDO, got %s", p.TableName())
+	}
+}

--- a/models/reserva_test.go
+++ b/models/reserva_test.go
@@ -1,0 +1,33 @@
+package models
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestReservaMarshalJSON(t *testing.T) {
+	fecha := time.Date(2024, time.September, 12, 0, 0, 0, 0, time.UTC)
+	r := Reserva{FECHA: fecha}
+
+	b, err := json.Marshal(r)
+	if err != nil {
+		t.Fatalf("json.Marshal returned error: %v", err)
+	}
+
+	var data map[string]interface{}
+	if err := json.Unmarshal(b, &data); err != nil {
+		t.Fatalf("json.Unmarshal returned error: %v", err)
+	}
+
+	if data["fechaReserva"] != "12-09-2024" {
+		t.Errorf("expected fechaReserva 12-09-2024, got %v", data["fechaReserva"])
+	}
+}
+
+func TestReservaTableName(t *testing.T) {
+	r := Reserva{}
+	if r.TableName() != "RESERVA" {
+		t.Errorf("expected table name RESERVA, got %s", r.TableName())
+	}
+}

--- a/models/trabajador_test.go
+++ b/models/trabajador_test.go
@@ -1,0 +1,45 @@
+package models
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestTrabajadorMarshalJSON(t *testing.T) {
+	nacimiento := time.Date(1990, time.March, 1, 0, 0, 0, 0, time.UTC)
+	ingreso := time.Date(2023, time.February, 10, 9, 15, 30, 0, time.UTC)
+	retiro := time.Date(2024, time.April, 5, 18, 0, 0, 0, time.UTC)
+	tr := Trabajador{
+		FECHA_NACIMIENTO: &nacimiento,
+		FECHA_INGRESO:    ingreso,
+		FECHA_RETIRO:     &retiro,
+	}
+
+	b, err := json.Marshal(tr)
+	if err != nil {
+		t.Fatalf("json.Marshal returned error: %v", err)
+	}
+
+	var data map[string]interface{}
+	if err := json.Unmarshal(b, &data); err != nil {
+		t.Fatalf("json.Unmarshal returned error: %v", err)
+	}
+
+	if data["fechaNacimiento"] != "01-03-1990" {
+		t.Errorf("expected fechaNacimiento 01-03-1990, got %v", data["fechaNacimiento"])
+	}
+	if data["fechaIngreso"] != "10-02-2023 09:15:30" {
+		t.Errorf("expected fechaIngreso 10-02-2023 09:15:30, got %v", data["fechaIngreso"])
+	}
+	if data["fechaRetiro"] != "05-04-2024 18:00:00" {
+		t.Errorf("expected fechaRetiro 05-04-2024 18:00:00, got %v", data["fechaRetiro"])
+	}
+}
+
+func TestTrabajadorTableName(t *testing.T) {
+	tr := Trabajador{}
+	if tr.TableName() != "TRABAJADOR" {
+		t.Errorf("expected table name TRABAJADOR, got %s", tr.TableName())
+	}
+}


### PR DESCRIPTION
## Summary
- add unit tests for Domicilio, Nomina, CambiosHorario, Incidencia, Trabajador, Pedido, and Reserva models
- verify custom JSON date formatting and table name mappings

## Testing
- `go test ./...` *(fails: no output)*

------
https://chatgpt.com/codex/tasks/task_e_689fec9e3dec8325b8b3b2bb373e848b