### PR TITLE
Increase models test coverage

### DIFF
--- a/models/Restaurante.go
+++ b/models/Restaurante.go
@@ -6,6 +6,8 @@ import (
 	"github.com/beego/beego/v2/client/orm"
 )
 
+var jsonMarshal = json.Marshal
+
 type Restaurante struct {
 	PK_ID_RESTAURANTE    int    `orm:"column(PK_ID_RESTAURANTE);pk" json:"restauranteId"`
 	NOMBRE_RESTAURANTE   string `orm:"column(NOMBRE_RESTAURANTE)" json:"nombreRestaurante"`
@@ -21,7 +23,7 @@ func (t *Restaurante) TableName() string {
 
 // Método para establecer los días laborales como una cadena JSON
 func (r *Restaurante) SetDiasLaborales(dias []string) error {
-	diasJSON, err := json.Marshal(dias)
+	diasJSON, err := jsonMarshal(dias)
 	if err != nil {
 		return err
 	}

--- a/models/restaurante_test.go
+++ b/models/restaurante_test.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"encoding/json"
+	"errors"
 	"reflect"
 	"testing"
 )
@@ -31,5 +32,18 @@ func TestRestauranteGetDiasLaboralesInvalidJSON(t *testing.T) {
 	r := Restaurante{DIAS_LABORALES: "not-json"}
 	if _, err := r.GetDiasLaborales(); err == nil {
 		t.Errorf("expected error for invalid JSON")
+	}
+}
+
+func TestRestauranteSetDiasLaboralesError(t *testing.T) {
+	original := jsonMarshal
+	jsonMarshal = func(v any) ([]byte, error) {
+		return nil, errors.New("marshal error")
+	}
+	defer func() { jsonMarshal = original }()
+
+	r := Restaurante{}
+	if err := r.SetDiasLaborales([]string{"Lunes"}); err == nil {
+		t.Errorf("expected error but got nil")
 	}
 }

--- a/models/trabajador_test.go
+++ b/models/trabajador_test.go
@@ -43,3 +43,28 @@ func TestTrabajadorTableName(t *testing.T) {
 		t.Errorf("expected table name TRABAJADOR, got %s", tr.TableName())
 	}
 }
+
+func TestTrabajadorMarshalJSONNil(t *testing.T) {
+	ingreso := time.Date(2023, time.February, 10, 9, 15, 30, 0, time.UTC)
+	tr := Trabajador{FECHA_INGRESO: ingreso}
+
+	b, err := json.Marshal(tr)
+	if err != nil {
+		t.Fatalf("json.Marshal returned error: %v", err)
+	}
+
+	var data map[string]interface{}
+	if err := json.Unmarshal(b, &data); err != nil {
+		t.Fatalf("json.Unmarshal returned error: %v", err)
+	}
+
+	if _, ok := data["fechaNacimiento"]; ok {
+		t.Errorf("expected fechaNacimiento to be omitted")
+	}
+	if data["fechaIngreso"] != "10-02-2023 09:15:30" {
+		t.Errorf("expected fechaIngreso 10-02-2023 09:15:30, got %v", data["fechaIngreso"])
+	}
+	if _, ok := data["fechaRetiro"]; ok {
+		t.Errorf("expected fechaRetiro to be omitted")
+	}
+}


### PR DESCRIPTION
## Summary
- enable mocking json marshalling in `Restaurante.SetDiasLaborales`
- add tests for `SetDiasLaborales` error path and for `Trabajador.MarshalJSON` nil dates

## Testing
- `go test ./models -coverprofile=models_coverage.out`


------
https://chatgpt.com/codex/tasks/task_e_68a0922414d0832598b98e371b0a3769