### PR TITLE
test: expand CambiosHorario controller coverage

### DIFF
--- a/controllers/cambios_horario_controller_test.go
+++ b/controllers/cambios_horario_controller_test.go
@@ -1,12 +1,15 @@
 package controllers
 
 import (
-	"net/http"
-	"net/http/httptest"
-	"strings"
-	"testing"
+        "net/http"
+        "net/http/httptest"
+        "strings"
+        "testing"
+        "time"
 
-	"github.com/beego/beego/v2/server/web/context"
+        "restaurante/database"
+
+        "github.com/beego/beego/v2/server/web/context"
 )
 
 func TestCambiosHorarioGetAllWithoutDB(t *testing.T) {
@@ -29,17 +32,149 @@ func TestCambiosHorarioGetAllWithoutDB(t *testing.T) {
 }
 
 func TestCambiosHorarioPostInvalidJSON(t *testing.T) {
-	r := httptest.NewRequest(http.MethodPost, "/cambios_horario", strings.NewReader("notjson"))
-	w := httptest.NewRecorder()
-	ctx := context.NewContext()
-	ctx.Reset(w, r)
+        r := httptest.NewRequest(http.MethodPost, "/cambios_horario", strings.NewReader("notjson"))
+        w := httptest.NewRecorder()
+        ctx := context.NewContext()
+        ctx.Reset(w, r)
 	c := CambiosHorarioController{}
 	c.Ctx = ctx
 	c.Data = make(map[interface{}]interface{})
 
 	c.Post()
 
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("expected status 400, got %d", w.Code)
-	}
+        if w.Code != http.StatusBadRequest {
+                t.Fatalf("expected status 400, got %d", w.Code)
+        }
+}
+
+func TestCambiosHorarioGetByCurrentDateWithoutDB(t *testing.T) {
+        database.BogotaZone = time.Local
+        r := httptest.NewRequest(http.MethodGet, "/cambios_horario/actual", nil)
+        w := httptest.NewRecorder()
+        ctx := context.NewContext()
+        ctx.Reset(w, r)
+        c := CambiosHorarioController{}
+        c.Ctx = ctx
+        c.Data = make(map[interface{}]interface{})
+
+        c.GetByCurrentDate()
+
+        if w.Code != http.StatusInternalServerError {
+                t.Fatalf("expected status 500, got %d", w.Code)
+        }
+        if !strings.Contains(w.Body.String(), "Error al consultar cambios de horario") {
+                t.Errorf("unexpected body: %s", w.Body.String())
+        }
+}
+
+func TestCambiosHorarioPostMissingFecha(t *testing.T) {
+        body := `{"abierto":true,"horaApertura":"08:00:00","horaCierre":"17:00:00"}`
+        r := httptest.NewRequest(http.MethodPost, "/cambios_horario", strings.NewReader(body))
+        w := httptest.NewRecorder()
+        ctx := context.NewContext()
+        ctx.Reset(w, r)
+        ctx.Input.RequestBody = []byte(body)
+        c := CambiosHorarioController{}
+        c.Ctx = ctx
+        c.Data = make(map[interface{}]interface{})
+
+        c.Post()
+
+        if w.Code != http.StatusBadRequest {
+                t.Fatalf("expected status 400, got %d", w.Code)
+        }
+        if !strings.Contains(w.Body.String(), "FECHA es obligatorio") {
+                t.Errorf("unexpected body: %s", w.Body.String())
+        }
+}
+
+func TestCambiosHorarioPostMissingHoraApertura(t *testing.T) {
+        body := `{"fechaCambioHorario":"2024-10-10","abierto":true,"horaCierre":"17:00:00"}`
+        r := httptest.NewRequest(http.MethodPost, "/cambios_horario", strings.NewReader(body))
+        w := httptest.NewRecorder()
+        ctx := context.NewContext()
+        ctx.Reset(w, r)
+        ctx.Input.RequestBody = []byte(body)
+        c := CambiosHorarioController{}
+        c.Ctx = ctx
+        c.Data = make(map[interface{}]interface{})
+
+        c.Post()
+
+        if w.Code != http.StatusBadRequest {
+                t.Fatalf("expected status 400, got %d", w.Code)
+        }
+        if !strings.Contains(w.Body.String(), "HORA_APERTURA es obligatorio") {
+                t.Errorf("unexpected body: %s", w.Body.String())
+        }
+}
+
+func TestCambiosHorarioPostAbiertoFalse(t *testing.T) {
+        body := `{"fechaCambioHorario":"2024-10-10","abierto":false}`
+        r := httptest.NewRequest(http.MethodPost, "/cambios_horario", strings.NewReader(body))
+        w := httptest.NewRecorder()
+        ctx := context.NewContext()
+        ctx.Reset(w, r)
+        ctx.Input.RequestBody = []byte(body)
+        c := CambiosHorarioController{}
+        c.Ctx = ctx
+        c.Data = make(map[interface{}]interface{})
+
+        c.Post()
+
+        if w.Code != http.StatusInternalServerError {
+                t.Fatalf("expected status 500, got %d", w.Code)
+        }
+        if !strings.Contains(w.Body.String(), "Error al crear el cambio de horario") {
+                t.Errorf("unexpected body: %s", w.Body.String())
+        }
+}
+
+func TestCambiosHorarioPutInvalidID(t *testing.T) {
+        r := httptest.NewRequest(http.MethodPut, "/cambios_horario", nil)
+        w := httptest.NewRecorder()
+        ctx := context.NewContext()
+        ctx.Reset(w, r)
+        c := CambiosHorarioController{}
+        c.Ctx = ctx
+        c.Data = make(map[interface{}]interface{})
+
+        c.Put()
+
+        if w.Code != http.StatusBadRequest {
+                t.Fatalf("expected status 400, got %d", w.Code)
+        }
+}
+
+func TestCambiosHorarioPutInvalidJSON(t *testing.T) {
+        r := httptest.NewRequest(http.MethodPut, "/cambios_horario?id=1", strings.NewReader("notjson"))
+        w := httptest.NewRecorder()
+        ctx := context.NewContext()
+        ctx.Reset(w, r)
+        ctx.Input.RequestBody = []byte("notjson")
+        c := CambiosHorarioController{}
+        c.Ctx = ctx
+        c.Data = make(map[interface{}]interface{})
+
+        c.Put()
+
+        if w.Code != http.StatusBadRequest {
+                t.Fatalf("expected status 400, got %d", w.Code)
+        }
+}
+
+func TestCambiosHorarioDeleteInvalidID(t *testing.T) {
+        r := httptest.NewRequest(http.MethodDelete, "/cambios_horario", nil)
+        w := httptest.NewRecorder()
+        ctx := context.NewContext()
+        ctx.Reset(w, r)
+        c := CambiosHorarioController{}
+        c.Ctx = ctx
+        c.Data = make(map[interface{}]interface{})
+
+        c.Delete()
+
+        if w.Code != http.StatusBadRequest {
+                t.Fatalf("expected status 400, got %d", w.Code)
+        }
 }


### PR DESCRIPTION
## Summary
- add tests for error paths in CambiosHorarioController
- cover missing field validations and default closed-day logic

## Testing
- `go test ./controllers -run CambiosHorario -cover`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a0aa34a8a48325acad1f13dea9a5b5