### PR TITLE
test: increase coverage for NominaTrabajadorController

### DIFF
--- a/controllers/nomina_trabajador_controller_test.go
+++ b/controllers/nomina_trabajador_controller_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/beego/beego/v2/server/web/context"
 )
@@ -33,6 +34,7 @@ func TestNominaTrabajadorPostInvalidJSON(t *testing.T) {
 	w := httptest.NewRecorder()
 	ctx := context.NewContext()
 	ctx.Reset(w, r)
+	ctx.Input.RequestBody = []byte("notjson")
 	c := NominaTrabajadorController{}
 	c.Ctx = ctx
 	c.Data = make(map[interface{}]interface{})
@@ -41,5 +43,126 @@ func TestNominaTrabajadorPostInvalidJSON(t *testing.T) {
 
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("expected status 400, got %d", w.Code)
+	}
+}
+
+func TestNominaTrabajadorPostMissingDocumento(t *testing.T) {
+	body := `{"PK_DOCUMENTO_TRABAJADOR":0}`
+	r := httptest.NewRequest(http.MethodPost, "/nomina_trabajador", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	ctx.Input.RequestBody = []byte(body)
+	c := NominaTrabajadorController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	c.Post()
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "PK_DOCUMENTO_TRABAJADOR") {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
+}
+
+func TestNominaTrabajadorPostDBError(t *testing.T) {
+	body := `{"PK_DOCUMENTO_TRABAJADOR":123}`
+	r := httptest.NewRequest(http.MethodPost, "/nomina_trabajador", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	ctx.Input.RequestBody = []byte(body)
+	c := NominaTrabajadorController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	c.Post()
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected status 500, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "Error al consultar incidencias del trabajador") {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
+}
+
+func TestNominaTrabajadorGetByTrabajadorMissingDocumento(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/nomina_trabajador/search", nil)
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	c := NominaTrabajadorController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	c.GetByTrabajador()
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d", w.Code)
+	}
+}
+
+func TestNominaTrabajadorGetByTrabajadorNoResultados(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/nomina_trabajador/search?documento=1", nil)
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	c := NominaTrabajadorController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	c.GetByTrabajador()
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "No se encontraron relaciones nómina-trabajador") {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
+}
+
+func TestNominaTrabajadorGetNominasByMesInvalidParams(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/nomina_trabajador/mes?mes=0&anio=0", nil)
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	c := NominaTrabajadorController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	c.GetNominasByMes()
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d", w.Code)
+	}
+}
+
+func TestNominaTrabajadorGetNominasByMesDBError(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/nomina_trabajador/mes?mes=1&anio=2023", nil)
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	c := NominaTrabajadorController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	c.GetNominasByMes()
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected status 500, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "Error al buscar las nóminas") {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
+}
+
+func TestObtenerMesEnEspanol(t *testing.T) {
+	if obtenerMesEnEspañol(time.January) != "Enero" {
+		t.Errorf("expected Enero")
+	}
+	if obtenerMesEnEspañol(time.December) != "Diciembre" {
+		t.Errorf("expected Diciembre")
 	}
 }


### PR DESCRIPTION
## Summary
- expand unit tests for NominaTrabajadorController covering missing fields, DB errors, query filtering and helper function

## Testing
- `go test -run "(NominaTrabajador|ObtenerMesEnEspanol)" -coverprofile=cover.out -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68a0ad04ab648325a5c47d838525241f