### PR TITLE
Add token middleware tests

### DIFF
--- a/tests/setup_test.go
+++ b/tests/setup_test.go
@@ -17,6 +17,7 @@ func TestMain(m *testing.M) {
 	_, file, _, _ := runtime.Caller(0)
 	appPath, _ := filepath.Abs(filepath.Dir(filepath.Join(file, ".."+string(filepath.Separator))))
 	os.Setenv("BEEGO_APP_CONFIG_FILE", filepath.Join(appPath, "conf", "app.test.conf"))
+	os.Setenv("cocina-de-maria", "test-secret")
 	os.Chdir(appPath)
 	beego.TestBeegoInit(appPath)
 

--- a/tests/token_middleware_test.go
+++ b/tests/token_middleware_test.go
@@ -3,10 +3,13 @@ package test
 import (
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
+	"time"
 
 	beego "github.com/beego/beego/v2/server/web"
+	jwt "github.com/dgrijalva/jwt-go"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
@@ -44,5 +47,43 @@ func TestPublicPostWithoutToken(t *testing.T) {
 	Convey("POST /restaurante/v1/clientes without token should not return unauthorized", t, func() {
 		So(w.Code, ShouldNotEqual, http.StatusUnauthorized)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
+	})
+}
+
+// generateValidToken creates a JWT for testing purposes using the same secret as the application.
+func generateValidToken() string {
+	claims := jwt.MapClaims{
+		"documento": 1,
+		"rol":       "Cliente",
+		"nombre":    "Test User",
+		"exp":       time.Now().Add(time.Hour).Unix(),
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	tokenString, _ := token.SignedString([]byte(os.Getenv("cocina-de-maria")))
+	return tokenString
+}
+
+// TestProtectedEndpointWithInvalidToken verifies that an invalid token is rejected with 401.
+func TestProtectedEndpointWithInvalidToken(t *testing.T) {
+	r, _ := http.NewRequest("GET", "/restaurante/v1/clientes", nil)
+	r.Header.Set("Authorization", "Bearer invalid-token")
+	w := httptest.NewRecorder()
+	beego.BeeApp.Handlers.ServeHTTP(w, r)
+
+	Convey("GET /restaurante/v1/clientes with invalid token should be unauthorized", t, func() {
+		So(w.Code, ShouldEqual, http.StatusUnauthorized)
+	})
+}
+
+// TestProtectedEndpointWithValidToken ensures that a valid token allows access past the middleware.
+func TestProtectedEndpointWithValidToken(t *testing.T) {
+	token := generateValidToken()
+	r, _ := http.NewRequest("GET", "/restaurante/v1/clientes", nil)
+	r.Header.Set("Authorization", "Bearer "+token)
+	w := httptest.NewRecorder()
+	beego.BeeApp.Handlers.ServeHTTP(w, r)
+
+	Convey("GET /restaurante/v1/clientes with valid token should not be unauthorized", t, func() {
+		So(w.Code, ShouldNotEqual, http.StatusUnauthorized)
 	})
 }


### PR DESCRIPTION
## Summary
- configure test environment with JWT secret for token validation
- expand token middleware tests to cover invalid and valid tokens

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a0b586883c8325ac78986a0e16fba3