### PR TITLE
Add client info to domicilio detail endpoint

### DIFF
--- a/controllers/DomicilioController.go
+++ b/controllers/DomicilioController.go
@@ -106,46 +106,77 @@ func (c *DomicilioController) GetAll() {
 // @Accept json
 // @Produce json
 // @Param   id     query    int     true        "ID del Domicilio"
-// @Success 200 {object} models.Domicilio "Domicilio encontrado"
+// @Success 200 {object} models.DomicilioDetail "Domicilio encontrado"
 // @Failure 404 {object} models.ApiResponse "Domicilio no encontrado"
 // @Security BearerAuth
 // @Router /domicilios/search [get]
 func (c *DomicilioController) GetById() {
-	o := orm.NewOrm()
-	id, err := c.GetInt("id")
+        o := orm.NewOrm()
+        id, err := c.GetInt("id")
 
-	if err != nil || id == 0 {
-		c.Ctx.Output.SetStatus(http.StatusBadRequest)
-		c.Data["json"] = models.ApiResponse{
-			Code:    http.StatusBadRequest,
-			Message: "El parámetro 'id' es inválido o está ausente",
-			Cause:   err.Error(),
-		}
-		c.ServeJSON()
-		return
-	}
+        if err != nil || id == 0 {
+                c.Ctx.Output.SetStatus(http.StatusBadRequest)
+                c.Data["json"] = models.ApiResponse{
+                        Code:    http.StatusBadRequest,
+                        Message: "El parámetro 'id' es inválido o está ausente",
+                        Cause:   err.Error(),
+                }
+                c.ServeJSON()
+                return
+        }
 
-	domicilio := models.Domicilio{PK_ID_DOMICILIO: id}
+        query := `
+SELECT
+    d."PK_ID_DOMICILIO"                AS pk_id_domicilio,
+    d."DIRECCION"                      AS direccion,
+    d."TELEFONO"                       AS telefono,
+    d."ESTADO_PAGO"                   AS estado_pago,
+    d."ENTREGADO"                     AS entregado,
+    d."FECHA"                         AS fecha,
+    d."OBSERVACIONES"                 AS observaciones,
+    d."CREATED_AT"                    AS created_at,
+    d."UPDATED_AT"                    AS updated_at,
+    d."CREATED_BY"                    AS created_by,
+    d."UPDATED_BY"                    AS updated_by,
+    d."PK_DOCUMENTO_TRABAJADOR"       AS pk_documento_trabajador,
+    COALESCE(c."NOMBRE", '')          AS nombre_cliente,
+    COALESCE(pc."PK_DOCUMENTO_CLIENTE",0) AS documento_cliente
+FROM "DOMICILIO" d
+LEFT JOIN "PEDIDO" p ON d."PK_ID_DOMICILIO" = p."PK_ID_DOMICILIO"
+LEFT JOIN "PEDIDO_CLIENTE" pc ON p."PK_ID_PEDIDO" = pc."PK_ID_PEDIDO"
+LEFT JOIN "CLIENTE" c ON pc."PK_DOCUMENTO_CLIENTE" = c."PK_DOCUMENTO_CLIENTE"
+WHERE d."PK_ID_DOMICILIO" = ?`
 
-	err = o.Read(&domicilio)
-	if err == orm.ErrNoRows {
-		c.Ctx.Output.SetStatus(http.StatusOK)
-		c.Data["json"] = models.ApiResponse{
-			Code:    http.StatusNotFound,
-			Message: "Domicilio no encontrado",
-			Cause:   err.Error(),
-		}
-		c.ServeJSON()
-		return
-	}
+        var detalle models.DomicilioDetail
+        err = o.Raw(query, id).QueryRow(&detalle)
+        if err == orm.ErrNoRows {
+                c.Ctx.Output.SetStatus(http.StatusOK)
+                c.Data["json"] = models.ApiResponse{
+                        Code:    http.StatusNotFound,
+                        Message: "Domicilio no encontrado",
+                        Cause:   err.Error(),
+                }
+                c.ServeJSON()
+                return
+        }
+        if err != nil {
+                c.Ctx.Output.SetStatus(http.StatusInternalServerError)
+                c.Data["json"] = models.ApiResponse{
+                        Code:    http.StatusInternalServerError,
+                        Message: "Error al obtener el domicilio",
+                        Cause:   err.Error(),
+                }
+                c.ServeJSON()
+                return
+        }
 
-	c.Ctx.Output.SetStatus(http.StatusOK)
-	c.Data["json"] = models.ApiResponse{
-		Code:    http.StatusOK,
-		Message: "Domicilio encontrado",
-		Data:    domicilio,
-	}
-	c.ServeJSON()
+        c.Ctx.Output.SetStatus(http.StatusOK)
+        c.Data["json"] = models.ApiResponse{
+                Code:    http.StatusOK,
+                Message: "Domicilio encontrado",
+                Data:    detalle,
+        }
+        c.ServeJSON()
 }
 
 // @Title Create

--- a/models/Domicilio.go
+++ b/models/Domicilio.go
@@ -22,12 +22,19 @@ type Domicilio struct {
 	PK_DOCUMENTO_TRABAJADOR *int      `orm:"column(PK_DOCUMENTO_TRABAJADOR);null" json:"trabajadorAsignado,omitempty"`
 }
 
+// DomicilioDetail extiende la información de un domicilio con datos del cliente asociado.
+type DomicilioDetail struct {
+        Domicilio
+        NombreCliente    string `json:"nombreCliente" orm:"column(nombre_cliente)"`
+        DocumentoCliente int64  `json:"documentoCliente" orm:"column(documento_cliente)"`
+}
+
 func (d *Domicilio) TableName() string {
 	return "DOMICILIO"
 }
 
 func init() {
-	orm.RegisterModel(new(Domicilio))
+        orm.RegisterModel(new(Domicilio))
 }
 
 // Personalizar el formato de fecha para la API
@@ -44,4 +51,20 @@ func (d Domicilio) MarshalJSON() ([]byte, error) {
 		UPDATED_AT: d.UPDATED_AT.Format("02-01-2006 15:04:05"),
 		Alias:      (Alias)(d),
 	})
+}
+
+// MarshalJSON para DomicilioDetail formatea las fechas igual que el modelo base.
+func (d DomicilioDetail) MarshalJSON() ([]byte, error) {
+        type Alias DomicilioDetail
+        return json.Marshal(&struct {
+                FECHA      string `json:"fechaDomicilio"`
+                CREATED_AT string `json:"createdAt"`
+                UPDATED_AT string `json:"updatedAt"`
+                Alias
+        }{
+                FECHA:      d.FECHA.Format("02-01-2006"),
+                CREATED_AT: d.CREATED_AT.Format("02-01-2006 15:04:05"),
+                UPDATED_AT: d.UPDATED_AT.Format("02-01-2006 15:04:05"),
+                Alias:      (Alias)(d),
+        })
 }


### PR DESCRIPTION
## Summary
- extend domicilio model with customer details
- return customer name and document from `/domicilios/search`

## Testing
- `go test ./controllers -run TestDomicilioGetByIdInvalidID -count=1 -timeout 5s` *(fails: command hung, likely missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68aa5b777cd48325b46ca5cf3cb0f9ab