### PR TITLE
test: expand nomina controller coverage

### DIFF
--- a/controllers/nomina_controller_test.go
+++ b/controllers/nomina_controller_test.go
@@ -43,3 +43,93 @@ func TestNominaPostInvalidJSON(t *testing.T) {
 		t.Fatalf("expected status 400, got %d", w.Code)
 	}
 }
+
+func TestNominaPostDBError(t *testing.T) {
+	r := httptest.NewRequest(http.MethodPost, "/nominas", nil)
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	ctx.Input.RequestBody = []byte("{\"estadoNomina\":\"OTRO\"}")
+	c := NominaController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	c.Post()
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected status 500, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "Error al crear la nómina") {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
+}
+
+func TestNominaPutInvalidID(t *testing.T) {
+	r := httptest.NewRequest(http.MethodPut, "/nominas", nil)
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	c := NominaController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	c.Put()
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d", w.Code)
+	}
+}
+
+func TestNominaPutUpdateError(t *testing.T) {
+	r := httptest.NewRequest(http.MethodPut, "/nominas?id=1", nil)
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	c := NominaController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	c.Put()
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected status 500, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "Error al actualizar el estado de la nómina") {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
+}
+
+func TestNominaDeleteInvalidID(t *testing.T) {
+	r := httptest.NewRequest(http.MethodDelete, "/nominas", nil)
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	c := NominaController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	c.Delete()
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d", w.Code)
+	}
+}
+
+func TestNominaDeleteNotFound(t *testing.T) {
+	r := httptest.NewRequest(http.MethodDelete, "/nominas?id=1", nil)
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	c := NominaController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	c.Delete()
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "Nómina no encontrada") {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
+}


### PR DESCRIPTION
## Summary
- add tests covering error paths for NominaController post, put and delete operations

## Testing
- `go test ./... -coverprofile=coverage.out`


------
https://chatgpt.com/codex/tasks/task_e_68a0acfbbe4c832593e1d30d33243d1e