### PR TITLE
Handle CORS preflight and fix token middleware tests

### DIFF
--- a/controllers/ClienteController.go
+++ b/controllers/ClienteController.go
@@ -16,6 +16,15 @@ type ClienteController struct {
 	web.Controller
 }
 
+// Options responde a las solicitudes preflight de CORS
+// permitiendo que el navegador verifique los permisos
+// antes de enviar la petición real.
+func (c *ClienteController) Options() {
+	c.Ctx.ResponseWriter.Header().Set("Access-Control-Allow-Methods", "POST, GET, OPTIONS, PUT, DELETE")
+	c.Ctx.ResponseWriter.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+	c.Ctx.Output.SetStatus(http.StatusOK)
+}
+
 func normalizeEmail(s string) string {
 	return strings.ToLower(strings.TrimSpace(s))
 }

--- a/tests/token_middleware_test.go
+++ b/tests/token_middleware_test.go
@@ -3,6 +3,7 @@ package test
 import (
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	beego "github.com/beego/beego/v2/server/web"
@@ -33,7 +34,9 @@ func TestOptionsBypassesToken(t *testing.T) {
 
 // TestPublicPostWithoutToken confirms that public POST endpoints can be accessed without a token and return a validation error instead.
 func TestPublicPostWithoutToken(t *testing.T) {
-	r, _ := http.NewRequest("POST", "/restaurante/v1/clientes", nil)
+	body := strings.NewReader("invalid")
+	r, _ := http.NewRequest("POST", "/restaurante/v1/clientes", body)
+	r.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 	beego.BeeApp.Handlers.ServeHTTP(w, r)
 


### PR DESCRIPTION
## Summary
- respond to CORS preflight requests in ClienteController
- adjust token middleware tests and send invalid JSON bodies

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a098d73d1c83259167ee134a743bc9