### PR TITLE
Increase controller test coverage

### DIFF
--- a/controllers/cambios_horario_controller_test.go
+++ b/controllers/cambios_horario_controller_test.go
@@ -1,0 +1,45 @@
+package controllers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/beego/beego/v2/server/web/context"
+)
+
+func TestCambiosHorarioGetAllWithoutDB(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/cambios_horario", nil)
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	c := CambiosHorarioController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	c.GetAll()
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected status 500, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "Error al obtener cambios de horario") {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
+}
+
+func TestCambiosHorarioPostInvalidJSON(t *testing.T) {
+	r := httptest.NewRequest(http.MethodPost, "/cambios_horario", strings.NewReader("notjson"))
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	c := CambiosHorarioController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	c.Post()
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d", w.Code)
+	}
+}

--- a/controllers/nomina_controller_test.go
+++ b/controllers/nomina_controller_test.go
@@ -1,0 +1,45 @@
+package controllers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/beego/beego/v2/server/web/context"
+)
+
+func TestNominaGetAllWithoutDB(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/nominas", nil)
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	c := NominaController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	c.GetAll()
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected status 500, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "Error al obtener nóminas") {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
+}
+
+func TestNominaPostInvalidJSON(t *testing.T) {
+	r := httptest.NewRequest(http.MethodPost, "/nominas", strings.NewReader("notjson"))
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	c := NominaController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	c.Post()
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d", w.Code)
+	}
+}

--- a/controllers/nomina_trabajador_controller_test.go
+++ b/controllers/nomina_trabajador_controller_test.go
@@ -1,0 +1,45 @@
+package controllers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/beego/beego/v2/server/web/context"
+)
+
+func TestNominaTrabajadorGetAllWithoutDB(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/nomina_trabajador", nil)
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	c := NominaTrabajadorController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	c.GetAll()
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected status 500, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "Error al obtener las relaciones nómina-trabajador") {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
+}
+
+func TestNominaTrabajadorPostInvalidJSON(t *testing.T) {
+	r := httptest.NewRequest(http.MethodPost, "/nomina_trabajador", strings.NewReader("notjson"))
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	c := NominaTrabajadorController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	c.Post()
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d", w.Code)
+	}
+}

--- a/controllers/pedido_controller_test.go
+++ b/controllers/pedido_controller_test.go
@@ -1,0 +1,48 @@
+package controllers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/beego/beego/v2/server/web/context"
+)
+
+func TestPedidoGetAllWithoutDB(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/pedidos", nil)
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	c := PedidoController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	c.GetAll()
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "Error al obtener los pedidos") {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
+}
+
+func TestPedidoPostDatabaseError(t *testing.T) {
+	r := httptest.NewRequest(http.MethodPost, "/pedidos", nil)
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	c := PedidoController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	c.Post()
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected status 500, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "Error al crear el pedido") {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
+}

--- a/controllers/reserva_controller_test.go
+++ b/controllers/reserva_controller_test.go
@@ -1,0 +1,45 @@
+package controllers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/beego/beego/v2/server/web/context"
+)
+
+func TestReservaGetAllWithoutDB(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/reservas", nil)
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	c := ReservaController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	c.GetAll()
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected status 500, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "Error al obtener reservas") {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
+}
+
+func TestReservaGetByIdInvalidID(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/reservas/search", nil)
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	c := ReservaController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	c.GetById()
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d", w.Code)
+	}
+}


### PR DESCRIPTION
## Summary
- add unit tests for CambiosHorario, Pedido, Reserva, Nomina, and NominaTrabajador controllers
- cover DB failure paths and invalid input scenarios

## Testing
- `go test ./controllers -cover -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68a0a7f2cac883259a4913a1af0a9317