### PR TITLE
Fix schedule and reservation route handling and tests

### DIFF
--- a/controllers/CambiosHorarioController.go
+++ b/controllers/CambiosHorarioController.go
@@ -15,6 +15,11 @@ type CambiosHorarioController struct {
 	web.Controller
 }
 
+// queryCambioHorarioByDate allows tests to mock the database query used in GetByCurrentDate.
+var queryCambioHorarioByDate = func(o orm.Ormer, date string, ch *models.CambiosHorario) error {
+	return o.QueryTable(new(models.CambiosHorario)).Filter("FECHA", date).One(ch)
+}
+
 // @Title GetAll
 // @Summary Obtener todos los cambios de horario
 // @Description Obtiene un listado de todos los cambios de horario registrados en la base de datos
@@ -87,12 +92,10 @@ func (c *CambiosHorarioController) GetByCurrentDate() {
 	currentDate := time.Now().In(database.BogotaZone)
 
 	// Consultar si hay un cambio de horario para la fecha actual
-	err := o.QueryTable(new(models.CambiosHorario)).
-		Filter("FECHA", currentDate.Format("2006-01-02")).
-		One(&cambioHorario)
+	err := queryCambioHorarioByDate(o, currentDate.Format("2006-01-02"), &cambioHorario)
 
 	if err == orm.ErrNoRows {
-		c.Ctx.Output.SetStatus(http.StatusOK)
+		c.Ctx.Output.SetStatus(http.StatusNotFound)
 		c.Data["json"] = models.ApiResponse{
 			Code:    http.StatusNotFound,
 			Message: "No hay cambios de horario para la fecha actual",

--- a/controllers/ReservaController.go
+++ b/controllers/ReservaController.go
@@ -456,7 +456,7 @@ func (c *ReservaController) GetByParameter() {
 	}
 
 	if fechaReserva != "" {
-		_, err := time.Parse("2006-01-02", fechaReserva)
+		parsedDate, err := time.Parse("2006-01-02", fechaReserva)
 		if err != nil {
 			c.Ctx.Output.SetStatus(http.StatusBadRequest)
 			c.Data["json"] = models.ApiResponse{
@@ -466,7 +466,7 @@ func (c *ReservaController) GetByParameter() {
 			c.ServeJSON()
 			return
 		}
-		query = query.Filter("FECHA", fechaReserva)
+		query = query.Filter("FECHA", parsedDate)
 	}
 
 	// Ejecutar la consulta

--- a/controllers/cambios_horario_controller_test.go
+++ b/controllers/cambios_horario_controller_test.go
@@ -1,15 +1,17 @@
 package controllers
 
 import (
-        "net/http"
-        "net/http/httptest"
-        "strings"
-        "testing"
-        "time"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
 
-        "restaurante/database"
+	"restaurante/database"
+	"restaurante/models"
 
-        "github.com/beego/beego/v2/server/web/context"
+	"github.com/beego/beego/v2/client/orm"
+	"github.com/beego/beego/v2/server/web/context"
 )
 
 func TestCambiosHorarioGetAllWithoutDB(t *testing.T) {
@@ -32,149 +34,175 @@ func TestCambiosHorarioGetAllWithoutDB(t *testing.T) {
 }
 
 func TestCambiosHorarioPostInvalidJSON(t *testing.T) {
-        r := httptest.NewRequest(http.MethodPost, "/cambios_horario", strings.NewReader("notjson"))
-        w := httptest.NewRecorder()
-        ctx := context.NewContext()
-        ctx.Reset(w, r)
+	r := httptest.NewRequest(http.MethodPost, "/cambios_horario", strings.NewReader("notjson"))
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
 	c := CambiosHorarioController{}
 	c.Ctx = ctx
 	c.Data = make(map[interface{}]interface{})
 
 	c.Post()
 
-        if w.Code != http.StatusBadRequest {
-                t.Fatalf("expected status 400, got %d", w.Code)
-        }
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d", w.Code)
+	}
 }
 
 func TestCambiosHorarioGetByCurrentDateWithoutDB(t *testing.T) {
-        database.BogotaZone = time.Local
-        r := httptest.NewRequest(http.MethodGet, "/cambios_horario/actual", nil)
-        w := httptest.NewRecorder()
-        ctx := context.NewContext()
-        ctx.Reset(w, r)
-        c := CambiosHorarioController{}
-        c.Ctx = ctx
-        c.Data = make(map[interface{}]interface{})
+	database.BogotaZone = time.Local
+	r := httptest.NewRequest(http.MethodGet, "/cambios_horario/actual", nil)
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	c := CambiosHorarioController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
 
-        c.GetByCurrentDate()
+	c.GetByCurrentDate()
 
-        if w.Code != http.StatusInternalServerError {
-                t.Fatalf("expected status 500, got %d", w.Code)
-        }
-        if !strings.Contains(w.Body.String(), "Error al consultar cambios de horario") {
-                t.Errorf("unexpected body: %s", w.Body.String())
-        }
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected status 500, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "Error al consultar cambios de horario") {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
+}
+
+func TestCambiosHorarioGetByCurrentDateNotFound(t *testing.T) {
+	database.BogotaZone = time.Local
+	original := queryCambioHorarioByDate
+	queryCambioHorarioByDate = func(o orm.Ormer, date string, ch *models.CambiosHorario) error {
+		return orm.ErrNoRows
+	}
+	defer func() { queryCambioHorarioByDate = original }()
+
+	r := httptest.NewRequest(http.MethodGet, "/cambios_horario/actual", nil)
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	c := CambiosHorarioController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	c.GetByCurrentDate()
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected status 404, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "No hay cambios de horario para la fecha actual") {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
 }
 
 func TestCambiosHorarioPostMissingFecha(t *testing.T) {
-        body := `{"abierto":true,"horaApertura":"08:00:00","horaCierre":"17:00:00"}`
-        r := httptest.NewRequest(http.MethodPost, "/cambios_horario", strings.NewReader(body))
-        w := httptest.NewRecorder()
-        ctx := context.NewContext()
-        ctx.Reset(w, r)
-        ctx.Input.RequestBody = []byte(body)
-        c := CambiosHorarioController{}
-        c.Ctx = ctx
-        c.Data = make(map[interface{}]interface{})
+	body := `{"abierto":true,"horaApertura":"08:00:00","horaCierre":"17:00:00"}`
+	r := httptest.NewRequest(http.MethodPost, "/cambios_horario", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	ctx.Input.RequestBody = []byte(body)
+	c := CambiosHorarioController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
 
-        c.Post()
+	c.Post()
 
-        if w.Code != http.StatusBadRequest {
-                t.Fatalf("expected status 400, got %d", w.Code)
-        }
-        if !strings.Contains(w.Body.String(), "FECHA es obligatorio") {
-                t.Errorf("unexpected body: %s", w.Body.String())
-        }
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "FECHA es obligatorio") {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
 }
 
 func TestCambiosHorarioPostMissingHoraApertura(t *testing.T) {
-        body := `{"fechaCambioHorario":"2024-10-10","abierto":true,"horaCierre":"17:00:00"}`
-        r := httptest.NewRequest(http.MethodPost, "/cambios_horario", strings.NewReader(body))
-        w := httptest.NewRecorder()
-        ctx := context.NewContext()
-        ctx.Reset(w, r)
-        ctx.Input.RequestBody = []byte(body)
-        c := CambiosHorarioController{}
-        c.Ctx = ctx
-        c.Data = make(map[interface{}]interface{})
+	body := `{"fechaCambioHorario":"2024-10-10","abierto":true,"horaCierre":"17:00:00"}`
+	r := httptest.NewRequest(http.MethodPost, "/cambios_horario", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	ctx.Input.RequestBody = []byte(body)
+	c := CambiosHorarioController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
 
-        c.Post()
+	c.Post()
 
-        if w.Code != http.StatusBadRequest {
-                t.Fatalf("expected status 400, got %d", w.Code)
-        }
-        if !strings.Contains(w.Body.String(), "HORA_APERTURA es obligatorio") {
-                t.Errorf("unexpected body: %s", w.Body.String())
-        }
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "HORA_APERTURA es obligatorio") {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
 }
 
 func TestCambiosHorarioPostAbiertoFalse(t *testing.T) {
-        body := `{"fechaCambioHorario":"2024-10-10","abierto":false}`
-        r := httptest.NewRequest(http.MethodPost, "/cambios_horario", strings.NewReader(body))
-        w := httptest.NewRecorder()
-        ctx := context.NewContext()
-        ctx.Reset(w, r)
-        ctx.Input.RequestBody = []byte(body)
-        c := CambiosHorarioController{}
-        c.Ctx = ctx
-        c.Data = make(map[interface{}]interface{})
+	body := `{"fechaCambioHorario":"2024-10-10","abierto":false}`
+	r := httptest.NewRequest(http.MethodPost, "/cambios_horario", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	ctx.Input.RequestBody = []byte(body)
+	c := CambiosHorarioController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
 
-        c.Post()
+	c.Post()
 
-        if w.Code != http.StatusInternalServerError {
-                t.Fatalf("expected status 500, got %d", w.Code)
-        }
-        if !strings.Contains(w.Body.String(), "Error al crear el cambio de horario") {
-                t.Errorf("unexpected body: %s", w.Body.String())
-        }
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected status 500, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "Error al crear el cambio de horario") {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
 }
 
 func TestCambiosHorarioPutInvalidID(t *testing.T) {
-        r := httptest.NewRequest(http.MethodPut, "/cambios_horario", nil)
-        w := httptest.NewRecorder()
-        ctx := context.NewContext()
-        ctx.Reset(w, r)
-        c := CambiosHorarioController{}
-        c.Ctx = ctx
-        c.Data = make(map[interface{}]interface{})
+	r := httptest.NewRequest(http.MethodPut, "/cambios_horario", nil)
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	c := CambiosHorarioController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
 
-        c.Put()
+	c.Put()
 
-        if w.Code != http.StatusBadRequest {
-                t.Fatalf("expected status 400, got %d", w.Code)
-        }
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d", w.Code)
+	}
 }
 
 func TestCambiosHorarioPutInvalidJSON(t *testing.T) {
-        r := httptest.NewRequest(http.MethodPut, "/cambios_horario?id=1", strings.NewReader("notjson"))
-        w := httptest.NewRecorder()
-        ctx := context.NewContext()
-        ctx.Reset(w, r)
-        ctx.Input.RequestBody = []byte("notjson")
-        c := CambiosHorarioController{}
-        c.Ctx = ctx
-        c.Data = make(map[interface{}]interface{})
+	r := httptest.NewRequest(http.MethodPut, "/cambios_horario?id=1", strings.NewReader("notjson"))
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	ctx.Input.RequestBody = []byte("notjson")
+	c := CambiosHorarioController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
 
-        c.Put()
+	c.Put()
 
-        if w.Code != http.StatusBadRequest {
-                t.Fatalf("expected status 400, got %d", w.Code)
-        }
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d", w.Code)
+	}
 }
 
 func TestCambiosHorarioDeleteInvalidID(t *testing.T) {
-        r := httptest.NewRequest(http.MethodDelete, "/cambios_horario", nil)
-        w := httptest.NewRecorder()
-        ctx := context.NewContext()
-        ctx.Reset(w, r)
-        c := CambiosHorarioController{}
-        c.Ctx = ctx
-        c.Data = make(map[interface{}]interface{})
+	r := httptest.NewRequest(http.MethodDelete, "/cambios_horario", nil)
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	c := CambiosHorarioController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
 
-        c.Delete()
+	c.Delete()
 
-        if w.Code != http.StatusBadRequest {
-                t.Fatalf("expected status 400, got %d", w.Code)
-        }
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d", w.Code)
+	}
 }

--- a/controllers/reserva_controller_test.go
+++ b/controllers/reserva_controller_test.go
@@ -150,6 +150,25 @@ func TestReservaGetByParameterInvalidFecha(t *testing.T) {
 	}
 }
 
+func TestReservaGetByParameterDBError(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/reservas/parameter?documentoCliente=123&fecha=2024-10-10", nil)
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	c := ReservaController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	c.GetByParameter()
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected status 500, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "Error al obtener reservas") {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
+}
+
 func TestReservaDeleteInvalidID(t *testing.T) {
 	r := httptest.NewRequest(http.MethodDelete, "/reservas", nil)
 	w := httptest.NewRecorder()


### PR DESCRIPTION
## Summary
- Fix reservation date filter to use parsed date value
- Adjust schedule lookup to return 404 when no record exists
- Add unit tests for schedule not found and reservation query errors

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a0b919faec83258c80a5f9517946f8