### PR TITLE
test: cover CambiosHorarioController

### DIFF
--- a/controllers/CambiosHorarioController.go
+++ b/controllers/CambiosHorarioController.go
@@ -20,6 +20,25 @@ var queryCambioHorarioByDate = func(o orm.Ormer, date string, ch *models.Cambios
 	return o.QueryTable(new(models.CambiosHorario)).Filter("FECHA", date).One(ch)
 }
 
+// database operation hooks allow tests to mock database interactions.
+var (
+	queryAllCambiosHorario = func(o orm.Ormer, horarios *[]models.CambiosHorario) (int64, error) {
+		return o.QueryTable(new(models.CambiosHorario)).All(horarios)
+	}
+	insertCambioHorario = func(o orm.Ormer, horario *models.CambiosHorario) (int64, error) {
+		return o.Insert(horario)
+	}
+	queryCambioHorarioByID = func(o orm.Ormer, id int64, horario *models.CambiosHorario) error {
+		return o.QueryTable(new(models.CambiosHorario)).Filter("cambioHorarioId", id).One(horario)
+	}
+	updateCambioHorario = func(o orm.Ormer, horario *models.CambiosHorario) (int64, error) {
+		return o.Update(horario)
+	}
+	deleteCambioHorarioByID = func(o orm.Ormer, id int64) (int64, error) {
+		return o.QueryTable(new(models.CambiosHorario)).Filter("cambioHorarioId", id).Delete()
+	}
+)
+
 // @Title GetAll
 // @Summary Obtener todos los cambios de horario
 // @Description Obtiene un listado de todos los cambios de horario registrados en la base de datos
@@ -33,7 +52,7 @@ func (c *CambiosHorarioController) GetAll() {
 	o := orm.NewOrm()
 	var horarios []models.CambiosHorario
 
-	_, err := o.QueryTable(new(models.CambiosHorario)).All(&horarios)
+	_, err := queryAllCambiosHorario(o, &horarios)
 	if err != nil {
 		c.Ctx.Output.SetStatus(http.StatusInternalServerError)
 		c.Data["json"] = models.ApiResponse{
@@ -259,7 +278,7 @@ func (c *CambiosHorarioController) Post() {
 	}
 
 	// Insertar en la base de datos
-	_, err := o.Insert(&horario)
+	_, err := insertCambioHorario(o, &horario)
 	if err != nil {
 		c.Ctx.Output.SetStatus(http.StatusInternalServerError)
 		c.Data["json"] = models.ApiResponse{
@@ -334,7 +353,7 @@ func (c *CambiosHorarioController) Put() {
 
 	// Buscar el cambio de horario por ID
 	var horario models.CambiosHorario
-	if err := o.QueryTable(new(models.CambiosHorario)).Filter("cambioHorarioId", id).One(&horario); err == orm.ErrNoRows {
+	if err := queryCambioHorarioByID(o, id, &horario); err == orm.ErrNoRows {
 		c.Ctx.Output.SetStatus(http.StatusOK)
 		c.Data["json"] = models.ApiResponse{
 			Code:    http.StatusNotFound,
@@ -412,7 +431,7 @@ func (c *CambiosHorarioController) Put() {
 	}
 
 	// Guardar los cambios
-	if _, err := o.Update(&horario); err != nil {
+	if _, err := updateCambioHorario(o, &horario); err != nil {
 		c.Ctx.Output.SetStatus(http.StatusInternalServerError)
 		c.Data["json"] = models.ApiResponse{
 			Code:    http.StatusInternalServerError,
@@ -471,9 +490,7 @@ func (c *CambiosHorarioController) Delete() {
 	}
 
 	// Eliminar el cambio de horario
-	if num, err := o.QueryTable(new(models.CambiosHorario)).
-		Filter("cambioHorarioId", id).
-		Delete(); err != nil {
+	if num, err := deleteCambioHorarioByID(o, id); err != nil {
 		c.Ctx.Output.SetStatus(http.StatusInternalServerError)
 		c.Data["json"] = models.ApiResponse{
 			Code:    http.StatusInternalServerError,

--- a/controllers/cambios_horario_controller_test.go
+++ b/controllers/cambios_horario_controller_test.go
@@ -1,6 +1,7 @@
 package controllers
 
 import (
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -204,5 +205,427 @@ func TestCambiosHorarioDeleteInvalidID(t *testing.T) {
 
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("expected status 400, got %d", w.Code)
+	}
+}
+
+func TestCambiosHorarioGetAllSuccess(t *testing.T) {
+	original := queryAllCambiosHorario
+	queryAllCambiosHorario = func(o orm.Ormer, horarios *[]models.CambiosHorario) (int64, error) {
+		apertura, _ := time.Parse("15:04:05", "08:00:00")
+		cierre, _ := time.Parse("15:04:05", "17:00:00")
+		*horarios = []models.CambiosHorario{{
+			PK_ID_CAMBIO_HORARIO: 1,
+			FECHA:                time.Date(2024, 10, 10, 0, 0, 0, 0, time.UTC),
+			HORA_APERTURA:        &apertura,
+			HORA_CIERRE:          &cierre,
+			ABIERTO:              true,
+		}}
+		return 1, nil
+	}
+	defer func() { queryAllCambiosHorario = original }()
+
+	r := httptest.NewRequest(http.MethodGet, "/cambios_horario", nil)
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	c := CambiosHorarioController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	c.GetAll()
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "Cambios de horario obtenidos correctamente") {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
+}
+
+func TestCambiosHorarioGetByCurrentDateSuccess(t *testing.T) {
+	database.BogotaZone = time.UTC
+	original := queryCambioHorarioByDate
+	queryCambioHorarioByDate = func(o orm.Ormer, date string, ch *models.CambiosHorario) error {
+		apertura, _ := time.Parse("15:04:05", "09:00:00")
+		cierre, _ := time.Parse("15:04:05", "18:00:00")
+		ch.PK_ID_CAMBIO_HORARIO = 2
+		ch.FECHA = time.Date(2024, 10, 10, 0, 0, 0, 0, time.UTC)
+		ch.HORA_APERTURA = &apertura
+		ch.HORA_CIERRE = &cierre
+		ch.ABIERTO = true
+		return nil
+	}
+	defer func() { queryCambioHorarioByDate = original }()
+
+	r := httptest.NewRequest(http.MethodGet, "/cambios_horario/actual", nil)
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	c := CambiosHorarioController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	c.GetByCurrentDate()
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "Cambio de horario encontrado para la fecha actual") {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
+}
+
+func TestCambiosHorarioPostInvalidFecha(t *testing.T) {
+	body := `{"fechaCambioHorario":"2024/10/10","abierto":true,"horaApertura":"08:00:00","horaCierre":"17:00:00"}`
+	r := httptest.NewRequest(http.MethodPost, "/cambios_horario", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	ctx.Input.RequestBody = []byte(body)
+	c := CambiosHorarioController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	c.Post()
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d", w.Code)
+	}
+}
+
+func TestCambiosHorarioPostMissingAbierto(t *testing.T) {
+	body := `{"fechaCambioHorario":"2024-10-10"}`
+	r := httptest.NewRequest(http.MethodPost, "/cambios_horario", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	ctx.Input.RequestBody = []byte(body)
+	c := CambiosHorarioController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	c.Post()
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d", w.Code)
+	}
+}
+
+func TestCambiosHorarioPostInvalidHoraApertura(t *testing.T) {
+	body := `{"fechaCambioHorario":"2024-10-10","abierto":true,"horaApertura":"invalid","horaCierre":"17:00:00"}`
+	r := httptest.NewRequest(http.MethodPost, "/cambios_horario", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	ctx.Input.RequestBody = []byte(body)
+	c := CambiosHorarioController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	c.Post()
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d", w.Code)
+	}
+}
+
+func TestCambiosHorarioPostMissingHoraCierre(t *testing.T) {
+	body := `{"fechaCambioHorario":"2024-10-10","abierto":true,"horaApertura":"08:00:00"}`
+	r := httptest.NewRequest(http.MethodPost, "/cambios_horario", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	ctx.Input.RequestBody = []byte(body)
+	c := CambiosHorarioController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	c.Post()
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d", w.Code)
+	}
+}
+
+func TestCambiosHorarioPostInvalidHoraCierre(t *testing.T) {
+	body := `{"fechaCambioHorario":"2024-10-10","abierto":true,"horaApertura":"08:00:00","horaCierre":"invalid"}`
+	r := httptest.NewRequest(http.MethodPost, "/cambios_horario", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	ctx.Input.RequestBody = []byte(body)
+	c := CambiosHorarioController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	c.Post()
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d", w.Code)
+	}
+}
+
+func TestCambiosHorarioPostSuccess(t *testing.T) {
+	original := insertCambioHorario
+	insertCambioHorario = func(o orm.Ormer, h *models.CambiosHorario) (int64, error) {
+		h.PK_ID_CAMBIO_HORARIO = 1
+		return 1, nil
+	}
+	defer func() { insertCambioHorario = original }()
+
+	body := `{"fechaCambioHorario":"2024-10-10","abierto":true,"horaApertura":"08:00:00","horaCierre":"17:00:00"}`
+	r := httptest.NewRequest(http.MethodPost, "/cambios_horario", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	ctx.Input.RequestBody = []byte(body)
+	c := CambiosHorarioController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	c.Post()
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected status 201, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "Cambio de horario creado correctamente") {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
+}
+
+func TestCambiosHorarioPostAbiertoFalseSuccess(t *testing.T) {
+	original := insertCambioHorario
+	insertCambioHorario = func(o orm.Ormer, h *models.CambiosHorario) (int64, error) {
+		h.PK_ID_CAMBIO_HORARIO = 2
+		return 1, nil
+	}
+	defer func() { insertCambioHorario = original }()
+
+	body := `{"fechaCambioHorario":"2024-10-10","abierto":false}`
+	r := httptest.NewRequest(http.MethodPost, "/cambios_horario", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	ctx.Input.RequestBody = []byte(body)
+	c := CambiosHorarioController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	c.Post()
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected status 201, got %d", w.Code)
+	}
+}
+
+func TestCambiosHorarioPutNotFound(t *testing.T) {
+	original := queryCambioHorarioByID
+	queryCambioHorarioByID = func(o orm.Ormer, id int64, ch *models.CambiosHorario) error {
+		return orm.ErrNoRows
+	}
+	defer func() { queryCambioHorarioByID = original }()
+
+	r := httptest.NewRequest(http.MethodPut, "/cambios_horario?id=1", strings.NewReader(`{}`))
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	ctx.Input.RequestBody = []byte(`{}`)
+	c := CambiosHorarioController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	c.Put()
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "Cambio de horario no encontrado") {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
+}
+
+func TestCambiosHorarioPutDBError(t *testing.T) {
+	original := queryCambioHorarioByID
+	queryCambioHorarioByID = func(o orm.Ormer, id int64, ch *models.CambiosHorario) error {
+		return errors.New("db error")
+	}
+	defer func() { queryCambioHorarioByID = original }()
+
+	r := httptest.NewRequest(http.MethodPut, "/cambios_horario?id=1", strings.NewReader(`{}`))
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	ctx.Input.RequestBody = []byte(`{}`)
+	c := CambiosHorarioController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	c.Put()
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected status 500, got %d", w.Code)
+	}
+}
+
+func TestCambiosHorarioPutInvalidHoraApertura(t *testing.T) {
+	original := queryCambioHorarioByID
+	queryCambioHorarioByID = func(o orm.Ormer, id int64, ch *models.CambiosHorario) error { return nil }
+	defer func() { queryCambioHorarioByID = original }()
+
+	body := `{"abierto":true,"horaApertura":"bad"}`
+	r := httptest.NewRequest(http.MethodPut, "/cambios_horario?id=1", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	ctx.Input.RequestBody = []byte(body)
+	c := CambiosHorarioController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	c.Put()
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d", w.Code)
+	}
+}
+
+func TestCambiosHorarioPutInvalidHoraCierre(t *testing.T) {
+	original := queryCambioHorarioByID
+	queryCambioHorarioByID = func(o orm.Ormer, id int64, ch *models.CambiosHorario) error { return nil }
+	defer func() { queryCambioHorarioByID = original }()
+
+	body := `{"abierto":true,"horaApertura":"08:00:00","horaCierre":"bad"}`
+	r := httptest.NewRequest(http.MethodPut, "/cambios_horario?id=1", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	ctx.Input.RequestBody = []byte(body)
+	c := CambiosHorarioController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	c.Put()
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d", w.Code)
+	}
+}
+
+func TestCambiosHorarioPutUpdateError(t *testing.T) {
+	originalQuery := queryCambioHorarioByID
+	queryCambioHorarioByID = func(o orm.Ormer, id int64, ch *models.CambiosHorario) error { return nil }
+	originalUpdate := updateCambioHorario
+	updateCambioHorario = func(o orm.Ormer, ch *models.CambiosHorario) (int64, error) {
+		return 0, errors.New("update error")
+	}
+	defer func() {
+		queryCambioHorarioByID = originalQuery
+		updateCambioHorario = originalUpdate
+	}()
+
+	body := `{"abierto":true,"horaApertura":"08:00:00","horaCierre":"17:00:00"}`
+	r := httptest.NewRequest(http.MethodPut, "/cambios_horario?id=1", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	ctx.Input.RequestBody = []byte(body)
+	c := CambiosHorarioController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	c.Put()
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected status 500, got %d", w.Code)
+	}
+}
+
+func TestCambiosHorarioPutSuccess(t *testing.T) {
+	originalQuery := queryCambioHorarioByID
+	queryCambioHorarioByID = func(o orm.Ormer, id int64, ch *models.CambiosHorario) error { return nil }
+	originalUpdate := updateCambioHorario
+	updateCambioHorario = func(o orm.Ormer, ch *models.CambiosHorario) (int64, error) { return 1, nil }
+	defer func() {
+		queryCambioHorarioByID = originalQuery
+		updateCambioHorario = originalUpdate
+	}()
+
+	body := `{"abierto":true,"horaApertura":"08:00:00","horaCierre":"17:00:00"}`
+	r := httptest.NewRequest(http.MethodPut, "/cambios_horario?id=1", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	ctx.Input.RequestBody = []byte(body)
+	c := CambiosHorarioController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	c.Put()
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+}
+
+func TestCambiosHorarioDeleteNotFound(t *testing.T) {
+	original := deleteCambioHorarioByID
+	deleteCambioHorarioByID = func(o orm.Ormer, id int64) (int64, error) { return 0, nil }
+	defer func() { deleteCambioHorarioByID = original }()
+
+	r := httptest.NewRequest(http.MethodDelete, "/cambios_horario?id=1", nil)
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	c := CambiosHorarioController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	c.Delete()
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "Cambio de horario no encontrado") {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
+}
+
+func TestCambiosHorarioDeleteDBError(t *testing.T) {
+	original := deleteCambioHorarioByID
+	deleteCambioHorarioByID = func(o orm.Ormer, id int64) (int64, error) { return 0, errors.New("db") }
+	defer func() { deleteCambioHorarioByID = original }()
+
+	r := httptest.NewRequest(http.MethodDelete, "/cambios_horario?id=1", nil)
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	c := CambiosHorarioController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	c.Delete()
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected status 500, got %d", w.Code)
+	}
+}
+
+func TestCambiosHorarioDeleteSuccess(t *testing.T) {
+	original := deleteCambioHorarioByID
+	deleteCambioHorarioByID = func(o orm.Ormer, id int64) (int64, error) { return 1, nil }
+	defer func() { deleteCambioHorarioByID = original }()
+
+	r := httptest.NewRequest(http.MethodDelete, "/cambios_horario?id=1", nil)
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	c := CambiosHorarioController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	c.Delete()
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
 	}
 }


### PR DESCRIPTION
## Summary
- add mockable hooks for CambiosHorarioController database operations
- create comprehensive unit tests covering all branches of CambiosHorarioController

## Testing
- `go test ./controllers -run CambiosHorario -count=1`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a0c1559a9c8325a2624114de9f0193