### PR TITLE
test(database): increase coverage

### DIFF
--- a/database/database.go
+++ b/database/database.go
@@ -10,6 +10,12 @@ import (
 	_ "github.com/lib/pq"
 )
 
+// registerDataBase allows tests to stub orm.RegisterDataBase.
+var registerDataBase = orm.RegisterDataBase
+
+// loadLocation allows tests to stub time.LoadLocation.
+var loadLocation = time.LoadLocation
+
 func InitDB() error {
 	dbHost, _ := web.AppConfig.String("db_host")
 	dbPort, _ := web.AppConfig.String("db_port")
@@ -20,7 +26,7 @@ func InitDB() error {
 	connStr := fmt.Sprintf("user=%s password=%s host=%s port=%s dbname=%s sslmode=disable TimeZone=UTC",
 		dbUser, dbPass, dbHost, dbPort, dbName)
 
-	err := orm.RegisterDataBase("default", "postgres", connStr)
+	err := registerDataBase("default", "postgres", connStr)
 
 	if err != nil {
 		return err
@@ -36,7 +42,7 @@ var BogotaZone *time.Location
 
 func InitTimezone() {
 	var err error
-	BogotaZone, err = time.LoadLocation("America/Bogota")
+	BogotaZone, err = loadLocation("America/Bogota")
 	if err != nil {
 		log.Println("Advertencia: Error al cargar el timezone 'America/Bogota'. Usando UTC.")
 		BogotaZone = time.FixedZone("UTC-5", -5*60*60)

--- a/database/database_unit_test.go
+++ b/database/database_unit_test.go
@@ -1,8 +1,12 @@
 package database
 
 import (
+	"errors"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/beego/beego/v2/client/orm"
 	"github.com/beego/beego/v2/server/web"
 )
 
@@ -23,8 +27,25 @@ func TestInitTimezone(t *testing.T) {
 	}
 }
 
+// Verifica que InitTimezone use la zona UTC-5 cuando no encuentra los datos de zona horaria.
+func TestInitTimezoneFallback(t *testing.T) {
+	BogotaZone = nil
+	orig := loadLocation
+	loadLocation = func(name string) (*time.Location, error) { return nil, errors.New("no tz data") }
+	t.Cleanup(func() { loadLocation = orig })
+
+	InitTimezone()
+	if BogotaZone == nil {
+		t.Fatal("BogotaZone no fue inicializada")
+	}
+	if BogotaZone.String() != "UTC-5" {
+		t.Fatalf("zona horaria inesperada: %s", BogotaZone.String())
+	}
+}
+
 // InitDB debe fallar cuando los datos de conexión son inválidos.
 func TestInitDBReturnsError(t *testing.T) {
+	t.Setenv("PGCONNECT_TIMEOUT", "1")
 	_ = web.AppConfig.Set("db_host", "127.0.0.1")
 	_ = web.AppConfig.Set("db_port", "1") // puerto inválido para forzar error
 	_ = web.AppConfig.Set("db_user", "postgres")
@@ -33,5 +54,41 @@ func TestInitDBReturnsError(t *testing.T) {
 
 	if err := InitDB(); err == nil {
 		t.Fatal("se esperaba error de InitDB con configuración inválida")
+	}
+}
+
+// Verifica que InitDB registre la base de datos correctamente cuando la función de registro no falla.
+func TestInitDBSuccess(t *testing.T) {
+	_ = web.AppConfig.Set("db_host", "localhost")
+	_ = web.AppConfig.Set("db_port", "5432")
+	_ = web.AppConfig.Set("db_user", "user")
+	_ = web.AppConfig.Set("db_pass", "pass")
+	_ = web.AppConfig.Set("db_name", "db")
+
+	var (
+		called    bool
+		gotAlias  string
+		gotDriver string
+		gotConn   string
+	)
+	orig := registerDataBase
+	registerDataBase = func(alias, driver, conn string, params ...orm.DBOption) error {
+		called = true
+		gotAlias, gotDriver, gotConn = alias, driver, conn
+		return nil
+	}
+	t.Cleanup(func() { registerDataBase = orig })
+
+	if err := InitDB(); err != nil {
+		t.Fatalf("InitDB devolvió error: %v", err)
+	}
+	if !called {
+		t.Fatal("registerDataBase no fue llamada")
+	}
+	if gotAlias != "default" || gotDriver != "postgres" {
+		t.Fatalf("parámetros inesperados: %s %s", gotAlias, gotDriver)
+	}
+	if !strings.Contains(gotConn, "host=localhost") || !strings.Contains(gotConn, "port=5432") {
+		t.Fatalf("connStr inesperado: %s", gotConn)
 	}
 }


### PR DESCRIPTION
## Summary
- allow stubbing of database and timezone helpers
- add tests covering success and fallback paths to reach 100% coverage

## Testing
- `go test ./database -cover`
- `PGCONNECT_TIMEOUT=1 go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68a0920c2ce0832595b4f16aef270947