### PR TITLE
Configure isolated Beego test environment

### DIFF
--- a/conf/app.test.conf
+++ b/conf/app.test.conf
@@ -1,0 +1,16 @@
+appname = restaurante
+httpport = 8080
+runmode = test
+
+# Otras configuraciones
+enabledocs = false
+copyrequestbody = true
+swagger = false
+
+# Configuración de la base de datos de pruebas
+db_host = localhost
+db_port = 5432
+db_user = postgres
+db_pass = 12346
+db_name = restaurante_test_db
+

--- a/tests/default_test.go
+++ b/tests/default_test.go
@@ -3,8 +3,6 @@ package test
 import (
 	"net/http"
 	"net/http/httptest"
-	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/beego/beego/v2/core/logs"
@@ -14,12 +12,6 @@ import (
 	beego "github.com/beego/beego/v2/server/web"
 	. "github.com/smartystreets/goconvey/convey"
 )
-
-func init() {
-	_, file, _, _ := runtime.Caller(0)
-	apppath, _ := filepath.Abs(filepath.Dir(filepath.Join(file, ".."+string(filepath.Separator))))
-	beego.TestBeegoInit(apppath)
-}
 
 // TestBeego is a sample to run an endpoint test
 func TestBeego(t *testing.T) {

--- a/tests/setup_test.go
+++ b/tests/setup_test.go
@@ -1,0 +1,27 @@
+package test
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"restaurante/database"
+
+	beego "github.com/beego/beego/v2/server/web"
+)
+
+// TestMain sets up Beego and a dedicated test database before running tests.
+func TestMain(m *testing.M) {
+	_, file, _, _ := runtime.Caller(0)
+	appPath, _ := filepath.Abs(filepath.Dir(filepath.Join(file, ".."+string(filepath.Separator))))
+	os.Setenv("BEEGO_APP_CONFIG_FILE", filepath.Join(appPath, "conf", "app.test.conf"))
+	os.Chdir(appPath)
+	beego.TestBeegoInit(appPath)
+
+	// Initialize the database using the test configuration
+	database.InitDB()
+
+	code := m.Run()
+	os.Exit(code)
+}


### PR DESCRIPTION
## Summary
- Add `TestMain` to initialize Beego and load a dedicated test database configuration
- Provide `app.test.conf` with test database credentials
- Streamline default test to use the shared setup

## Testing
- `go test ./...` *(fails: dial tcp [::1]:5432: connect: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_689fec9d9184832594dd1c7e0a66a745