### PR TITLE
Achieve full coverage for ReservaController

### DIFF
--- a/controllers/ReservaController.go
+++ b/controllers/ReservaController.go
@@ -24,6 +24,33 @@ var estadosPermitidos = map[string]bool{
 	"CUMPLIDA":   true,
 }
 
+var queryAllReservas = func(o orm.Ormer, reservas *[]models.Reserva) (int64, error) {
+	return o.QueryTable(new(models.Reserva)).All(reservas)
+}
+
+var readReserva = func(o orm.Ormer, r *models.Reserva) error {
+	return o.Read(r)
+}
+
+var insertReserva = func(o orm.Ormer, r *models.Reserva) (int64, error) {
+	return o.Insert(r)
+}
+
+var updateReserva = func(o orm.Ormer, r *models.Reserva, cols ...string) (int64, error) {
+	return o.Update(r, cols...)
+}
+
+var queryReservasByParam = func(o orm.Ormer, documentoCliente int64, fecha time.Time, useDoc, useFecha bool, reservas *[]models.Reserva) (int64, error) {
+	qs := o.QueryTable(new(models.Reserva))
+	if useDoc {
+		qs = qs.Filter("DOCUMENTO_CLIENTE", documentoCliente)
+	}
+	if useFecha {
+		qs = qs.Filter("FECHA", fecha)
+	}
+	return qs.All(reservas)
+}
+
 // @Title GetAll
 // @Summary Obtener todas las reservas
 // @Description Devuelve todas las reservas registradas en la base de datos.
@@ -34,10 +61,10 @@ var estadosPermitidos = map[string]bool{
 // @Failure 500 {object} models.ApiResponse "Error en la base de datos"
 // @Router /reservas [get]
 func (c *ReservaController) GetAll() {
-	o := orm.NewOrm()
+	o := ormNew()
 	var reservas []models.Reserva
 
-	_, err := o.QueryTable(new(models.Reserva)).All(&reservas)
+	_, err := queryAllReservas(o, &reservas)
 	if err != nil {
 		c.Ctx.Output.SetStatus(http.StatusInternalServerError)
 		c.Data["json"] = models.ApiResponse{
@@ -80,7 +107,7 @@ func (c *ReservaController) GetAll() {
 // @Failure 404 {object} models.ApiResponse "Reserva no encontrada"
 // @Router /reservas/search [get]
 func (c *ReservaController) GetById() {
-	o := orm.NewOrm()
+	o := ormNew()
 	id, err := c.GetInt("id")
 
 	if err != nil || id == 0 {
@@ -96,7 +123,7 @@ func (c *ReservaController) GetById() {
 
 	reserva := models.Reserva{PK_ID_RESERVA: id}
 
-	err = o.Read(&reserva)
+	err = readReserva(o, &reserva)
 	if err == orm.ErrNoRows {
 		c.Ctx.Output.SetStatus(http.StatusOK)
 		c.Data["json"] = models.ApiResponse{
@@ -134,7 +161,7 @@ func (c *ReservaController) GetById() {
 // @Failure 400 {object} models.ApiResponse "Error en la solicitud"
 // @Router /reservas [post]
 func (c *ReservaController) Post() {
-	o := orm.NewOrm()
+	o := ormNew()
 	var input map[string]interface{}
 
 	// Decodificar la solicitud
@@ -262,7 +289,7 @@ func (c *ReservaController) Post() {
 	reserva.UPDATED_AT = time.Time{}
 
 	// Insertar en la base de datos
-	_, err := o.Insert(&reserva)
+	_, err := insertReserva(o, &reserva)
 	if err != nil {
 		c.Ctx.Output.SetStatus(http.StatusInternalServerError)
 		c.Data["json"] = models.ApiResponse{
@@ -296,7 +323,7 @@ func (c *ReservaController) Post() {
 // @Failure 404 {object} models.ApiResponse "Reserva no encontrada"
 // @Router /reservas [put]
 func (c *ReservaController) Put() {
-	o := orm.NewOrm()
+	o := ormNew()
 
 	// Obtener el ID de la reserva desde los parámetros
 	idStr := c.GetString("id")
@@ -314,7 +341,7 @@ func (c *ReservaController) Put() {
 
 	// Buscar la reserva por ID
 	reserva := models.Reserva{PK_ID_RESERVA: id}
-	if err := o.Read(&reserva); err != nil {
+	if err := readReserva(o, &reserva); err != nil {
 		c.Ctx.Output.SetStatus(http.StatusOK)
 		c.Data["json"] = models.ApiResponse{
 			Code:    http.StatusNotFound,
@@ -407,7 +434,7 @@ func (c *ReservaController) Put() {
 	reserva.UPDATED_AT = time.Now().UTC()
 
 	// Actualizar los datos en la base de datos
-	if _, err := o.Update(&reserva); err != nil {
+	if _, err := updateReserva(o, &reserva); err != nil {
 		c.Ctx.Output.SetStatus(http.StatusInternalServerError)
 		c.Data["json"] = models.ApiResponse{
 			Code:    http.StatusInternalServerError,
@@ -441,22 +468,18 @@ func (c *ReservaController) Put() {
 // @Failure 500 {object} models.ApiResponse "Error en la base de datos"
 // @Router /reservas/parameter [get]
 func (c *ReservaController) GetByParameter() {
-	o := orm.NewOrm()
+	o := ormNew()
 	var reservas []models.Reserva
 
-	// Obtener parámetros de la consulta
 	documentoCliente, errDoc := c.GetInt64("documentoCliente")
 	fechaReserva := c.GetString("fecha")
 
-	// Construir la consulta con filtros dinámicos
-	query := o.QueryTable(new(models.Reserva))
-
-	if errDoc == nil && documentoCliente != 0 {
-		query = query.Filter("DOCUMENTO_CLIENTE", documentoCliente)
-	}
-
+	useDoc := errDoc == nil && documentoCliente != 0
+	var parsedDate time.Time
+	useFecha := false
 	if fechaReserva != "" {
-		parsedDate, err := time.Parse("2006-01-02", fechaReserva)
+		var err error
+		parsedDate, err = time.Parse("2006-01-02", fechaReserva)
 		if err != nil {
 			c.Ctx.Output.SetStatus(http.StatusBadRequest)
 			c.Data["json"] = models.ApiResponse{
@@ -466,11 +489,10 @@ func (c *ReservaController) GetByParameter() {
 			c.ServeJSON()
 			return
 		}
-		query = query.Filter("FECHA", parsedDate)
+		useFecha = true
 	}
 
-	// Ejecutar la consulta
-	_, err := query.All(&reservas)
+	_, err := queryReservasByParam(o, documentoCliente, parsedDate, useDoc, useFecha, &reservas)
 	if err != nil {
 		c.Ctx.Output.SetStatus(http.StatusInternalServerError)
 		c.Data["json"] = models.ApiResponse{
@@ -512,7 +534,7 @@ func (c *ReservaController) GetByParameter() {
 // @Failure 404 {object} models.ApiResponse "Reserva no encontrada"
 // @Router /reservas [delete]
 func (c *ReservaController) Delete() {
-	o := orm.NewOrm()
+	o := ormNew()
 
 	// Obtener el ID de la reserva desde los parámetros
 	idStr := c.GetString("id")
@@ -530,7 +552,7 @@ func (c *ReservaController) Delete() {
 
 	// Buscar la reserva por ID
 	reserva := models.Reserva{PK_ID_RESERVA: id}
-	if err := o.Read(&reserva); err != nil {
+	if err := readReserva(o, &reserva); err != nil {
 		c.Ctx.Output.SetStatus(http.StatusOK)
 		c.Data["json"] = models.ApiResponse{
 			Code:    http.StatusNotFound,
@@ -546,7 +568,7 @@ func (c *ReservaController) Delete() {
 	reserva.UPDATED_AT = time.Now() // Actualizar la fecha de modificación
 
 	// Guardar los cambios en la base de datos
-	if _, err := o.Update(&reserva, "estadoReserva", "updatedAt"); err != nil {
+	if _, err := updateReserva(o, &reserva, "estadoReserva", "updatedAt"); err != nil {
 		c.Ctx.Output.SetStatus(http.StatusInternalServerError)
 		c.Data["json"] = models.ApiResponse{
 			Code:    http.StatusInternalServerError,

--- a/controllers/reserva_controller_test.go
+++ b/controllers/reserva_controller_test.go
@@ -3,15 +3,41 @@ package controllers
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/beego/beego/v2/client/orm"
 	"github.com/beego/beego/v2/server/web/context"
+
+	"restaurante/models"
 )
 
+func resetReservaMocks() {
+	ormNew = orm.NewOrm
+	queryAllReservas = func(o orm.Ormer, reservas *[]models.Reserva) (int64, error) {
+		return o.QueryTable(new(models.Reserva)).All(reservas)
+	}
+	readReserva = func(o orm.Ormer, r *models.Reserva) error { return o.Read(r) }
+	insertReserva = func(o orm.Ormer, r *models.Reserva) (int64, error) { return o.Insert(r) }
+	updateReserva = func(o orm.Ormer, r *models.Reserva, cols ...string) (int64, error) { return o.Update(r, cols...) }
+	queryReservasByParam = func(o orm.Ormer, doc int64, fecha time.Time, useDoc, useFecha bool, reservas *[]models.Reserva) (int64, error) {
+		qs := o.QueryTable(new(models.Reserva))
+		if useDoc {
+			qs = qs.Filter("DOCUMENTO_CLIENTE", doc)
+		}
+		if useFecha {
+			qs = qs.Filter("FECHA", fecha)
+		}
+		return qs.All(reservas)
+	}
+}
+
 func TestReservaGetAllWithoutDB(t *testing.T) {
+	t.Cleanup(resetReservaMocks)
 	r := httptest.NewRequest(http.MethodGet, "/reservas", nil)
 	w := httptest.NewRecorder()
 	ctx := context.NewContext()
@@ -31,6 +57,7 @@ func TestReservaGetAllWithoutDB(t *testing.T) {
 }
 
 func TestReservaGetByIdInvalidID(t *testing.T) {
+	t.Cleanup(resetReservaMocks)
 	r := httptest.NewRequest(http.MethodGet, "/reservas/search", nil)
 	w := httptest.NewRecorder()
 	ctx := context.NewContext()
@@ -47,6 +74,7 @@ func TestReservaGetByIdInvalidID(t *testing.T) {
 }
 
 func TestReservaPostInvalidJSON(t *testing.T) {
+	t.Cleanup(resetReservaMocks)
 	r := httptest.NewRequest(http.MethodPost, "/reservas", strings.NewReader("notjson"))
 	w := httptest.NewRecorder()
 	ctx := context.NewContext()
@@ -63,6 +91,7 @@ func TestReservaPostInvalidJSON(t *testing.T) {
 }
 
 func TestReservaPostInvalidDate(t *testing.T) {
+	t.Cleanup(resetReservaMocks)
 	payload := map[string]interface{}{
 		"fechaReserva":     "2024-13-01",
 		"horaReserva":      "12:00:00",
@@ -90,6 +119,7 @@ func TestReservaPostInvalidDate(t *testing.T) {
 }
 
 func TestReservaPostMissingHora(t *testing.T) {
+	t.Cleanup(resetReservaMocks)
 	payload := map[string]interface{}{
 		"fechaReserva":     "2024-01-01",
 		"personas":         2,
@@ -116,6 +146,7 @@ func TestReservaPostMissingHora(t *testing.T) {
 }
 
 func TestReservaPutInvalidID(t *testing.T) {
+	t.Cleanup(resetReservaMocks)
 	r := httptest.NewRequest(http.MethodPut, "/reservas", nil)
 	w := httptest.NewRecorder()
 	ctx := context.NewContext()
@@ -132,6 +163,7 @@ func TestReservaPutInvalidID(t *testing.T) {
 }
 
 func TestReservaGetByParameterInvalidFecha(t *testing.T) {
+	t.Cleanup(resetReservaMocks)
 	r := httptest.NewRequest(http.MethodGet, "/reservas/parameter?fecha=2024-13-01", nil)
 	w := httptest.NewRecorder()
 	ctx := context.NewContext()
@@ -151,6 +183,7 @@ func TestReservaGetByParameterInvalidFecha(t *testing.T) {
 }
 
 func TestReservaGetByParameterDBError(t *testing.T) {
+	t.Cleanup(resetReservaMocks)
 	r := httptest.NewRequest(http.MethodGet, "/reservas/parameter?documentoCliente=123&fecha=2024-10-10", nil)
 	w := httptest.NewRecorder()
 	ctx := context.NewContext()
@@ -170,6 +203,7 @@ func TestReservaGetByParameterDBError(t *testing.T) {
 }
 
 func TestReservaDeleteInvalidID(t *testing.T) {
+	t.Cleanup(resetReservaMocks)
 	r := httptest.NewRequest(http.MethodDelete, "/reservas", nil)
 	w := httptest.NewRecorder()
 	ctx := context.NewContext()
@@ -182,5 +216,481 @@ func TestReservaDeleteInvalidID(t *testing.T) {
 
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("expected status 400, got %d", w.Code)
+	}
+}
+
+func TestReservaGetAllSuccess(t *testing.T) {
+	db := []models.Reserva{{
+		PK_ID_RESERVA: 1,
+		CREATED_AT:    time.Now(),
+		UPDATED_AT:    time.Now(),
+		FECHA:         time.Now(),
+		HORA:          "2024-01-01T12:00:00Z",
+	}}
+	ormNew = func() orm.Ormer { return nil }
+	queryAllReservas = func(o orm.Ormer, reservas *[]models.Reserva) (int64, error) {
+		*reservas = append(*reservas, db...)
+		return int64(len(db)), nil
+	}
+	t.Cleanup(resetReservaMocks)
+	r := httptest.NewRequest(http.MethodGet, "/reservas", nil)
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	c := ReservaController{}
+	c.Ctx = ctx
+	c.Data = map[interface{}]interface{}{}
+	c.GetAll()
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+}
+
+func TestReservaGetByIdScenarios(t *testing.T) {
+	db := map[int]models.Reserva{1: {
+		PK_ID_RESERVA: 1,
+		FECHA:         time.Now(),
+		CREATED_AT:    time.Now(),
+		UPDATED_AT:    time.Now(),
+		HORA:          "2024-01-01T12:00:00Z",
+	}}
+	ormNew = func() orm.Ormer { return nil }
+	readReserva = func(o orm.Ormer, r *models.Reserva) error {
+		res, ok := db[r.PK_ID_RESERVA]
+		if !ok {
+			return orm.ErrNoRows
+		}
+		*r = res
+		return nil
+	}
+	t.Cleanup(resetReservaMocks)
+	// not found
+	r := httptest.NewRequest(http.MethodGet, "/reservas/search?id=2", nil)
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	c := ReservaController{}
+	c.Ctx = ctx
+	c.Data = map[interface{}]interface{}{}
+	c.GetById()
+	if w.Code != http.StatusOK || !strings.Contains(w.Body.String(), "Reserva no encontrada") {
+		t.Fatalf("not found failed")
+	}
+	// success
+	r = httptest.NewRequest(http.MethodGet, "/reservas/search?id=1", nil)
+	w = httptest.NewRecorder()
+	ctx = context.NewContext()
+	ctx.Reset(w, r)
+	c.Ctx = ctx
+	c.Data = map[interface{}]interface{}{}
+	c.GetById()
+	if w.Code != http.StatusOK || !strings.Contains(w.Body.String(), "\"reservaId\":1") {
+		t.Fatalf("success failed")
+	}
+}
+
+func TestReservaPostMissingFecha(t *testing.T) {
+	t.Cleanup(resetReservaMocks)
+	payload := map[string]interface{}{
+		"horaReserva":      "12:00:00",
+		"personas":         2,
+		"documentoCliente": 123,
+	}
+	body, _ := json.Marshal(payload)
+	r := httptest.NewRequest(http.MethodPost, "/reservas", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	ctx.Input.RequestBody = body
+	c := ReservaController{}
+	c.Ctx = ctx
+	c.Data = map[interface{}]interface{}{}
+	c.Post()
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestReservaPostInvalidHora(t *testing.T) {
+	t.Cleanup(resetReservaMocks)
+	payload := map[string]interface{}{
+		"fechaReserva":     "2024-01-01",
+		"horaReserva":      "99:99:99",
+		"personas":         2,
+		"documentoCliente": 123,
+	}
+	body, _ := json.Marshal(payload)
+	r := httptest.NewRequest(http.MethodPost, "/reservas", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	ctx.Input.RequestBody = body
+	c := ReservaController{}
+	c.Ctx = ctx
+	c.Data = map[interface{}]interface{}{}
+
+	c.Post()
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestReservaPostMissingPersonas(t *testing.T) {
+	t.Cleanup(resetReservaMocks)
+	payload := map[string]interface{}{
+		"fechaReserva":     "2024-01-01",
+		"horaReserva":      "12:00:00",
+		"documentoCliente": 123,
+	}
+	body, _ := json.Marshal(payload)
+	r := httptest.NewRequest(http.MethodPost, "/reservas", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	ctx.Input.RequestBody = body
+	c := ReservaController{}
+	c.Ctx = ctx
+	c.Data = map[interface{}]interface{}{}
+
+	c.Post()
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestReservaPostInvalidEstado(t *testing.T) {
+	t.Cleanup(resetReservaMocks)
+	payload := map[string]interface{}{
+		"fechaReserva":     "2024-01-01",
+		"horaReserva":      "12:00:00",
+		"personas":         2,
+		"documentoCliente": 123,
+		"estadoReserva":    "DESCONOCIDO",
+	}
+	body, _ := json.Marshal(payload)
+	r := httptest.NewRequest(http.MethodPost, "/reservas", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	ctx.Input.RequestBody = body
+	c := ReservaController{}
+	c.Ctx = ctx
+	c.Data = map[interface{}]interface{}{}
+
+	c.Post()
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestReservaPostInvalidDocumento(t *testing.T) {
+	t.Cleanup(resetReservaMocks)
+	payload := map[string]interface{}{
+		"fechaReserva":     "2024-01-01",
+		"horaReserva":      "12:00:00",
+		"personas":         2,
+		"documentoCliente": "abc",
+	}
+	body, _ := json.Marshal(payload)
+	r := httptest.NewRequest(http.MethodPost, "/reservas", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	ctx.Input.RequestBody = body
+	c := ReservaController{}
+	c.Ctx = ctx
+	c.Data = map[interface{}]interface{}{}
+
+	c.Post()
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestReservaPostInsertError(t *testing.T) {
+	ormNew = func() orm.Ormer { return nil }
+	insertReserva = func(o orm.Ormer, r *models.Reserva) (int64, error) { return 0, errors.New("db") }
+	t.Cleanup(resetReservaMocks)
+	payload := map[string]interface{}{
+		"fechaReserva":     "2024-01-01",
+		"horaReserva":      "12:00:00",
+		"personas":         2,
+		"documentoCliente": 123,
+	}
+	body, _ := json.Marshal(payload)
+	r := httptest.NewRequest(http.MethodPost, "/reservas", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	ctx.Input.RequestBody = body
+	c := ReservaController{}
+	c.Ctx = ctx
+	c.Data = map[interface{}]interface{}{}
+
+	c.Post()
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", w.Code)
+	}
+}
+
+func TestReservaPostSuccess(t *testing.T) {
+	db := make([]models.Reserva, 0)
+	ormNew = func() orm.Ormer { return nil }
+	insertReserva = func(o orm.Ormer, r *models.Reserva) (int64, error) {
+		db = append(db, *r)
+		return 1, nil
+	}
+	t.Cleanup(resetReservaMocks)
+	payload := map[string]interface{}{
+		"fechaReserva":     "2024-01-01",
+		"horaReserva":      "12:00:00",
+		"personas":         2,
+		"documentoCliente": 123,
+		"estadoReserva":    "CONFIRMADA",
+		"indicaciones":     "Ninguna",
+		"createdBy":        "admin",
+		"nombreCompleto":   "John Doe",
+		"telefono":         "123",
+	}
+	body, _ := json.Marshal(payload)
+	r := httptest.NewRequest(http.MethodPost, "/reservas", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	ctx.Input.RequestBody = body
+	c := ReservaController{}
+	c.Ctx = ctx
+	c.Data = map[interface{}]interface{}{}
+
+	c.Post()
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d", w.Code)
+	}
+}
+
+func TestReservaPutScenarios(t *testing.T) {
+	db := map[int]models.Reserva{1: {
+		PK_ID_RESERVA: 1,
+		FECHA:         time.Now(),
+		CREATED_AT:    time.Now(),
+		UPDATED_AT:    time.Now(),
+		HORA:          "12:00:00",
+	}}
+	ormNew = func() orm.Ormer { return nil }
+	readReserva = func(o orm.Ormer, r *models.Reserva) error {
+		res, ok := db[r.PK_ID_RESERVA]
+		if !ok {
+			return orm.ErrNoRows
+		}
+		*r = res
+		return nil
+	}
+	updateReserva = func(o orm.Ormer, r *models.Reserva, cols ...string) (int64, error) {
+		db[r.PK_ID_RESERVA] = *r
+		return 1, nil
+	}
+	t.Cleanup(resetReservaMocks)
+
+	// not found
+	r := httptest.NewRequest(http.MethodPut, "/reservas?id=2", strings.NewReader("{}"))
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	c := ReservaController{}
+	c.Ctx = ctx
+	c.Data = map[interface{}]interface{}{}
+
+	c.Put()
+	if w.Code != http.StatusOK || !strings.Contains(w.Body.String(), "Reserva no encontrada") {
+		t.Fatalf("not found failed")
+	}
+
+	// invalid json
+	r = httptest.NewRequest(http.MethodPut, "/reservas?id=1", strings.NewReader("{invalid"))
+	w = httptest.NewRecorder()
+	ctx = context.NewContext()
+	ctx.Reset(w, r)
+	c.Ctx = ctx
+	c.Data = map[interface{}]interface{}{}
+	c.Put()
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+
+	// invalid fecha
+	payload := map[string]interface{}{"fechaReserva": "2024-13-01", "horaReserva": "12:00:00", "personas": 2, "documentoCliente": 123}
+	body, _ := json.Marshal(payload)
+	r = httptest.NewRequest(http.MethodPut, "/reservas?id=1", bytes.NewReader(body))
+	w = httptest.NewRecorder()
+	ctx = context.NewContext()
+	ctx.Reset(w, r)
+	ctx.Input.RequestBody = body
+	c.Ctx = ctx
+	c.Data = map[interface{}]interface{}{}
+	c.Put()
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+
+	// invalid hora
+	payload["fechaReserva"] = "2024-01-01"
+	payload["horaReserva"] = "99:99:99"
+	body, _ = json.Marshal(payload)
+	r = httptest.NewRequest(http.MethodPut, "/reservas?id=1", bytes.NewReader(body))
+	w = httptest.NewRecorder()
+	ctx = context.NewContext()
+	ctx.Reset(w, r)
+	ctx.Input.RequestBody = body
+	c.Ctx = ctx
+	c.Put()
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+
+	// invalid documento
+	payload["horaReserva"] = "12:00:00"
+	payload["documentoCliente"] = "abc"
+	body, _ = json.Marshal(payload)
+	r = httptest.NewRequest(http.MethodPut, "/reservas?id=1", bytes.NewReader(body))
+	w = httptest.NewRecorder()
+	ctx = context.NewContext()
+	ctx.Reset(w, r)
+	ctx.Input.RequestBody = body
+	c.Ctx = ctx
+	c.Put()
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+
+	// update error
+	payload["documentoCliente"] = 123
+	body, _ = json.Marshal(payload)
+	updateReserva = func(o orm.Ormer, r *models.Reserva, cols ...string) (int64, error) { return 0, errors.New("db") }
+	r = httptest.NewRequest(http.MethodPut, "/reservas?id=1", bytes.NewReader(body))
+	w = httptest.NewRecorder()
+	ctx = context.NewContext()
+	ctx.Reset(w, r)
+	ctx.Input.RequestBody = body
+	c.Ctx = ctx
+	c.Put()
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", w.Code)
+	}
+
+	// success
+	updateReserva = func(o orm.Ormer, r *models.Reserva, cols ...string) (int64, error) {
+		db[r.PK_ID_RESERVA] = *r
+		return 1, nil
+	}
+	payload = map[string]interface{}{
+		"fechaReserva":     "2024-01-02",
+		"horaReserva":      "13:00:00",
+		"personas":         3,
+		"estadoReserva":    "CONFIRMADA",
+		"indicaciones":     "OK",
+		"updatedBy":        "admin",
+		"nombreCompleto":   "John",
+		"telefono":         "123",
+		"documentoCliente": 123,
+	}
+	body, _ = json.Marshal(payload)
+	r = httptest.NewRequest(http.MethodPut, "/reservas?id=1", bytes.NewReader(body))
+	w = httptest.NewRecorder()
+	ctx = context.NewContext()
+	ctx.Reset(w, r)
+	ctx.Input.RequestBody = body
+	c.Ctx = ctx
+	c.Put()
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+}
+
+func TestReservaGetByParameterSuccess(t *testing.T) {
+	db := []models.Reserva{{
+		PK_ID_RESERVA:     1,
+		DOCUMENTO_CLIENTE: func() *int64 { v := int64(123); return &v }(),
+		FECHA:             time.Now(),
+		CREATED_AT:        time.Now(),
+		UPDATED_AT:        time.Now(),
+		HORA:              "2024-01-01T12:00:00Z",
+	}}
+	ormNew = func() orm.Ormer { return nil }
+	queryReservasByParam = func(o orm.Ormer, doc int64, fecha time.Time, useDoc, useFecha bool, reservas *[]models.Reserva) (int64, error) {
+		*reservas = append(*reservas, db...)
+		return int64(len(db)), nil
+	}
+	t.Cleanup(resetReservaMocks)
+	r := httptest.NewRequest(http.MethodGet, "/reservas/parameter?documentoCliente=123&fecha=2024-01-01", nil)
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	c := ReservaController{}
+	c.Ctx = ctx
+	c.Data = map[interface{}]interface{}{}
+
+	c.GetByParameter()
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+}
+
+func TestReservaDeleteScenarios(t *testing.T) {
+	db := map[int]models.Reserva{1: {PK_ID_RESERVA: 1}}
+	ormNew = func() orm.Ormer { return nil }
+	readReserva = func(o orm.Ormer, r *models.Reserva) error {
+		res, ok := db[r.PK_ID_RESERVA]
+		if !ok {
+			return orm.ErrNoRows
+		}
+		*r = res
+		return nil
+	}
+	updateReserva = func(o orm.Ormer, r *models.Reserva, cols ...string) (int64, error) {
+		db[r.PK_ID_RESERVA] = *r
+		return 1, nil
+	}
+	t.Cleanup(resetReservaMocks)
+
+	// not found
+	r := httptest.NewRequest(http.MethodDelete, "/reservas?id=2", nil)
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	c := ReservaController{}
+	c.Ctx = ctx
+	c.Data = map[interface{}]interface{}{}
+
+	c.Delete()
+	if w.Code != http.StatusOK || !strings.Contains(w.Body.String(), "Reserva no encontrada") {
+		t.Fatalf("not found failed")
+	}
+
+	// update error
+	updateReserva = func(o orm.Ormer, r *models.Reserva, cols ...string) (int64, error) { return 0, errors.New("db") }
+	r = httptest.NewRequest(http.MethodDelete, "/reservas?id=1", nil)
+	w = httptest.NewRecorder()
+	ctx = context.NewContext()
+	ctx.Reset(w, r)
+	c.Ctx = ctx
+	c.Data = map[interface{}]interface{}{}
+	c.Delete()
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", w.Code)
+	}
+
+	// success
+	updateReserva = func(o orm.Ormer, r *models.Reserva, cols ...string) (int64, error) {
+		db[r.PK_ID_RESERVA] = *r
+		return 1, nil
+	}
+	r = httptest.NewRequest(http.MethodDelete, "/reservas?id=1", nil)
+	w = httptest.NewRecorder()
+	ctx = context.NewContext()
+	ctx.Reset(w, r)
+	c.Ctx = ctx
+	c.Delete()
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
 	}
 }


### PR DESCRIPTION
## Summary
- add overrideable DB hooks in `ReservaController`
- implement extensive test scenarios for all Reserva endpoints

## Testing
- `go test ./controllers -coverprofile=cover.out`
- `go tool cover -func=cover.out | grep ReservaController.go`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a28bbbb4448325933444e48ff3251d