### PR TITLE
test: increase trabajador controller coverage

### DIFF
--- a/controllers/trabajador_controller_test.go
+++ b/controllers/trabajador_controller_test.go
@@ -57,3 +57,109 @@ func TestTrabajadorGetAllWithoutDB(t *testing.T) {
 		t.Errorf("unexpected body: %s", w.Body.String())
 	}
 }
+
+func TestTrabajadorGetByIdInvalidID(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/restaurante/v1/trabajadores/search", nil)
+	w := httptest.NewRecorder()
+	ctx := context2.NewContext()
+	ctx.Reset(w, r)
+	c := TrabajadorController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	c.GetById()
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d", w.Code)
+	}
+}
+
+func TestTrabajadorPostInvalidJSON(t *testing.T) {
+	body := "notjson"
+	r := httptest.NewRequest(http.MethodPost, "/restaurante/v1/trabajadores", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	ctx := context2.NewContext()
+	ctx.Reset(w, r)
+	ctx.Input.RequestBody = []byte(body)
+	c := TrabajadorController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	c.Post()
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d", w.Code)
+	}
+}
+
+func TestTrabajadorPostMissingField(t *testing.T) {
+	body := `{"nombre":"John","apellido":"Doe","rol":"Admin","fechaIngreso":"2023-01-01","sueldo":1000,"password":"secret"}`
+	r := httptest.NewRequest(http.MethodPost, "/restaurante/v1/trabajadores", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	ctx := context2.NewContext()
+	ctx.Reset(w, r)
+	ctx.Input.RequestBody = []byte(body)
+	c := TrabajadorController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	c.Post()
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "documentoTrabajador") {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
+}
+
+func TestTrabajadorPutInvalidID(t *testing.T) {
+	r := httptest.NewRequest(http.MethodPut, "/restaurante/v1/trabajadores", strings.NewReader("{}"))
+	w := httptest.NewRecorder()
+	ctx := context2.NewContext()
+	ctx.Reset(w, r)
+	c := TrabajadorController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	c.Put()
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d", w.Code)
+	}
+}
+
+func TestTrabajadorDeleteInvalidID(t *testing.T) {
+	r := httptest.NewRequest(http.MethodDelete, "/restaurante/v1/trabajadores", nil)
+	w := httptest.NewRecorder()
+	ctx := context2.NewContext()
+	ctx.Reset(w, r)
+	c := TrabajadorController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	c.Delete()
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d", w.Code)
+	}
+}
+
+func TestTrabajadorDeleteWithoutDB(t *testing.T) {
+	r := httptest.NewRequest(http.MethodDelete, "/restaurante/v1/trabajadores?id=1", nil)
+	w := httptest.NewRecorder()
+	ctx := context2.NewContext()
+	ctx.Reset(w, r)
+	c := TrabajadorController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	c.Delete()
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected status 500, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "Error al buscar el trabajador") {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
+}


### PR DESCRIPTION
## Summary
- add tests for TrabajadorController error scenarios

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a0ad60f458832582fe03626e758422