### PR TITLE
test: add tests for PedidoCliente controller

### DIFF
--- a/controllers/pedido_cliente_controller_test.go
+++ b/controllers/pedido_cliente_controller_test.go
@@ -1,0 +1,87 @@
+package controllers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/beego/beego/v2/server/web/context"
+)
+
+func TestPedidoClienteGetAllWithoutDB(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/pedido_clientes", nil)
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	c := PedidoClienteController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	c.GetAll()
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected status 500, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "Error al obtener las relaciones de la base de datos") {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
+}
+
+func TestPedidoClientePostInvalidJSON(t *testing.T) {
+	r := httptest.NewRequest(http.MethodPost, "/pedido_clientes", strings.NewReader("{"))
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	c := PedidoClienteController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	c.Post()
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "Error en la solicitud") {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
+}
+
+func TestPedidoClientePostMissingFields(t *testing.T) {
+	body := `{"documentoCliente":0,"pedidoId":0}`
+	r := httptest.NewRequest(http.MethodPost, "/pedido_clientes", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	ctx.Input.RequestBody = []byte(body)
+	c := PedidoClienteController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	c.Post()
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "Faltan campos obligatorios") {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
+}
+
+func TestPedidoClientePostClienteNoEncontrado(t *testing.T) {
+	body := `{"documentoCliente":1,"pedidoId":1}`
+	r := httptest.NewRequest(http.MethodPost, "/pedido_clientes", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	ctx.Input.RequestBody = []byte(body)
+	c := PedidoClienteController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	c.Post()
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+}


### PR DESCRIPTION
## Summary
- add unit tests covering error paths in PedidoClienteController GetAll and Post handlers

## Testing
- `go test ./... -coverprofile=coverage.out`


------
https://chatgpt.com/codex/tasks/task_e_68a0ad28931c8325906e6af3c12a67df