### PR TITLE
Add controller unit tests

### DIFF
--- a/controllers/cliente_controller_test.go
+++ b/controllers/cliente_controller_test.go
@@ -1,0 +1,48 @@
+package controllers
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/beego/beego/v2/server/web/context"
+)
+
+func TestNormalizeEmail(t *testing.T) {
+	got := normalizeEmail("  Foo@Example.COM  ")
+	if got != "foo@example.com" {
+		t.Errorf("expected foo@example.com, got %s", got)
+	}
+}
+
+func TestIsUniqueEmailErr(t *testing.T) {
+	uniqueErr := errors.New("pq: duplicate key value violates unique constraint \"uq_cliente_correo\"")
+	if !isUniqueEmailErr(uniqueErr) {
+		t.Errorf("expected true for unique email error")
+	}
+	otherErr := errors.New("some other error")
+	if isUniqueEmailErr(otherErr) {
+		t.Errorf("expected false for non unique email error")
+	}
+}
+
+func TestClienteGetAllWithoutDB(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/restaurante/v1/clientes", nil)
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	c := ClienteController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	c.GetAll()
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected status 500, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "Error al obtener clientes") {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
+}

--- a/controllers/controller_test_utils_test.go
+++ b/controllers/controller_test_utils_test.go
@@ -1,0 +1,37 @@
+package controllers
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+
+	"github.com/beego/beego/v2/client/orm"
+)
+
+type mockDriver struct{}
+
+func (d mockDriver) Open(name string) (driver.Conn, error) {
+	return &mockConn{}, nil
+}
+
+type mockConn struct{}
+
+func (c *mockConn) Prepare(query string) (driver.Stmt, error) {
+	return nil, errors.New("not implemented")
+}
+func (c *mockConn) Close() error              { return nil }
+func (c *mockConn) Begin() (driver.Tx, error) { return nil, errors.New("not implemented") }
+func (c *mockConn) ExecContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
+	return nil, errors.New("mock exec error")
+}
+func (c *mockConn) QueryContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
+	return nil, errors.New("mock query error")
+}
+func (c *mockConn) Ping(ctx context.Context) error { return nil }
+
+func init() {
+	sql.Register("mock", mockDriver{})
+	orm.RegisterDriver("mock", orm.DRPostgres)
+	orm.RegisterDataBase("default", "mock", "")
+}

--- a/controllers/restaurante_controller_test.go
+++ b/controllers/restaurante_controller_test.go
@@ -1,0 +1,29 @@
+package controllers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/beego/beego/v2/server/web/context"
+)
+
+func TestRestauranteGetAllWithoutDB(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/restaurante/v1/restaurantes", nil)
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	c := RestauranteController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	c.GetAll()
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected status 500, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "Error al obtener restaurantes") {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
+}


### PR DESCRIPTION
## Summary
- add tests for ClienteController helper functions and GetAll error handling
- add tests for RestauranteController GetAll error handling
- introduce mock database driver for controller tests

## Testing
- `go test ./controllers -run Test`
- `go test ./...` *(fails: Register db Ping `default`, connect: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_689ff165aa808325a05474b305c1d287