### PR TITLE
test(database): cover InitDB and InitTimezone

### DIFF
--- a/database/database_unit_test.go
+++ b/database/database_unit_test.go
@@ -1,8 +1,37 @@
 package database
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/beego/beego/v2/server/web"
+)
 
 // Test mínimo para que el paquete database tenga cobertura sin tocar la DB real.
 func TestDatabasePackageLoads(t *testing.T) {
 	t.Log("database unit test ok")
+}
+
+// Verifica que InitTimezone cargue correctamente la zona horaria de Bogotá.
+func TestInitTimezone(t *testing.T) {
+	BogotaZone = nil
+	InitTimezone()
+	if BogotaZone == nil {
+		t.Fatal("BogotaZone no fue inicializada")
+	}
+	if BogotaZone.String() != "America/Bogota" {
+		t.Fatalf("zona horaria inesperada: %s", BogotaZone.String())
+	}
+}
+
+// InitDB debe fallar cuando los datos de conexión son inválidos.
+func TestInitDBReturnsError(t *testing.T) {
+	_ = web.AppConfig.Set("db_host", "127.0.0.1")
+	_ = web.AppConfig.Set("db_port", "1") // puerto inválido para forzar error
+	_ = web.AppConfig.Set("db_user", "postgres")
+	_ = web.AppConfig.Set("db_pass", "bad")
+	_ = web.AppConfig.Set("db_name", "test")
+
+	if err := InitDB(); err == nil {
+		t.Fatal("se esperaba error de InitDB con configuración inválida")
+	}
 }


### PR DESCRIPTION
## Summary
- add unit tests for InitTimezone and InitDB error handling
- increase database package coverage

## Testing
- `go test ./database -cover`
- `go test ./... -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68a0751fbd0c8325b4667341bf13ec7b