### PR TITLE
Expose payment linkage in pedido details

### DIFF
--- a/controllers/PedidoController.go
+++ b/controllers/PedidoController.go
@@ -365,7 +365,7 @@ func (c *PedidoController) GetPedidoDetails() {
 	// Consulta para obtener detalles del pedido
 	query := `
 SELECT
-    p."PK_ID_PEDIDO"                                   AS pedido_id,
+    p."PK_ID_PEDIDO"                                   AS pk_id_pedido,
     COALESCE(TO_CHAR(p."FECHA", 'YYYY-MM-DD'), '')     AS fecha,
     COALESCE(TO_CHAR(p."HORA",  'HH24:MI:SS'), '')     AS hora,
     COALESCE(p."DELIVERY", false)                      AS delivery,
@@ -378,10 +378,15 @@ SELECT
             FROM "PRODUCTO_PEDIDO" pp
             WHERE pp."PK_ID_PEDIDO" = p."PK_ID_PEDIDO"
         ) subq
-    ), '[]')                                           AS productos
+    ), '[]')                                           AS productos,
+    COALESCE(p."PK_ID_PAGO", 0)                        AS pago_id,
+    COALESCE(pa."PK_ID_METODO_PAGO", 0)                AS metodo_pago_id,
+    COALESCE(p."PK_ID_DOMICILIO", 0)                   AS domicilio_id,
+    COALESCE(pc."PK_DOCUMENTO_CLIENTE", 0)             AS documento_cliente
 FROM "PEDIDO" p
 LEFT JOIN "PAGO" pa        ON p."PK_ID_PAGO" = pa."PK_ID_PAGO"
 LEFT JOIN "METODO_PAGO" mp ON pa."PK_ID_METODO_PAGO" = mp."PK_ID_METODO_PAGO"
+LEFT JOIN "PEDIDO_CLIENTE" pc ON p."PK_ID_PEDIDO" = pc."PK_ID_PEDIDO"
 WHERE p."PK_ID_PEDIDO" = ?;
     `
 

--- a/controllers/pedido_controller_test.go
+++ b/controllers/pedido_controller_test.go
@@ -1,22 +1,22 @@
 package controllers
 
 import (
-        stdctx "context"
-        "database/sql/driver"
-        "errors"
-        "net/http"
-        "net/http/httptest"
-        "strings"
-        "testing"
-        "time"
+	stdctx "context"
+	"database/sql/driver"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
 
-        beegoCtx "github.com/beego/beego/v2/server/web/context"
+	beegoCtx "github.com/beego/beego/v2/server/web/context"
 )
 
 func TestPedidoGetAllWithoutDB(t *testing.T) {
 	r := httptest.NewRequest(http.MethodGet, "/pedidos", nil)
 	w := httptest.NewRecorder()
-        ctx := beegoCtx.NewContext()
+	ctx := beegoCtx.NewContext()
 	ctx.Reset(w, r)
 	c := PedidoController{}
 	c.Ctx = ctx
@@ -33,13 +33,16 @@ func TestPedidoGetAllWithoutDB(t *testing.T) {
 }
 
 func TestPedidoPostDatabaseError(t *testing.T) {
-	r := httptest.NewRequest(http.MethodPost, "/pedidos", nil)
+	body := "{}"
+	r := httptest.NewRequest(http.MethodPost, "/pedidos", strings.NewReader(body))
+	r.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
-        ctx := beegoCtx.NewContext()
+	ctx := beegoCtx.NewContext()
 	ctx.Reset(w, r)
 	c := PedidoController{}
 	c.Ctx = ctx
 	c.Data = make(map[interface{}]interface{})
+	c.Ctx.Input.RequestBody = []byte(body)
 
 	c.Post()
 
@@ -54,7 +57,7 @@ func TestPedidoPostDatabaseError(t *testing.T) {
 func TestPedidoAssignDomicilioNotFound(t *testing.T) {
 	r := httptest.NewRequest(http.MethodPost, "/pedidos/asignar-domicilio?pedido_id=1&domicilio_id=1", nil)
 	w := httptest.NewRecorder()
-        ctx := beegoCtx.NewContext()
+	ctx := beegoCtx.NewContext()
 	ctx.Reset(w, r)
 	c := PedidoController{}
 	c.Ctx = ctx
@@ -73,7 +76,7 @@ func TestPedidoAssignDomicilioNotFound(t *testing.T) {
 func TestPedidoAssignPagoNotFound(t *testing.T) {
 	r := httptest.NewRequest(http.MethodPost, "/pedidos/asignar-pago?pedido_id=1&pago_id=1", nil)
 	w := httptest.NewRecorder()
-        ctx := beegoCtx.NewContext()
+	ctx := beegoCtx.NewContext()
 	ctx.Reset(w, r)
 	c := PedidoController{}
 	c.Ctx = ctx
@@ -92,7 +95,7 @@ func TestPedidoAssignPagoNotFound(t *testing.T) {
 func TestPedidoUpdateEstadoPedidoNotFound(t *testing.T) {
 	r := httptest.NewRequest(http.MethodPut, "/pedidos/actualizar-estado?pedido_id=1&estado=TERMINADO", nil)
 	w := httptest.NewRecorder()
-        ctx := beegoCtx.NewContext()
+	ctx := beegoCtx.NewContext()
 	ctx.Reset(w, r)
 	c := PedidoController{}
 	c.Ctx = ctx
@@ -111,7 +114,7 @@ func TestPedidoUpdateEstadoPedidoNotFound(t *testing.T) {
 func TestPedidoGetPedidoDetailsMissingID(t *testing.T) {
 	r := httptest.NewRequest(http.MethodGet, "/pedidos/detalles", nil)
 	w := httptest.NewRecorder()
-        ctx := beegoCtx.NewContext()
+	ctx := beegoCtx.NewContext()
 	ctx.Reset(w, r)
 	c := PedidoController{}
 	c.Ctx = ctx
@@ -128,10 +131,10 @@ func TestPedidoGetPedidoDetailsMissingID(t *testing.T) {
 }
 
 func TestPedidoGetPedidoDetailsDBError(t *testing.T) {
-        r := httptest.NewRequest(http.MethodGet, "/pedidos/detalles?pedido_id=1", nil)
-        w := httptest.NewRecorder()
-        ctx := beegoCtx.NewContext()
-        ctx.Reset(w, r)
+	r := httptest.NewRequest(http.MethodGet, "/pedidos/detalles?pedido_id=1", nil)
+	w := httptest.NewRecorder()
+	ctx := beegoCtx.NewContext()
+	ctx.Reset(w, r)
 	c := PedidoController{}
 	c.Ctx = ctx
 	c.Data = make(map[interface{}]interface{})
@@ -141,354 +144,364 @@ func TestPedidoGetPedidoDetailsDBError(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected status 200, got %d", w.Code)
 	}
-        if !strings.Contains(w.Body.String(), "Error al obtener los detalles del pedido") {
-                t.Errorf("unexpected body: %s", w.Body.String())
-        }
+	if !strings.Contains(w.Body.String(), "Error al obtener los detalles del pedido") {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
 }
 
 func TestPedidoPostParseError(t *testing.T) {
-        r := httptest.NewRequest(http.MethodPost, "/pedidos", strings.NewReader("a=%"))
-        r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-        w := httptest.NewRecorder()
-        ctx := beegoCtx.NewContext()
-        ctx.Reset(w, r)
-        c := PedidoController{}
-        c.Ctx = ctx
-        c.Data = make(map[interface{}]interface{})
+	r := httptest.NewRequest(http.MethodPost, "/pedidos", strings.NewReader("a=%"))
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	ctx := beegoCtx.NewContext()
+	ctx.Reset(w, r)
+	c := PedidoController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
 
-        c.Post()
+	c.Post()
 
-        if w.Code != http.StatusBadRequest {
-                t.Fatalf("expected status 400, got %d", w.Code)
-        }
-        if !strings.Contains(w.Body.String(), "Datos inválidos") {
-                t.Errorf("unexpected body: %s", w.Body.String())
-        }
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "Datos inválidos") {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
 }
 
 func TestPedidoPostSuccess(t *testing.T) {
-        MockExec = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Result, error) {
-                return mockResult{}, nil
-        }
-        MockQuery = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
-                cols := []string{"PK_ID_PEDIDO"}
-                vals := [][]driver.Value{{int64(1)}}
-                return &mockRows{columns: cols, values: vals}, nil
-        }
-        defer func() { MockExec = nil; MockQuery = nil }()
+	MockExec = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Result, error) {
+		return mockResult{}, nil
+	}
+	MockQuery = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
+		cols := []string{"PK_ID_PEDIDO"}
+		vals := [][]driver.Value{{int64(1)}}
+		return &mockRows{columns: cols, values: vals}, nil
+	}
+	defer func() { MockExec = nil; MockQuery = nil }()
 
-        r := httptest.NewRequest(http.MethodPost, "/pedidos", nil)
-        r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-        w := httptest.NewRecorder()
-        ctx := beegoCtx.NewContext()
-        ctx.Reset(w, r)
-        c := PedidoController{}
-        c.Ctx = ctx
-        c.Data = make(map[interface{}]interface{})
+	body := "{}"
+	r := httptest.NewRequest(http.MethodPost, "/pedidos", strings.NewReader(body))
+	r.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	ctx := beegoCtx.NewContext()
+	ctx.Reset(w, r)
+	c := PedidoController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+	c.Ctx.Input.RequestBody = []byte(body)
 
-        c.Post()
+	c.Post()
 
-        if w.Code != http.StatusOK {
-                t.Fatalf("expected status 200, got %d", w.Code)
-        }
-        if !strings.Contains(w.Body.String(), "Pedido creado exitosamente") {
-                t.Errorf("unexpected body: %s", w.Body.String())
-        }
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "Pedido creado exitosamente") {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
 }
 
 func TestPedidoGetAllWithFiltersNoResults(t *testing.T) {
-        MockQuery = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
-                cols := []string{"PK_ID_PEDIDO", "FECHA", "HORA", "DELIVERY", "ESTADO_PEDIDO", "PK_ID_DOMICILIO", "PK_ID_PAGO", "PK_ID_RESTAURANTE", "UPDATED_AT", "UPDATED_BY"}
-                return &mockRows{columns: cols, values: [][]driver.Value{}}, nil
-        }
-        defer func() { MockQuery = nil }()
+	MockQuery = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
+		cols := []string{"PK_ID_PEDIDO", "FECHA", "HORA", "DELIVERY", "ESTADO_PEDIDO", "PK_ID_DOMICILIO", "PK_ID_PAGO", "PK_ID_RESTAURANTE", "UPDATED_AT", "UPDATED_BY"}
+		return &mockRows{columns: cols, values: [][]driver.Value{}}, nil
+	}
+	defer func() { MockQuery = nil }()
 
-        url := "/pedidos?fecha=2024-01-01&desde=2024-01-01&hasta=2024-02-01&mes=1&anio=2024&cliente=1&metodo_pago=NEQUI&domicilio=true"
-        r := httptest.NewRequest(http.MethodGet, url, nil)
-        w := httptest.NewRecorder()
-        ctx := beegoCtx.NewContext()
-        ctx.Reset(w, r)
-        c := PedidoController{}
-        c.Ctx = ctx
-        c.Data = make(map[interface{}]interface{})
+	url := "/pedidos?fecha=2024-01-01&desde=2024-01-01&hasta=2024-02-01&mes=1&anio=2024&cliente=1&metodo_pago=NEQUI&domicilio=true"
+	r := httptest.NewRequest(http.MethodGet, url, nil)
+	w := httptest.NewRecorder()
+	ctx := beegoCtx.NewContext()
+	ctx.Reset(w, r)
+	c := PedidoController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
 
-        c.GetAll()
+	c.GetAll()
 
-        if w.Code != http.StatusOK {
-                t.Fatalf("expected status 200, got %d", w.Code)
-        }
-        if !strings.Contains(w.Body.String(), "No se encontraron pedidos") {
-                t.Errorf("unexpected body: %s", w.Body.String())
-        }
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "No se encontraron pedidos") {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
 }
 
 func TestPedidoGetAllWithResults(t *testing.T) {
-        MockQuery = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
-                cols := []string{"PK_ID_PEDIDO", "FECHA", "HORA", "DELIVERY", "ESTADO_PEDIDO", "PK_ID_DOMICILIO", "PK_ID_PAGO", "PK_ID_RESTAURANTE", "UPDATED_AT", "UPDATED_BY"}
-                now := time.Now()
-                vals := [][]driver.Value{{int64(1), now, "12:00:00", false, "INICIADO", nil, nil, nil, now, "tester"}}
-                return &mockRows{columns: cols, values: vals}, nil
-        }
-        defer func() { MockQuery = nil }()
+	MockQuery = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
+		cols := []string{"PK_ID_PEDIDO", "FECHA", "HORA", "DELIVERY", "ESTADO_PEDIDO", "PK_ID_DOMICILIO", "PK_ID_PAGO", "PK_ID_RESTAURANTE", "UPDATED_AT", "UPDATED_BY"}
+		now := time.Now()
+		vals := [][]driver.Value{{int64(1), now, "12:00:00", false, "INICIADO", nil, nil, nil, now, "tester"}}
+		return &mockRows{columns: cols, values: vals}, nil
+	}
+	defer func() { MockQuery = nil }()
 
-        r := httptest.NewRequest(http.MethodGet, "/pedidos", nil)
-        w := httptest.NewRecorder()
-        ctx := beegoCtx.NewContext()
-        ctx.Reset(w, r)
-        c := PedidoController{}
-        c.Ctx = ctx
-        c.Data = make(map[interface{}]interface{})
+	r := httptest.NewRequest(http.MethodGet, "/pedidos", nil)
+	w := httptest.NewRecorder()
+	ctx := beegoCtx.NewContext()
+	ctx.Reset(w, r)
+	c := PedidoController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
 
-        c.GetAll()
+	c.GetAll()
 
-        if w.Code != http.StatusOK {
-                t.Fatalf("expected status 200, got %d", w.Code)
-        }
-        if !strings.Contains(w.Body.String(), "Pedidos obtenidos exitosamente") {
-                t.Errorf("unexpected body: %s", w.Body.String())
-        }
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "Pedidos obtenidos exitosamente") {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
 }
 
 func TestPedidoGetAllDomicilioFalse(t *testing.T) {
-        MockQuery = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
-                cols := []string{"PK_ID_PEDIDO", "FECHA", "HORA", "DELIVERY", "ESTADO_PEDIDO", "PK_ID_DOMICILIO", "PK_ID_PAGO", "PK_ID_RESTAURANTE", "UPDATED_AT", "UPDATED_BY"}
-                return &mockRows{columns: cols, values: [][]driver.Value{}}, nil
-        }
-        defer func() { MockQuery = nil }()
+	MockQuery = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
+		cols := []string{"PK_ID_PEDIDO", "FECHA", "HORA", "DELIVERY", "ESTADO_PEDIDO", "PK_ID_DOMICILIO", "PK_ID_PAGO", "PK_ID_RESTAURANTE", "UPDATED_AT", "UPDATED_BY"}
+		return &mockRows{columns: cols, values: [][]driver.Value{}}, nil
+	}
+	defer func() { MockQuery = nil }()
 
-        r := httptest.NewRequest(http.MethodGet, "/pedidos?domicilio=false", nil)
-        w := httptest.NewRecorder()
-        ctx := beegoCtx.NewContext()
-        ctx.Reset(w, r)
-        c := PedidoController{}
-        c.Ctx = ctx
-        c.Data = make(map[interface{}]interface{})
+	r := httptest.NewRequest(http.MethodGet, "/pedidos?domicilio=false", nil)
+	w := httptest.NewRecorder()
+	ctx := beegoCtx.NewContext()
+	ctx.Reset(w, r)
+	c := PedidoController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
 
-        c.GetAll()
+	c.GetAll()
 
-        if w.Code != http.StatusOK {
-                t.Fatalf("expected status 200, got %d", w.Code)
-        }
-        if !strings.Contains(w.Body.String(), "No se encontraron pedidos") {
-                t.Errorf("unexpected body: %s", w.Body.String())
-        }
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "No se encontraron pedidos") {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
 }
 
 func TestPedidoAssignDomicilioUpdateError(t *testing.T) {
-        MockQuery = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
-                cols := []string{"PK_ID_PEDIDO", "FECHA", "HORA", "DELIVERY", "ESTADO_PEDIDO", "PK_ID_DOMICILIO", "PK_ID_PAGO", "PK_ID_RESTAURANTE", "UPDATED_AT", "UPDATED_BY"}
-                now := time.Now()
-                vals := [][]driver.Value{{int64(1), now, "12:00:00", false, "INICIADO", nil, nil, nil, now, "tester"}}
-                return &mockRows{columns: cols, values: vals}, nil
-        }
-        MockExec = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Result, error) {
-                return nil, errors.New("update error")
-        }
-        defer func() { MockQuery = nil; MockExec = nil }()
+	MockQuery = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
+		cols := []string{"PK_ID_PEDIDO", "FECHA", "HORA", "DELIVERY", "ESTADO_PEDIDO", "PK_ID_DOMICILIO", "PK_ID_PAGO", "PK_ID_RESTAURANTE", "UPDATED_AT", "UPDATED_BY"}
+		now := time.Now()
+		vals := [][]driver.Value{{int64(1), now, "12:00:00", false, "INICIADO", nil, nil, nil, now, "tester"}}
+		return &mockRows{columns: cols, values: vals}, nil
+	}
+	MockExec = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Result, error) {
+		return nil, errors.New("update error")
+	}
+	defer func() { MockQuery = nil; MockExec = nil }()
 
-        r := httptest.NewRequest(http.MethodPost, "/pedidos/asignar-domicilio?pedido_id=1&domicilio_id=1", nil)
-        w := httptest.NewRecorder()
-        ctx := beegoCtx.NewContext()
-        ctx.Reset(w, r)
-        c := PedidoController{}
-        c.Ctx = ctx
-        c.Data = make(map[interface{}]interface{})
+	r := httptest.NewRequest(http.MethodPost, "/pedidos/asignar-domicilio?pedido_id=1&domicilio_id=1", nil)
+	w := httptest.NewRecorder()
+	ctx := beegoCtx.NewContext()
+	ctx.Reset(w, r)
+	c := PedidoController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
 
-        c.AssignDomicilio()
+	c.AssignDomicilio()
 
-        if w.Code != http.StatusInternalServerError {
-                t.Fatalf("expected status 500, got %d", w.Code)
-        }
-        if !strings.Contains(w.Body.String(), "Error al asignar domicilio") {
-                t.Errorf("unexpected body: %s", w.Body.String())
-        }
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected status 500, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "Error al asignar domicilio") {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
 }
 
 func TestPedidoAssignDomicilioSuccess(t *testing.T) {
-        MockQuery = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
-                cols := []string{"PK_ID_PEDIDO", "FECHA", "HORA", "DELIVERY", "ESTADO_PEDIDO", "PK_ID_DOMICILIO", "PK_ID_PAGO", "PK_ID_RESTAURANTE", "UPDATED_AT", "UPDATED_BY"}
-                now := time.Now()
-                vals := [][]driver.Value{{int64(1), now, "12:00:00", false, "INICIADO", nil, nil, nil, now, "tester"}}
-                return &mockRows{columns: cols, values: vals}, nil
-        }
-        MockExec = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Result, error) {
-                return mockResult{}, nil
-        }
-        defer func() { MockQuery = nil; MockExec = nil }()
+	MockQuery = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
+		cols := []string{"PK_ID_PEDIDO", "FECHA", "HORA", "DELIVERY", "ESTADO_PEDIDO", "PK_ID_DOMICILIO", "PK_ID_PAGO", "PK_ID_RESTAURANTE", "UPDATED_AT", "UPDATED_BY"}
+		now := time.Now()
+		vals := [][]driver.Value{{int64(1), now, "12:00:00", false, "INICIADO", nil, nil, nil, now, "tester"}}
+		return &mockRows{columns: cols, values: vals}, nil
+	}
+	MockExec = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Result, error) {
+		return mockResult{}, nil
+	}
+	defer func() { MockQuery = nil; MockExec = nil }()
 
-        r := httptest.NewRequest(http.MethodPost, "/pedidos/asignar-domicilio?pedido_id=1&domicilio_id=1", nil)
-        w := httptest.NewRecorder()
-        ctx := beegoCtx.NewContext()
-        ctx.Reset(w, r)
-        c := PedidoController{}
-        c.Ctx = ctx
-        c.Data = make(map[interface{}]interface{})
+	r := httptest.NewRequest(http.MethodPost, "/pedidos/asignar-domicilio?pedido_id=1&domicilio_id=1", nil)
+	w := httptest.NewRecorder()
+	ctx := beegoCtx.NewContext()
+	ctx.Reset(w, r)
+	c := PedidoController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
 
-        c.AssignDomicilio()
+	c.AssignDomicilio()
 
-        if w.Code != http.StatusOK {
-                t.Fatalf("expected status 200, got %d", w.Code)
-        }
-        if !strings.Contains(w.Body.String(), "Domicilio asignado correctamente") {
-                t.Errorf("unexpected body: %s", w.Body.String())
-        }
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "Domicilio asignado correctamente") {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
 }
 
 func TestPedidoAssignPagoUpdateError(t *testing.T) {
-        MockQuery = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
-                cols := []string{"PK_ID_PEDIDO", "FECHA", "HORA", "DELIVERY", "ESTADO_PEDIDO", "PK_ID_DOMICILIO", "PK_ID_PAGO", "PK_ID_RESTAURANTE", "UPDATED_AT", "UPDATED_BY"}
-                now := time.Now()
-                vals := [][]driver.Value{{int64(1), now, "12:00:00", false, "INICIADO", nil, nil, nil, now, "tester"}}
-                return &mockRows{columns: cols, values: vals}, nil
-        }
-        MockExec = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Result, error) {
-                return nil, errors.New("update error")
-        }
-        defer func() { MockQuery = nil; MockExec = nil }()
+	MockQuery = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
+		cols := []string{"PK_ID_PEDIDO", "FECHA", "HORA", "DELIVERY", "ESTADO_PEDIDO", "PK_ID_DOMICILIO", "PK_ID_PAGO", "PK_ID_RESTAURANTE", "UPDATED_AT", "UPDATED_BY"}
+		now := time.Now()
+		vals := [][]driver.Value{{int64(1), now, "12:00:00", false, "INICIADO", nil, nil, nil, now, "tester"}}
+		return &mockRows{columns: cols, values: vals}, nil
+	}
+	MockExec = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Result, error) {
+		return nil, errors.New("update error")
+	}
+	defer func() { MockQuery = nil; MockExec = nil }()
 
-        r := httptest.NewRequest(http.MethodPost, "/pedidos/asignar-pago?pedido_id=1&pago_id=1", nil)
-        w := httptest.NewRecorder()
-        ctx := beegoCtx.NewContext()
-        ctx.Reset(w, r)
-        c := PedidoController{}
-        c.Ctx = ctx
-        c.Data = make(map[interface{}]interface{})
+	r := httptest.NewRequest(http.MethodPost, "/pedidos/asignar-pago?pedido_id=1&pago_id=1", nil)
+	w := httptest.NewRecorder()
+	ctx := beegoCtx.NewContext()
+	ctx.Reset(w, r)
+	c := PedidoController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
 
-        c.AssignPago()
+	c.AssignPago()
 
-        if w.Code != http.StatusInternalServerError {
-                t.Fatalf("expected status 500, got %d", w.Code)
-        }
-        if !strings.Contains(w.Body.String(), "Error al asignar pago") {
-                t.Errorf("unexpected body: %s", w.Body.String())
-        }
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected status 500, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "Error al asignar pago") {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
 }
 
 func TestPedidoAssignPagoSuccess(t *testing.T) {
-        qCount := 0
-        MockQuery = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
-                if qCount == 0 {
-                        qCount++
-                        cols := []string{"PK_ID_PEDIDO", "FECHA", "HORA", "DELIVERY", "ESTADO_PEDIDO", "PK_ID_DOMICILIO", "PK_ID_PAGO", "PK_ID_RESTAURANTE", "UPDATED_AT", "UPDATED_BY"}
-                        now := time.Now()
-                        vals := [][]driver.Value{{int64(1), now, "12:00:00", false, "INICIADO", nil, nil, nil, now, "tester"}}
-                        return &mockRows{columns: cols, values: vals}, nil
-                }
-                cols := []string{"PK_ID_PAGO", "FECHA", "HORA", "MONTO", "ESTADO_PAGO", "PK_ID_METODO_PAGO", "UPDATED_AT", "UPDATED_BY"}
-                now := time.Now()
-                vals := [][]driver.Value{{int64(1), now, "12:00:00", int64(100), "PENDIENTE", int64(1), now, "tester"}}
-                return &mockRows{columns: cols, values: vals}, nil
-        }
-        MockExec = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Result, error) {
-                return mockResult{}, nil
-        }
-        defer func() { MockQuery = nil; MockExec = nil }()
+	qCount := 0
+	MockQuery = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
+		if qCount == 0 {
+			qCount++
+			cols := []string{"PK_ID_PEDIDO", "FECHA", "HORA", "DELIVERY", "ESTADO_PEDIDO", "PK_ID_DOMICILIO", "PK_ID_PAGO", "PK_ID_RESTAURANTE", "UPDATED_AT", "UPDATED_BY"}
+			now := time.Now()
+			vals := [][]driver.Value{{int64(1), now, "12:00:00", false, "INICIADO", nil, nil, nil, now, "tester"}}
+			return &mockRows{columns: cols, values: vals}, nil
+		}
+		cols := []string{"PK_ID_PAGO", "FECHA", "HORA", "MONTO", "ESTADO_PAGO", "PK_ID_METODO_PAGO", "UPDATED_AT", "UPDATED_BY"}
+		now := time.Now()
+		vals := [][]driver.Value{{int64(1), now, "12:00:00", int64(100), "PENDIENTE", int64(1), now, "tester"}}
+		return &mockRows{columns: cols, values: vals}, nil
+	}
+	MockExec = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Result, error) {
+		return mockResult{}, nil
+	}
+	defer func() { MockQuery = nil; MockExec = nil }()
 
-        r := httptest.NewRequest(http.MethodPost, "/pedidos/asignar-pago?pedido_id=1&pago_id=1", nil)
-        w := httptest.NewRecorder()
-        ctx := beegoCtx.NewContext()
-        ctx.Reset(w, r)
-        c := PedidoController{}
-        c.Ctx = ctx
-        c.Data = make(map[interface{}]interface{})
+	r := httptest.NewRequest(http.MethodPost, "/pedidos/asignar-pago?pedido_id=1&pago_id=1", nil)
+	w := httptest.NewRecorder()
+	ctx := beegoCtx.NewContext()
+	ctx.Reset(w, r)
+	c := PedidoController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
 
-        c.AssignPago()
+	c.AssignPago()
 
-        if w.Code != http.StatusOK {
-                t.Fatalf("expected status 200, got %d", w.Code)
-        }
-        if !strings.Contains(w.Body.String(), "Pago asignado correctamente") {
-                t.Errorf("unexpected body: %s", w.Body.String())
-        }
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "Pago asignado correctamente") {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
 }
 
 func TestPedidoUpdateEstadoPedidoUpdateError(t *testing.T) {
-        MockQuery = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
-                cols := []string{"PK_ID_PEDIDO", "FECHA", "HORA", "DELIVERY", "ESTADO_PEDIDO", "PK_ID_DOMICILIO", "PK_ID_PAGO", "PK_ID_RESTAURANTE", "UPDATED_AT", "UPDATED_BY"}
-                now := time.Now()
-                vals := [][]driver.Value{{int64(1), now, "12:00:00", false, "INICIADO", nil, nil, nil, now, "tester"}}
-                return &mockRows{columns: cols, values: vals}, nil
-        }
-        MockExec = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Result, error) {
-                return nil, errors.New("update error")
-        }
-        defer func() { MockQuery = nil; MockExec = nil }()
+	MockQuery = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
+		cols := []string{"PK_ID_PEDIDO", "FECHA", "HORA", "DELIVERY", "ESTADO_PEDIDO", "PK_ID_DOMICILIO", "PK_ID_PAGO", "PK_ID_RESTAURANTE", "UPDATED_AT", "UPDATED_BY"}
+		now := time.Now()
+		vals := [][]driver.Value{{int64(1), now, "12:00:00", false, "INICIADO", nil, nil, nil, now, "tester"}}
+		return &mockRows{columns: cols, values: vals}, nil
+	}
+	MockExec = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Result, error) {
+		return nil, errors.New("update error")
+	}
+	defer func() { MockQuery = nil; MockExec = nil }()
 
-        r := httptest.NewRequest(http.MethodPut, "/pedidos/actualizar-estado?pedido_id=1&estado=TERMINADO", nil)
-        w := httptest.NewRecorder()
-        ctx := beegoCtx.NewContext()
-        ctx.Reset(w, r)
-        c := PedidoController{}
-        c.Ctx = ctx
-        c.Data = make(map[interface{}]interface{})
+	r := httptest.NewRequest(http.MethodPut, "/pedidos/actualizar-estado?pedido_id=1&estado=TERMINADO", nil)
+	w := httptest.NewRecorder()
+	ctx := beegoCtx.NewContext()
+	ctx.Reset(w, r)
+	c := PedidoController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
 
-        c.UpdateEstadoPedido()
+	c.UpdateEstadoPedido()
 
-        if w.Code != http.StatusInternalServerError {
-                t.Fatalf("expected status 500, got %d", w.Code)
-        }
-        if !strings.Contains(w.Body.String(), "Error al actualizar estado del pedido") {
-                t.Errorf("unexpected body: %s", w.Body.String())
-        }
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected status 500, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "Error al actualizar estado del pedido") {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
 }
 
 func TestPedidoUpdateEstadoPedidoSuccess(t *testing.T) {
-        MockQuery = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
-                cols := []string{"PK_ID_PEDIDO", "FECHA", "HORA", "DELIVERY", "ESTADO_PEDIDO", "PK_ID_DOMICILIO", "PK_ID_PAGO", "PK_ID_RESTAURANTE", "UPDATED_AT", "UPDATED_BY"}
-                now := time.Now()
-                vals := [][]driver.Value{{int64(1), now, "12:00:00", false, "INICIADO", nil, nil, nil, now, "tester"}}
-                return &mockRows{columns: cols, values: vals}, nil
-        }
-        MockExec = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Result, error) {
-                return mockResult{}, nil
-        }
-        defer func() { MockQuery = nil; MockExec = nil }()
+	MockQuery = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
+		cols := []string{"PK_ID_PEDIDO", "FECHA", "HORA", "DELIVERY", "ESTADO_PEDIDO", "PK_ID_DOMICILIO", "PK_ID_PAGO", "PK_ID_RESTAURANTE", "UPDATED_AT", "UPDATED_BY"}
+		now := time.Now()
+		vals := [][]driver.Value{{int64(1), now, "12:00:00", false, "INICIADO", nil, nil, nil, now, "tester"}}
+		return &mockRows{columns: cols, values: vals}, nil
+	}
+	MockExec = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Result, error) {
+		return mockResult{}, nil
+	}
+	defer func() { MockQuery = nil; MockExec = nil }()
 
-        r := httptest.NewRequest(http.MethodPut, "/pedidos/actualizar-estado?pedido_id=1&estado=TERMINADO", nil)
-        w := httptest.NewRecorder()
-        ctx := beegoCtx.NewContext()
-        ctx.Reset(w, r)
-        c := PedidoController{}
-        c.Ctx = ctx
-        c.Data = make(map[interface{}]interface{})
+	r := httptest.NewRequest(http.MethodPut, "/pedidos/actualizar-estado?pedido_id=1&estado=TERMINADO", nil)
+	w := httptest.NewRecorder()
+	ctx := beegoCtx.NewContext()
+	ctx.Reset(w, r)
+	c := PedidoController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
 
-        c.UpdateEstadoPedido()
+	c.UpdateEstadoPedido()
 
-        if w.Code != http.StatusOK {
-                t.Fatalf("expected status 200, got %d", w.Code)
-        }
-        if !strings.Contains(w.Body.String(), "Estado del pedido actualizado correctamente") {
-                t.Errorf("unexpected body: %s", w.Body.String())
-        }
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "Estado del pedido actualizado correctamente") {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
 }
 
 func TestPedidoGetPedidoDetailsSuccess(t *testing.T) {
-        MockQuery = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
-                cols := []string{"PK_ID_PEDIDO", "FECHA", "HORA", "DELIVERY", "ESTADO_PEDIDO", "metodo_pago", "productos"}
-                vals := [][]driver.Value{{int64(1), "2024-01-01", "12:00:00", false, "TERMINADO", "NEQUI", "[]"}}
-                return &mockRows{columns: cols, values: vals}, nil
-        }
-        defer func() { MockQuery = nil }()
+	MockQuery = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
+		cols := []string{"pk_id_pedido", "fecha", "hora", "delivery", "estado_pedido", "metodo_pago", "productos", "pago_id", "metodo_pago_id", "domicilio_id", "documento_cliente"}
+		vals := [][]driver.Value{{int64(1), "2024-01-01", "12:00:00", false, "TERMINADO", "NEQUI", "[]", int64(2), int64(3), int64(4), int64(5)}}
+		return &mockRows{columns: cols, values: vals}, nil
+	}
+	defer func() { MockQuery = nil }()
 
-        r := httptest.NewRequest(http.MethodGet, "/pedidos/detalles?pedido_id=1", nil)
-        w := httptest.NewRecorder()
-        ctx := beegoCtx.NewContext()
-        ctx.Reset(w, r)
-        c := PedidoController{}
-        c.Ctx = ctx
-        c.Data = make(map[interface{}]interface{})
+	r := httptest.NewRequest(http.MethodGet, "/pedidos/detalles?pedido_id=1", nil)
+	w := httptest.NewRecorder()
+	ctx := beegoCtx.NewContext()
+	ctx.Reset(w, r)
+	c := PedidoController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
 
-       c.GetPedidoDetails()
-       body := w.Body.String()
+	c.GetPedidoDetails()
+	body := w.Body.String()
 
-        if w.Code != http.StatusOK {
-                t.Fatalf("expected status 200, got %d", w.Code)
-        }
-        if !strings.Contains(body, "Detalles del pedido obtenidos exitosamente") ||
-                !strings.Contains(body, "\"fechaPedido\":\"2024-01-01\"") ||
-                !strings.Contains(body, "\"horaPedido\":\"12:00:00\"") ||
-                !strings.Contains(body, "\"delivery\":false") ||
-                !strings.Contains(body, "\"estadoPedido\":\"TERMINADO\"") {
-                t.Errorf("unexpected body: %s", body)
-        }
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+	for _, field := range []string{
+		"Detalles del pedido obtenidos exitosamente",
+		"\"fechaPedido\":\"2024-01-01\"",
+		"\"horaPedido\":\"12:00:00\"",
+		"\"delivery\":false",
+		"\"estadoPedido\":\"TERMINADO\"",
+		"\"pagoId\":2",
+		"\"metodoPagoId\":3",
+		"\"domicilioId\":4",
+		"\"documentoCliente\":5",
+	} {
+		if !strings.Contains(body, field) {
+			t.Errorf("unexpected body: %s", body)
+		}
+	}
 }

--- a/models/Pedido.go
+++ b/models/Pedido.go
@@ -21,13 +21,17 @@ type Pedido struct {
 }
 
 type PedidoDetails struct {
-	PedidoID     int64  `json:"pedidoId" orm:"column(pk_id_pedido)"`
-	Fecha        string `json:"fechaPedido" orm:"column(fecha)"`
-	Hora         string `json:"horaPedido" orm:"column(hora)"`
-	Delivery     bool   `json:"delivery" orm:"column(delivery)"`
-	EstadoPedido string `json:"estadoPedido" orm:"column(estado_pedido)"`
-	MetodoPago   string `json:"metodoPago" orm:"column(metodo_pago)"`
-	Productos    string `json:"productos" orm:"column(productos)"`
+	PedidoID         int64  `json:"pedidoId" orm:"column(pk_id_pedido)"`
+	Fecha            string `json:"fechaPedido" orm:"column(fecha)"`
+	Hora             string `json:"horaPedido" orm:"column(hora)"`
+	Delivery         bool   `json:"delivery" orm:"column(delivery)"`
+	EstadoPedido     string `json:"estadoPedido" orm:"column(estado_pedido)"`
+	MetodoPago       string `json:"metodoPago" orm:"column(metodo_pago)"`
+	Productos        string `json:"productos" orm:"column(productos)"`
+	PagoID           int64  `json:"pagoId" orm:"column(pago_id)"`
+	MetodoPagoID     int64  `json:"metodoPagoId" orm:"column(metodo_pago_id)"`
+	DomicilioID      int64  `json:"domicilioId" orm:"column(domicilio_id)"`
+	DocumentoCliente int64  `json:"documentoCliente" orm:"column(documento_cliente)"`
 }
 
 func (p *Pedido) TableName() string {


### PR DESCRIPTION
## Summary
- include payment, method, domicilio and client identifiers in `PedidoDetails`
- expand `GetPedidoDetails` query to select new identifiers and join `PEDIDO_CLIENTE`
- test that `/pedidos/detalles` exposes new fields

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68aa5463934c8325abe1a683e229ad38