### PR TITLE
test: cover CambiosHorario controller

### DIFF
--- a/controllers/cambios_horario_controller_test.go
+++ b/controllers/cambios_horario_controller_test.go
@@ -205,9 +205,9 @@ func TestCambiosHorario_Put_NotFoundPath(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", w.Code)
 	}
-       if !strings.Contains(w.Body.String(), `"code":404`) || !strings.Contains(w.Body.String(), `"message":"Cambio de horario no encontrado"`) {
-               t.Errorf("unexpected body: %s", w.Body.String())
-       }
+	if !strings.Contains(w.Body.String(), `"code":404`) || !strings.Contains(w.Body.String(), `"message":"Cambio de horario no encontrado"`) {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
 }
 
 func TestCambiosHorario_Put_UpdateSuccess(t *testing.T) {
@@ -260,9 +260,9 @@ func TestCambiosHorario_Delete_NotFound(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", w.Code)
 	}
-       if !strings.Contains(w.Body.String(), `"code":404`) || !strings.Contains(w.Body.String(), `"message":"Cambio de horario no encontrado"`) {
-               t.Errorf("unexpected body: %s", w.Body.String())
-       }
+	if !strings.Contains(w.Body.String(), `"code":404`) || !strings.Contains(w.Body.String(), `"message":"Cambio de horario no encontrado"`) {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
 }
 
 func TestCambiosHorario_Delete_Success(t *testing.T) {
@@ -280,5 +280,278 @@ func TestCambiosHorario_Delete_Success(t *testing.T) {
 	}
 	if !strings.Contains(w.Body.String(), "eliminado correctamente") {
 		t.Errorf("unexpected body: %s", w.Body.String())
+	}
+}
+
+func TestCambiosHorario_GetAll_WithHoras(t *testing.T) {
+	orig := queryAllCambiosHorario
+	queryAllCambiosHorario = func(o orm.Ormer, horarios *[]models.CambiosHorario) (int64, error) {
+		horaApertura, _ := time.Parse("15:04:05", "08:00:00")
+		horaCierre, _ := time.Parse("15:04:05", "17:00:00")
+		*horarios = []models.CambiosHorario{
+			{
+				PK_ID_CAMBIO_HORARIO: 3,
+				FECHA:                time.Date(2024, 10, 12, 0, 0, 0, 0, time.UTC),
+				ABIERTO:              true,
+				HORA_APERTURA:        &horaApertura,
+				HORA_CIERRE:          &horaCierre,
+			},
+		}
+		return 1, nil
+	}
+	defer func() { queryAllCambiosHorario = orig }()
+
+	c, w := setupCtx(http.MethodGet, "/cambios_horario", "")
+	c.GetAll()
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), `"horaApertura":"08:00:00"`) || !strings.Contains(w.Body.String(), `"horaCierre":"17:00:00"`) {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
+}
+
+func TestCambiosHorario_GetByCurrentDate_Success(t *testing.T) {
+	database.BogotaZone = time.Local
+	orig := queryCambioHorarioByDate
+	queryCambioHorarioByDate = func(o orm.Ormer, date string, ch *models.CambiosHorario) error {
+		d, _ := time.Parse("2006-01-02", date)
+		ha, _ := time.Parse("15:04:05", "08:00:00")
+		hc, _ := time.Parse("15:04:05", "17:00:00")
+		*ch = models.CambiosHorario{
+			PK_ID_CAMBIO_HORARIO: 1,
+			FECHA:                d,
+			ABIERTO:              true,
+			HORA_APERTURA:        &ha,
+			HORA_CIERRE:          &hc,
+		}
+		return nil
+	}
+	defer func() { queryCambioHorarioByDate = orig }()
+
+	c, w := setupCtx(http.MethodGet, "/cambios_horario/actual", "")
+	c.GetByCurrentDate()
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), `"cambioHorarioId":1`) {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
+}
+
+func TestCambiosHorario_Post_InvalidFecha(t *testing.T) {
+	body := `{"fechaCambioHorario":"2024/10/10","abierto":false}`
+	c, w := setupCtx(http.MethodPost, "/cambios_horario", body)
+	c.Post()
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "Formato de fecha inválido") {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
+}
+
+func TestCambiosHorario_Post_MissingAbierto(t *testing.T) {
+	body := `{"fechaCambioHorario":"2024-10-10"}`
+	c, w := setupCtx(http.MethodPost, "/cambios_horario", body)
+	c.Post()
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "ABIERTO es obligatorio") {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
+}
+
+func TestCambiosHorario_Post_InvalidHoraApertura(t *testing.T) {
+	body := `{"fechaCambioHorario":"2024-10-10","abierto":true,"horaApertura":"bad","horaCierre":"17:00:00"}`
+	c, w := setupCtx(http.MethodPost, "/cambios_horario", body)
+	c.Post()
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "Formato de hora inválido para HORA_APERTURA") {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
+}
+
+func TestCambiosHorario_Post_MissingHoraCierre(t *testing.T) {
+	body := `{"fechaCambioHorario":"2024-10-10","abierto":true,"horaApertura":"08:00:00"}`
+	c, w := setupCtx(http.MethodPost, "/cambios_horario", body)
+	c.Post()
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "HORA_CIERRE es obligatorio") {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
+}
+
+func TestCambiosHorario_Post_InvalidHoraCierre(t *testing.T) {
+	body := `{"fechaCambioHorario":"2024-10-10","abierto":true,"horaApertura":"08:00:00","horaCierre":"bad"}`
+	c, w := setupCtx(http.MethodPost, "/cambios_horario", body)
+	c.Post()
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "Formato de hora inválido para HORA_CIERRE") {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
+}
+
+func TestCambiosHorario_Post_AbiertoTrue_Success(t *testing.T) {
+	orig := insertCambioHorario
+	insertCambioHorario = func(o orm.Ormer, horario *models.CambiosHorario) (int64, error) {
+		horario.PK_ID_CAMBIO_HORARIO = 5
+		return 1, nil
+	}
+	defer func() { insertCambioHorario = orig }()
+
+	body := `{"fechaCambioHorario":"2024-10-10","abierto":true,"horaApertura":"08:00:00","horaCierre":"17:00:00"}`
+	c, w := setupCtx(http.MethodPost, "/cambios_horario", body)
+	c.Post()
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), `"cambioHorarioId":5`) {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
+}
+
+func TestCambiosHorario_Put_FindError(t *testing.T) {
+	orig := queryCambioHorarioByID
+	queryCambioHorarioByID = func(o orm.Ormer, id int64, horario *models.CambiosHorario) error {
+		return errors.New("db error")
+	}
+	defer func() { queryCambioHorarioByID = orig }()
+
+	c, w := setupCtx(http.MethodPut, "/cambios_horario?id=1", `{}`)
+	c.Put()
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", w.Code)
+	}
+}
+
+func TestCambiosHorario_Put_BadFecha(t *testing.T) {
+	origFind := queryCambioHorarioByID
+	queryCambioHorarioByID = func(o orm.Ormer, id int64, horario *models.CambiosHorario) error {
+		*horario = models.CambiosHorario{PK_ID_CAMBIO_HORARIO: id, FECHA: time.Now(), ABIERTO: true}
+		return nil
+	}
+	defer func() { queryCambioHorarioByID = origFind }()
+
+	body := `{"fechaCambioHorario":"bad"}`
+	c, w := setupCtx(http.MethodPut, "/cambios_horario?id=1", body)
+	c.Put()
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "Formato de fecha inválido") {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
+}
+
+func TestCambiosHorario_Put_AbiertoFalse(t *testing.T) {
+	origFind := queryCambioHorarioByID
+	origUpd := updateCambioHorario
+	queryCambioHorarioByID = func(o orm.Ormer, id int64, horario *models.CambiosHorario) error {
+		*horario = models.CambiosHorario{PK_ID_CAMBIO_HORARIO: id, FECHA: time.Date(2024, 10, 10, 0, 0, 0, 0, time.UTC), ABIERTO: true}
+		return nil
+	}
+	updateCambioHorario = func(o orm.Ormer, horario *models.CambiosHorario) (int64, error) {
+		return 1, nil
+	}
+	defer func() { queryCambioHorarioByID = origFind; updateCambioHorario = origUpd }()
+
+	body := `{"abierto":false}`
+	c, w := setupCtx(http.MethodPut, "/cambios_horario?id=2", body)
+	c.Put()
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), `"abierto":false`) {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
+}
+
+func TestCambiosHorario_Put_InvalidHoraApertura(t *testing.T) {
+	origFind := queryCambioHorarioByID
+	queryCambioHorarioByID = func(o orm.Ormer, id int64, horario *models.CambiosHorario) error {
+		*horario = models.CambiosHorario{PK_ID_CAMBIO_HORARIO: id, FECHA: time.Now(), ABIERTO: false}
+		return nil
+	}
+	defer func() { queryCambioHorarioByID = origFind }()
+
+	body := `{"abierto":true,"horaApertura":"bad"}`
+	c, w := setupCtx(http.MethodPut, "/cambios_horario?id=3", body)
+	c.Put()
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "Formato de hora inválido para HORA_APERTURA") {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
+}
+
+func TestCambiosHorario_Put_InvalidHoraCierre(t *testing.T) {
+	origFind := queryCambioHorarioByID
+	queryCambioHorarioByID = func(o orm.Ormer, id int64, horario *models.CambiosHorario) error {
+		*horario = models.CambiosHorario{PK_ID_CAMBIO_HORARIO: id, FECHA: time.Now(), ABIERTO: false}
+		return nil
+	}
+	defer func() { queryCambioHorarioByID = origFind }()
+
+	body := `{"abierto":true,"horaApertura":"08:00:00","horaCierre":"bad"}`
+	c, w := setupCtx(http.MethodPut, "/cambios_horario?id=4", body)
+	c.Put()
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "Formato de hora inválido para HORA_CIERRE") {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
+}
+
+func TestCambiosHorario_Put_UpdateError(t *testing.T) {
+	origFind := queryCambioHorarioByID
+	origUpd := updateCambioHorario
+	queryCambioHorarioByID = func(o orm.Ormer, id int64, horario *models.CambiosHorario) error {
+		*horario = models.CambiosHorario{PK_ID_CAMBIO_HORARIO: id, FECHA: time.Now(), ABIERTO: true}
+		return nil
+	}
+	updateCambioHorario = func(o orm.Ormer, horario *models.CambiosHorario) (int64, error) {
+		return 0, errors.New("update fail")
+	}
+	defer func() { queryCambioHorarioByID = origFind; updateCambioHorario = origUpd }()
+
+	body := `{"abierto":true,"horaApertura":"08:00:00","horaCierre":"17:00:00"}`
+	c, w := setupCtx(http.MethodPut, "/cambios_horario?id=5", body)
+	c.Put()
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", w.Code)
+	}
+}
+
+func TestCambiosHorario_Delete_DBError(t *testing.T) {
+	origDel := deleteCambioHorarioByID
+	deleteCambioHorarioByID = func(o orm.Ormer, id int64) (int64, error) {
+		return 0, errors.New("del err")
+	}
+	defer func() { deleteCambioHorarioByID = origDel }()
+
+	c, w := setupCtx(http.MethodDelete, "/cambios_horario?id=9", "")
+	c.Delete()
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", w.Code)
 	}
 }


### PR DESCRIPTION
## Summary
- expand CambiosHorarioController tests to cover hour fields, success paths and error handling
- add tests for bad dates, missing fields, and update/delete failures
- reach 100% coverage for CambiosHorarioController

## Testing
- `go test ./controllers -coverprofile=coverage_test.out`
- `go tool cover -func=coverage_test.out | grep CambiosHorarioController.go`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a281a73874832592e0e048f806869b