### PR TITLE
Add comprehensive login controller tests

### DIFF
--- a/controllers/LoginController.go
+++ b/controllers/LoginController.go
@@ -17,6 +17,11 @@ import (
 	"github.com/beego/beego/v2/server/web/context"
 )
 
+var (
+	newOrm                 = orm.NewOrm
+	compareHashAndPassword = bcrypt.CompareHashAndPassword
+)
+
 type LoginController struct {
 	web.Controller
 }
@@ -56,7 +61,7 @@ func (c *LoginController) Login() {
 		return
 	}
 
-	o := orm.NewOrm()
+	o := newOrm()
 
 	// Primero, intenta encontrar al usuario como trabajador
 	trabajador := models.Trabajador{PK_DOCUMENTO_TRABAJADOR: int64(loginRequest.Documento)}
@@ -64,7 +69,7 @@ func (c *LoginController) Login() {
 
 	if err == nil {
 		// Verificar la contraseña
-		if err := bcrypt.CompareHashAndPassword([]byte(trabajador.PASSWORD), []byte(loginRequest.Password)); err != nil {
+		if err := compareHashAndPassword([]byte(trabajador.PASSWORD), []byte(loginRequest.Password)); err != nil {
 			c.Ctx.Output.SetStatus(http.StatusUnauthorized)
 			c.Data["json"] = models.ApiResponse{
 				Code:    http.StatusUnauthorized,
@@ -85,7 +90,7 @@ func (c *LoginController) Login() {
 
 	if err == nil {
 		// Verificar la contraseña
-		if err := bcrypt.CompareHashAndPassword([]byte(cliente.PASSWORD), []byte(loginRequest.Password)); err != nil {
+		if err := compareHashAndPassword([]byte(cliente.PASSWORD), []byte(loginRequest.Password)); err != nil {
 			c.Ctx.Output.SetStatus(http.StatusUnauthorized)
 			c.Data["json"] = models.ApiResponse{
 				Code:    http.StatusUnauthorized,

--- a/controllers/login_controller_test.go
+++ b/controllers/login_controller_test.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -10,9 +11,19 @@ import (
 
 	"restaurante/models"
 
+	"github.com/beego/beego/v2/client/orm"
 	"github.com/beego/beego/v2/server/web/context"
 	"github.com/dgrijalva/jwt-go"
 )
+
+type mockOrmer struct {
+	orm.Ormer
+	ReadFunc func(interface{}, ...string) error
+}
+
+func (m mockOrmer) Read(v interface{}, cols ...string) error {
+	return m.ReadFunc(v, cols...)
+}
 
 func TestGenerateJWT(t *testing.T) {
 	os.Setenv("cocina-de-maria", "testsecret")
@@ -54,6 +65,7 @@ func TestLoginInvalidJSON(t *testing.T) {
 	w := httptest.NewRecorder()
 	ctx := context.NewContext()
 	ctx.Reset(w, r)
+	ctx.Input.RequestBody = []byte("notjson")
 	c := LoginController{}
 	c.Ctx = ctx
 	c.Data = make(map[interface{}]interface{})
@@ -62,6 +74,215 @@ func TestLoginInvalidJSON(t *testing.T) {
 
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("expected status 400, got %d", w.Code)
+	}
+}
+
+func TestLoginTrabajadorSuccess(t *testing.T) {
+	os.Setenv("cocina-de-maria", "testsecret")
+	defer os.Unsetenv("cocina-de-maria")
+	jwtSecret = []byte(os.Getenv("cocina-de-maria"))
+
+	origNewOrm := newOrm
+	defer func() { newOrm = origNewOrm }()
+	newOrm = func() orm.Ormer {
+		return &mockOrmer{ReadFunc: func(v interface{}, cols ...string) error {
+			if trab, ok := v.(*models.Trabajador); ok {
+				trab.NOMBRE = "Foo"
+				trab.APELLIDO = "Bar"
+				trab.ROL = "Admin"
+				trab.PASSWORD = "hashed"
+				return nil
+			}
+			return errors.New("not found")
+		}}
+	}
+
+	origCompare := compareHashAndPassword
+	defer func() { compareHashAndPassword = origCompare }()
+	compareHashAndPassword = func([]byte, []byte) error { return nil }
+
+	body := `{"documento":123,"password":"secret"}`
+	r := httptest.NewRequest(http.MethodPost, "/login", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	ctx.Input.RequestBody = []byte(body)
+	c := LoginController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	c.Login()
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+	var resp models.ApiResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected response code 200, got %d", resp.Code)
+	}
+	data := resp.Data.(map[string]interface{})
+	if data["token"].(string) == "" {
+		t.Errorf("expected token to be set")
+	}
+	if data["nombre"].(string) != "Foo Bar" {
+		t.Errorf("expected nombre Foo Bar, got %v", data["nombre"])
+	}
+}
+
+func TestLoginClienteSuccess(t *testing.T) {
+	os.Setenv("cocina-de-maria", "testsecret")
+	defer os.Unsetenv("cocina-de-maria")
+	jwtSecret = []byte(os.Getenv("cocina-de-maria"))
+
+	origNewOrm := newOrm
+	defer func() { newOrm = origNewOrm }()
+	newOrm = func() orm.Ormer {
+		return &mockOrmer{ReadFunc: func(v interface{}, cols ...string) error {
+			switch val := v.(type) {
+			case *models.Trabajador:
+				return errors.New("not found")
+			case *models.Cliente:
+				val.NOMBRE = "Jane"
+				val.APELLIDO = "Doe"
+				val.PASSWORD = "hashed"
+				return nil
+			}
+			return errors.New("unknown type")
+		}}
+	}
+
+	origCompare := compareHashAndPassword
+	defer func() { compareHashAndPassword = origCompare }()
+	compareHashAndPassword = func([]byte, []byte) error { return nil }
+
+	body := `{"documento":123,"password":"secret"}`
+	r := httptest.NewRequest(http.MethodPost, "/login", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	ctx.Input.RequestBody = []byte(body)
+	c := LoginController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	c.Login()
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+	var resp models.ApiResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected response code 200, got %d", resp.Code)
+	}
+	data := resp.Data.(map[string]interface{})
+	if data["token"].(string) == "" {
+		t.Errorf("expected token to be set")
+	}
+	if data["nombre"].(string) != "Jane Doe" {
+		t.Errorf("expected nombre Jane Doe, got %v", data["nombre"])
+	}
+}
+
+func TestLoginTrabajadorInvalidPassword(t *testing.T) {
+	origNewOrm := newOrm
+	defer func() { newOrm = origNewOrm }()
+	newOrm = func() orm.Ormer {
+		return &mockOrmer{ReadFunc: func(v interface{}, cols ...string) error {
+			if trab, ok := v.(*models.Trabajador); ok {
+				trab.PASSWORD = "hashed"
+				return nil
+			}
+			return errors.New("not found")
+		}}
+	}
+
+	origCompare := compareHashAndPassword
+	defer func() { compareHashAndPassword = origCompare }()
+	compareHashAndPassword = func([]byte, []byte) error { return errors.New("mismatch") }
+
+	body := `{"documento":123,"password":"bad"}`
+	r := httptest.NewRequest(http.MethodPost, "/login", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	ctx.Input.RequestBody = []byte(body)
+	c := LoginController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	c.Login()
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected status 401, got %d", w.Code)
+	}
+}
+
+func TestLoginClienteInvalidPassword(t *testing.T) {
+	origNewOrm := newOrm
+	defer func() { newOrm = origNewOrm }()
+	newOrm = func() orm.Ormer {
+		return &mockOrmer{ReadFunc: func(v interface{}, cols ...string) error {
+			switch val := v.(type) {
+			case *models.Trabajador:
+				return errors.New("not found")
+			case *models.Cliente:
+				val.PASSWORD = "hashed"
+				return nil
+			}
+			return errors.New("unknown type")
+		}}
+	}
+
+	origCompare := compareHashAndPassword
+	defer func() { compareHashAndPassword = origCompare }()
+	compareHashAndPassword = func([]byte, []byte) error { return errors.New("mismatch") }
+
+	body := `{"documento":123,"password":"bad"}`
+	r := httptest.NewRequest(http.MethodPost, "/login", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	ctx.Input.RequestBody = []byte(body)
+	c := LoginController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	c.Login()
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected status 401, got %d", w.Code)
+	}
+}
+
+func TestLoginUserNotFound(t *testing.T) {
+	origNewOrm := newOrm
+	defer func() { newOrm = origNewOrm }()
+	newOrm = func() orm.Ormer {
+		return &mockOrmer{ReadFunc: func(v interface{}, cols ...string) error {
+			return errors.New("not found")
+		}}
+	}
+
+	body := `{"documento":123,"password":"secret"}`
+	r := httptest.NewRequest(http.MethodPost, "/login", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	ctx.Input.RequestBody = []byte(body)
+	c := LoginController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	c.Login()
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected status 401, got %d", w.Code)
 	}
 }
 
@@ -106,6 +327,31 @@ func TestValidateTokenValid(t *testing.T) {
 
 	r := httptest.NewRequest(http.MethodGet, "/protected", nil)
 	r.Header.Set("Authorization", "Bearer "+tokenStr)
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+
+	ValidateToken(ctx)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+}
+
+func TestValidateTokenWithoutBearerPrefix(t *testing.T) {
+	os.Setenv("cocina-de-maria", "testsecret")
+	defer os.Unsetenv("cocina-de-maria")
+	jwtSecret = []byte(os.Getenv("cocina-de-maria"))
+
+	claims := &Claims{Documento: 1, Rol: "Admin", Nombre: "Tester"}
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	tokenStr, err := token.SignedString(jwtSecret)
+	if err != nil {
+		t.Fatalf("failed to sign token: %v", err)
+	}
+
+	r := httptest.NewRequest(http.MethodGet, "/protected", nil)
+	r.Header.Set("Authorization", tokenStr)
 	w := httptest.NewRecorder()
 	ctx := context.NewContext()
 	ctx.Reset(w, r)


### PR DESCRIPTION
## Summary
- inject ORM and password comparison functions for easier testing
- add tests for successful worker and client logins and error cases
- cover token validation without Bearer prefix

## Testing
- `go test ./controllers -coverprofile=coverage.out`
- `go test ./controllers -run Login -coverprofile=coverage_login.out && go tool cover -func=coverage_login.out | grep LoginController.go`


------
https://chatgpt.com/codex/tasks/task_e_68a0acdb607c8325998297e148ad7a2d