### PR TITLE
Add tests for ProductoPedidoController

### DIFF
--- a/controllers/producto_pedido_controller_test.go
+++ b/controllers/producto_pedido_controller_test.go
@@ -1,0 +1,201 @@
+package controllers
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/beego/beego/v2/server/web/context"
+)
+
+func TestProductoPedidoGetAllMissingParam(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/producto_pedido", nil)
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	c := ProductoPedidoController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	c.GetAll()
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "pedido_id") {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
+}
+
+func TestProductoPedidoGetAllDBError(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/producto_pedido?pedido_id=1", nil)
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	c := ProductoPedidoController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	c.GetAll()
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "Error al obtener los productos del pedido") {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
+}
+
+func TestProductoPedidoPostInvalidJSON(t *testing.T) {
+	body := "{"
+	r := httptest.NewRequest(http.MethodPost, "/producto_pedido", bytes.NewBufferString(body))
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	ctx.Input.RequestBody = []byte(body)
+	c := ProductoPedidoController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	c.Post()
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "Datos inválidos") {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
+}
+
+func TestProductoPedidoPostMissingFields(t *testing.T) {
+	body := `{"pedidoId":0,"detallesProductos":[]}`
+	r := httptest.NewRequest(http.MethodPost, "/producto_pedido", strings.NewReader(body))
+	r.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	ctx.Input.RequestBody = []byte(body)
+	c := ProductoPedidoController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	c.Post()
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "obligatorios") {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
+}
+
+func TestProductoPedidoPostDBError(t *testing.T) {
+	body := `{"pedidoId":1,"detallesProductos":[{"productoId":1,"cantidad":1}]}`
+	r := httptest.NewRequest(http.MethodPost, "/producto_pedido", strings.NewReader(body))
+	r.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	ctx.Input.RequestBody = []byte(body)
+	c := ProductoPedidoController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	c.Post()
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "Error al crear el pedido con productos") {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
+}
+
+func TestProductoPedidoUpdateMissingParam(t *testing.T) {
+	body := "[]"
+	r := httptest.NewRequest(http.MethodPut, "/producto_pedido", strings.NewReader(body))
+	r.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	ctx.Input.RequestBody = []byte(body)
+	c := ProductoPedidoController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	c.Update()
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "pedido_id") {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
+}
+
+func TestProductoPedidoUpdateInvalidJSON(t *testing.T) {
+	body := "{"
+	r := httptest.NewRequest(http.MethodPut, "/producto_pedido?pedido_id=1", bytes.NewBufferString(body))
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	ctx.Input.RequestBody = []byte(body)
+	c := ProductoPedidoController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	c.Update()
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "Datos inválidos") {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
+}
+
+func TestProductoPedidoUpdateEmptyList(t *testing.T) {
+	body := "[]"
+	r := httptest.NewRequest(http.MethodPut, "/producto_pedido?pedido_id=1", strings.NewReader(body))
+	r.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	ctx.Input.RequestBody = []byte(body)
+	c := ProductoPedidoController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	c.Update()
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "no puede estar vacía") {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
+}
+
+func TestProductoPedidoUpdateDBError(t *testing.T) {
+	body := `[{"productoId":1,"cantidad":1}]`
+	r := httptest.NewRequest(http.MethodPut, "/producto_pedido?pedido_id=1", strings.NewReader(body))
+	r.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	ctx.Input.RequestBody = []byte(body)
+	c := ProductoPedidoController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	c.Update()
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "Error al buscar el pedido") {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
+}


### PR DESCRIPTION
## Summary
- add unit tests covering parameter validation and database errors for ProductoPedidoController
- test POST and PUT handlers with invalid JSON, missing data, and empty lists

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a0ad43e1a883259b1139b074dc0dbb