### PR TITLE
test: improve domicilio controller coverage

### DIFF
--- a/controllers/domicilio_controller_test.go
+++ b/controllers/domicilio_controller_test.go
@@ -27,12 +27,14 @@ func TestDomicilioGetByIdInvalidID(t *testing.T) {
 
 func TestDomicilioPostInvalidJSON(t *testing.T) {
 	r := httptest.NewRequest(http.MethodPost, "/domicilios", strings.NewReader("notjson"))
+	r.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 	ctx := context.NewContext()
 	ctx.Reset(w, r)
 	c := DomicilioController{}
 	c.Ctx = ctx
 	c.Data = make(map[interface{}]interface{})
+	c.Ctx.Input.RequestBody = []byte("notjson")
 
 	c.Post()
 
@@ -54,5 +56,129 @@ func TestDomicilioGetAllWithoutDB(t *testing.T) {
 
 	if w.Code != http.StatusInternalServerError {
 		t.Fatalf("expected status 500, got %d", w.Code)
+	}
+}
+
+func TestDomicilioPostMissingDireccion(t *testing.T) {
+	body := "{\"fechaDomicilio\":\"2024-01-01\",\"telefono\":\"123\"}"
+	r := httptest.NewRequest(http.MethodPost, "/domicilios", strings.NewReader(body))
+	r.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	c := DomicilioController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+	c.Ctx.Input.RequestBody = []byte(body)
+
+	c.Post()
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d", w.Code)
+	}
+}
+
+func TestDomicilioPostInvalidFecha(t *testing.T) {
+	body := "{\"direccion\":\"A\",\"fechaDomicilio\":\"2024-13-01\",\"telefono\":\"123\"}"
+	r := httptest.NewRequest(http.MethodPost, "/domicilios", strings.NewReader(body))
+	r.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	c := DomicilioController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+	c.Ctx.Input.RequestBody = []byte(body)
+
+	c.Post()
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d", w.Code)
+	}
+}
+
+func TestDomicilioPostMissingTelefono(t *testing.T) {
+	body := "{\"direccion\":\"A\",\"fechaDomicilio\":\"2024-01-01\"}"
+	r := httptest.NewRequest(http.MethodPost, "/domicilios", strings.NewReader(body))
+	r.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	c := DomicilioController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+	c.Ctx.Input.RequestBody = []byte(body)
+
+	c.Post()
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d", w.Code)
+	}
+}
+
+func TestDomicilioPostValidWithoutDB(t *testing.T) {
+	body := "{\"direccion\":\"A\",\"fechaDomicilio\":\"2024-01-01\",\"telefono\":\"123\"}"
+	r := httptest.NewRequest(http.MethodPost, "/domicilios", strings.NewReader(body))
+	r.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	c := DomicilioController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+	c.Ctx.Input.RequestBody = []byte(body)
+
+	c.Post()
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected status 500, got %d", w.Code)
+	}
+}
+
+func TestDomicilioPutInvalidID(t *testing.T) {
+	r := httptest.NewRequest(http.MethodPut, "/domicilios?id=abc", strings.NewReader("{}"))
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	c := DomicilioController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	c.Put()
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d", w.Code)
+	}
+}
+
+func TestDomicilioDeleteInvalidID(t *testing.T) {
+	r := httptest.NewRequest(http.MethodDelete, "/domicilios?id=abc", nil)
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	c := DomicilioController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	c.Delete()
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d", w.Code)
+	}
+}
+
+func TestDomicilioAsignarDomiciliarioNotFound(t *testing.T) {
+	r := httptest.NewRequest(http.MethodPost, "/domicilios/asignar", nil)
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	c := DomicilioController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	c.AsignarDomiciliario()
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected status 404, got %d", w.Code)
 	}
 }


### PR DESCRIPTION
## Summary
- expand DomicilioController tests for missing fields, invalid data, and error paths
- add coverage for invalid IDs and assignment failures

## Testing
- `go test ./... -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68a0acbfd6c48325a91c161c9a7a1b73