### PR TITLE
Refactor pedido product handling with detalle join

### DIFF
--- a/controllers/DomicilioController.go
+++ b/controllers/DomicilioController.go
@@ -176,25 +176,25 @@ SELECT
   p."PK_ID_PEDIDO" AS pedido_id,
   pa."PK_ID_PAGO"  AS pago_id,
   pa."MONTO"::numeric AS pago_monto,
-  (
-    SELECT COALESCE(SUM((elem->>'SUBTOTAL')::numeric), 0)
-    FROM (
-      SELECT jsonb_array_elements(pp."DETALLES_PRODUCTOS") AS elem
-      FROM "PRODUCTO_PEDIDO" pp
-      WHERE pp."PK_ID_PEDIDO" = p."PK_ID_PEDIDO"
-    ) s
-  ) AS subtotal_productos,
-  (
-    SELECT COALESCE(jsonb_agg(elem), '[]'::jsonb)::text
-    FROM (
-      SELECT jsonb_array_elements(pp."DETALLES_PRODUCTOS") AS elem
-      FROM "PRODUCTO_PEDIDO" pp
-      WHERE pp."PK_ID_PEDIDO" = p."PK_ID_PEDIDO"
-    ) s
-  ) AS productos
+  COALESCE(SUM(ppd."SUBTOTAL"), 0) AS subtotal_productos,
+  COALESCE(
+    json_agg(
+      json_build_object(
+        'PK_ID_PRODUCTO', pr."PK_ID_PRODUCTO",
+        'NOMBRE', pr."NOMBRE",
+        'CANTIDAD', ppd."CANTIDAD",
+        'PRECIO_UNITARIO', ppd."PRECIO_UNITARIO",
+        'SUBTOTAL', ppd."SUBTOTAL"
+      )
+    ) FILTER (WHERE ppd."PK_ID_PRODUCTO_PEDIDO_DETALLE" IS NOT NULL), '[]'
+  )::text AS productos
 FROM "PEDIDO" p
 LEFT JOIN "PAGO" pa ON pa."PK_ID_PAGO" = p."PK_ID_PAGO"
+LEFT JOIN "PRODUCTO_PEDIDO" pp ON pp."PK_ID_PEDIDO" = p."PK_ID_PEDIDO"
+LEFT JOIN "PRODUCTO_PEDIDO_DETALLE" ppd ON ppd."PK_ID_PRODUCTO_PEDIDO" = pp."PK_ID_PRODUCTO_PEDIDO"
+LEFT JOIN "PRODUCTO" pr ON pr."PK_ID_PRODUCTO" = ppd."PK_ID_PRODUCTO"
 WHERE p."PK_ID_DOMICILIO" = ?
+GROUP BY p."PK_ID_PEDIDO", pa."PK_ID_PAGO", pa."MONTO"
 ORDER BY p."PK_ID_PEDIDO" DESC
 LIMIT 1;`
 

--- a/controllers/PedidoController.go
+++ b/controllers/PedidoController.go
@@ -371,14 +371,17 @@ SELECT
     COALESCE(p."DELIVERY", false)                      AS delivery,
     COALESCE(p."ESTADO_PEDIDO", '')                    AS estado_pedido,
     COALESCE(mp."TIPO", '')                            AS metodo_pago,
-    COALESCE((
-        SELECT jsonb_agg(elementos)::text
-        FROM (
-            SELECT jsonb_array_elements(pp."DETALLES_PRODUCTOS") AS elementos
-            FROM "PRODUCTO_PEDIDO" pp
-            WHERE pp."PK_ID_PEDIDO" = p."PK_ID_PEDIDO"
-        ) subq
-    ), '[]')                                           AS productos,
+    COALESCE(
+        json_agg(
+            json_build_object(
+                'PK_ID_PRODUCTO', pr."PK_ID_PRODUCTO",
+                'NOMBRE', pr."NOMBRE",
+                'CANTIDAD', ppd."CANTIDAD",
+                'PRECIO_UNITARIO', ppd."PRECIO_UNITARIO",
+                'SUBTOTAL', ppd."SUBTOTAL"
+            )
+        ) FILTER (WHERE ppd."PK_ID_PRODUCTO_PEDIDO_DETALLE" IS NOT NULL), '[]'
+    )::text                                           AS productos,
     COALESCE(p."PK_ID_PAGO", 0)                        AS pago_id,
     COALESCE(pa."PK_ID_METODO_PAGO", 0)                AS metodo_pago_id,
     COALESCE(p."PK_ID_DOMICILIO", 0)                   AS domicilio_id,
@@ -387,13 +390,31 @@ FROM "PEDIDO" p
 LEFT JOIN "PAGO" pa        ON p."PK_ID_PAGO" = pa."PK_ID_PAGO"
 LEFT JOIN "METODO_PAGO" mp ON pa."PK_ID_METODO_PAGO" = mp."PK_ID_METODO_PAGO"
 LEFT JOIN "PEDIDO_CLIENTE" pc ON p."PK_ID_PEDIDO" = pc."PK_ID_PEDIDO"
-WHERE p."PK_ID_PEDIDO" = ?;
-    `
+LEFT JOIN "PRODUCTO_PEDIDO" pp ON pp."PK_ID_PEDIDO" = p."PK_ID_PEDIDO"
+LEFT JOIN "PRODUCTO_PEDIDO_DETALLE" ppd ON ppd."PK_ID_PRODUCTO_PEDIDO" = pp."PK_ID_PRODUCTO_PEDIDO"
+LEFT JOIN "PRODUCTO" pr ON pr."PK_ID_PRODUCTO" = ppd."PK_ID_PRODUCTO"
+WHERE p."PK_ID_PEDIDO" = ?
+GROUP BY p."PK_ID_PEDIDO", p."FECHA", p."HORA", p."DELIVERY", p."ESTADO_PEDIDO",
+         mp."TIPO", p."PK_ID_PAGO", pa."PK_ID_METODO_PAGO", p."PK_ID_DOMICILIO", pc."PK_DOCUMENTO_CLIENTE";`
 
-	var details models.PedidoDetails
+	// Estructura auxiliar para procesar resultados
+	type detailsRow struct {
+		PedidoID         int64  `orm:"column(pk_id_pedido)"`
+		Fecha            string `orm:"column(fecha)"`
+		Hora             string `orm:"column(hora)"`
+		Delivery         bool   `orm:"column(delivery)"`
+		EstadoPedido     string `orm:"column(estado_pedido)"`
+		MetodoPago       string `orm:"column(metodo_pago)"`
+		Productos        string `orm:"column(productos)"`
+		PagoID           int64  `orm:"column(pago_id)"`
+		MetodoPagoID     int64  `orm:"column(metodo_pago_id)"`
+		DomicilioID      int64  `orm:"column(domicilio_id)"`
+		DocumentoCliente int64  `orm:"column(documento_cliente)"`
+	}
 
+	var row detailsRow
 	// Ejecutar consulta
-	err := o.Raw(query, pedidoID).QueryRow(&details)
+	err := o.Raw(query, pedidoID).QueryRow(&row)
 	if err != nil {
 		c.Data["json"] = models.ApiResponse{
 			Code:    500,
@@ -404,11 +425,30 @@ WHERE p."PK_ID_PEDIDO" = ?;
 		return
 	}
 
+	var productos []map[string]interface{}
+	if row.Productos != "" {
+		_ = json.Unmarshal([]byte(row.Productos), &productos)
+	}
+
+	data := map[string]interface{}{
+		"pedidoId":         row.PedidoID,
+		"fechaPedido":      row.Fecha,
+		"horaPedido":       row.Hora,
+		"delivery":         row.Delivery,
+		"estadoPedido":     row.EstadoPedido,
+		"metodoPago":       row.MetodoPago,
+		"productos":        productos,
+		"pagoId":           row.PagoID,
+		"metodoPagoId":     row.MetodoPagoID,
+		"domicilioId":      row.DomicilioID,
+		"documentoCliente": row.DocumentoCliente,
+	}
+
 	// Respuesta exitosa
 	c.Data["json"] = models.ApiResponse{
 		Code:    200,
 		Message: "Detalles del pedido obtenidos exitosamente",
-		Data:    details,
+		Data:    data,
 	}
 	c.ServeJSON()
 }

--- a/controllers/ProductoPedidoController.go
+++ b/controllers/ProductoPedidoController.go
@@ -41,14 +41,34 @@ func (c *ProductoPedidoController) GetAll() {
 		c.ServeJSON()
 		return
 	}
-
 	o := orm.NewOrm()
-	var productoPedido models.ProductoPedido
 
-	err = o.QueryTable(new(models.ProductoPedido)).
-		Filter("PK_ID_PEDIDO", pedidoID).
-		One(&productoPedido)
+	query := `
+SELECT
+    pp."PK_ID_PEDIDO" AS pedido_id,
+    COALESCE(
+        json_agg(
+            json_build_object(
+                'cantidad', ppd."CANTIDAD",
+                'nombre', pr."NOMBRE",
+                'productoId', ppd."PK_ID_PRODUCTO",
+                'precioUnitario', ppd."PRECIO_UNITARIO",
+                'subtotal', ppd."SUBTOTAL"
+            )
+        ) FILTER (WHERE ppd."PK_ID_PRODUCTO_PEDIDO_DETALLE" IS NOT NULL), '[]'
+    )::text AS detalles
+FROM "PRODUCTO_PEDIDO" pp
+LEFT JOIN "PRODUCTO_PEDIDO_DETALLE" ppd ON ppd."PK_ID_PRODUCTO_PEDIDO" = pp."PK_ID_PRODUCTO_PEDIDO"
+LEFT JOIN "PRODUCTO" pr ON pr."PK_ID_PRODUCTO" = ppd."PK_ID_PRODUCTO"
+WHERE pp."PK_ID_PEDIDO" = ?
+GROUP BY pp."PK_ID_PEDIDO";`
 
+	var row struct {
+		PedidoID int64  `orm:"column(pedido_id)"`
+		Detalles string `orm:"column(detalles)"`
+	}
+
+	err = o.Raw(query, pedidoID).QueryRow(&row)
 	if err == orm.ErrNoRows {
 		c.Data["json"] = models.ApiResponse{
 			Code:    http.StatusNotFound,
@@ -66,35 +86,14 @@ func (c *ProductoPedidoController) GetAll() {
 		return
 	}
 
-	// Convertir el JSONB a un formato de salida legible
 	var detalles []map[string]interface{}
-	if err := json.Unmarshal([]byte(productoPedido.DETALLES_PRODUCTOS), &detalles); err != nil {
-		c.Data["json"] = models.ApiResponse{
-			Code:    http.StatusInternalServerError,
-			Message: "Error al procesar los detalles del pedido",
-			Cause:   err.Error(),
-		}
-		c.ServeJSON()
-		return
+	if row.Detalles != "" {
+		_ = json.Unmarshal([]byte(row.Detalles), &detalles)
 	}
 
-	// Transformar las claves de los detalles a camelCase
-	var detallesCamelCase []map[string]interface{}
-	for _, detalle := range detalles {
-		camelCaseDetalle := map[string]interface{}{
-			"cantidad":       detalle["CANTIDAD"],
-			"nombre":         detalle["NOMBRE"],
-			"productoId":     detalle["PK_ID_PRODUCTO"],
-			"precioUnitario": detalle["PRECIO_UNITARIO"],
-			"subtotal":       detalle["SUBTOTAL"],
-		}
-		detallesCamelCase = append(detallesCamelCase, camelCaseDetalle)
-	}
-
-	// Construir la respuesta
 	response := map[string]interface{}{
-		"pedidoId":          productoPedido.PK_ID_PEDIDO,
-		"detallesProductos": detallesCamelCase,
+		"pedidoId":          row.PedidoID,
+		"detallesProductos": detalles,
 	}
 
 	c.Data["json"] = models.ApiResponse{
@@ -143,40 +142,58 @@ func (c *ProductoPedidoController) Post() {
 		return
 	}
 
-	// Convertir los detalles a JSON
-	detallesJSON, err := json.Marshal(input.DetallesProductos)
-	if err != nil {
-		c.Data["json"] = models.ApiResponse{
-			Code:    http.StatusInternalServerError,
-			Message: "Error al procesar los detalles del pedido",
-			Cause:   err.Error(),
-		}
-		c.ServeJSON()
-		return
-	}
-
-	productoPedido := models.ProductoPedido{
-		PK_ID_PEDIDO:       input.PedidoId,
-		DETALLES_PRODUCTOS: string(detallesJSON),
-	}
-
 	o := orm.NewOrm()
-	_, err = o.Insert(&productoPedido)
+	tx, err := o.Begin()
 	if err != nil {
-		c.Data["json"] = models.ApiResponse{
-			Code:    http.StatusInternalServerError,
-			Message: "Error al crear el pedido con productos",
-			Cause:   err.Error(),
-		}
+		c.Data["json"] = models.ApiResponse{Code: http.StatusInternalServerError, Message: "No se pudo iniciar la transacción", Cause: err.Error()}
 		c.ServeJSON()
 		return
 	}
 
-	c.Data["json"] = models.ApiResponse{
-		Code:    http.StatusCreated,
-		Message: "Pedido con productos agregado exitosamente",
-		Data:    productoPedido,
+	productoPedido := models.ProductoPedido{PK_ID_PEDIDO: input.PedidoId}
+	if _, err := tx.Insert(&productoPedido); err != nil {
+		tx.Rollback()
+		c.Data["json"] = models.ApiResponse{Code: http.StatusInternalServerError, Message: "Error al crear el pedido con productos", Cause: err.Error()}
+		c.ServeJSON()
+		return
 	}
+
+	for _, det := range input.DetallesProductos {
+		productoID, _ := det["productoId"].(float64)
+		cantidad, _ := det["cantidad"].(float64)
+		precio, _ := det["precioUnitario"].(float64)
+		subtotal, ok := det["subtotal"].(float64)
+		if !ok {
+			subtotal = precio * cantidad
+		}
+
+		detalle := models.ProductoPedidoDetalle{
+			PK_ID_PRODUCTO_PEDIDO: productoPedido.PK_ID_PRODUCTO_PEDIDO,
+			PK_ID_PRODUCTO:        int64(productoID),
+			CANTIDAD:              int(cantidad),
+			PRECIO_UNITARIO:       precio,
+			SUBTOTAL:              subtotal,
+		}
+		if _, err := tx.Insert(&detalle); err != nil {
+			tx.Rollback()
+			c.Data["json"] = models.ApiResponse{Code: http.StatusInternalServerError, Message: "Error al registrar los productos del pedido", Cause: err.Error()}
+			c.ServeJSON()
+			return
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		c.Data["json"] = models.ApiResponse{Code: http.StatusInternalServerError, Message: "Error al confirmar la transacción", Cause: err.Error()}
+		c.ServeJSON()
+		return
+	}
+
+	response := map[string]interface{}{
+		"pedidoId":          productoPedido.PK_ID_PEDIDO,
+		"detallesProductos": input.DetallesProductos,
+	}
+
+	c.Data["json"] = models.ApiResponse{Code: http.StatusCreated, Message: "Pedido con productos agregado exitosamente", Data: response}
 	c.ServeJSON()
 }
 
@@ -227,57 +244,64 @@ func (c *ProductoPedidoController) Update() {
 	}
 
 	o := orm.NewOrm()
-	productoPedido := models.ProductoPedido{}
+	tx, err := o.Begin()
+	if err != nil {
+		c.Data["json"] = models.ApiResponse{Code: http.StatusInternalServerError, Message: "No se pudo iniciar la transacción", Cause: err.Error()}
+		c.ServeJSON()
+		return
+	}
 
-	// Verificar si existe el pedido en la base de datos
-	err = o.QueryTable(new(models.ProductoPedido)).
-		Filter("PK_ID_PEDIDO", pedidoID).
-		One(&productoPedido)
+	var productoPedido models.ProductoPedido
+	err = tx.QueryTable(new(models.ProductoPedido)).Filter("PK_ID_PEDIDO", pedidoID).One(&productoPedido)
 	if err == orm.ErrNoRows {
-		c.Data["json"] = models.ApiResponse{
-			Code:    http.StatusNotFound,
-			Message: "Pedido no encontrado",
-		}
+		tx.Rollback()
+		c.Data["json"] = models.ApiResponse{Code: http.StatusNotFound, Message: "Pedido no encontrado"}
 		c.ServeJSON()
 		return
 	} else if err != nil {
-		c.Data["json"] = models.ApiResponse{
-			Code:    http.StatusInternalServerError,
-			Message: "Error al buscar el pedido",
-			Cause:   err.Error(),
-		}
+		tx.Rollback()
+		c.Data["json"] = models.ApiResponse{Code: http.StatusInternalServerError, Message: "Error al buscar el pedido", Cause: err.Error()}
 		c.ServeJSON()
 		return
 	}
 
-	// Convertir la nueva lista de productos a JSON
-	nuevosDetallesJSON, err := json.Marshal(nuevosProductos)
-	if err != nil {
-		c.Data["json"] = models.ApiResponse{
-			Code:    http.StatusInternalServerError,
-			Message: "Error al procesar los detalles actualizados",
-			Cause:   err.Error(),
-		}
+	if _, err := tx.QueryTable(new(models.ProductoPedidoDetalle)).Filter("PK_ID_PRODUCTO_PEDIDO", productoPedido.PK_ID_PRODUCTO_PEDIDO).Delete(); err != nil {
+		tx.Rollback()
+		c.Data["json"] = models.ApiResponse{Code: http.StatusInternalServerError, Message: "Error al limpiar los productos del pedido", Cause: err.Error()}
 		c.ServeJSON()
 		return
 	}
 
-	// Actualizar los detalles en la base de datos
-	productoPedido.DETALLES_PRODUCTOS = string(nuevosDetallesJSON)
-	if _, err := o.Update(&productoPedido, "DETALLES_PRODUCTOS"); err != nil {
-		c.Data["json"] = models.ApiResponse{
-			Code:    http.StatusInternalServerError,
-			Message: "Error al actualizar los productos del pedido",
-			Cause:   err.Error(),
+	for _, det := range nuevosProductos {
+		productoID, _ := det["productoId"].(float64)
+		cantidad, _ := det["cantidad"].(float64)
+		precio, _ := det["precioUnitario"].(float64)
+		subtotal, ok := det["subtotal"].(float64)
+		if !ok {
+			subtotal = precio * cantidad
 		}
+
+		detalle := models.ProductoPedidoDetalle{
+			PK_ID_PRODUCTO_PEDIDO: productoPedido.PK_ID_PRODUCTO_PEDIDO,
+			PK_ID_PRODUCTO:        int64(productoID),
+			CANTIDAD:              int(cantidad),
+			PRECIO_UNITARIO:       precio,
+			SUBTOTAL:              subtotal,
+		}
+		if _, err := tx.Insert(&detalle); err != nil {
+			tx.Rollback()
+			c.Data["json"] = models.ApiResponse{Code: http.StatusInternalServerError, Message: "Error al actualizar los productos del pedido", Cause: err.Error()}
+			c.ServeJSON()
+			return
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		c.Data["json"] = models.ApiResponse{Code: http.StatusInternalServerError, Message: "Error al confirmar la transacción", Cause: err.Error()}
 		c.ServeJSON()
 		return
 	}
 
-	c.Data["json"] = models.ApiResponse{
-		Code:    http.StatusOK,
-		Message: "Productos del pedido actualizados exitosamente",
-		Data:    nuevosProductos,
-	}
+	c.Data["json"] = models.ApiResponse{Code: http.StatusOK, Message: "Productos del pedido actualizados exitosamente", Data: nuevosProductos}
 	c.ServeJSON()
 }

--- a/models/ProductoPedido.go
+++ b/models/ProductoPedido.go
@@ -2,10 +2,12 @@ package models
 
 import "github.com/beego/beego/v2/client/orm"
 
+// ProductoPedido representa el vínculo entre un pedido y sus productos.
+// Los detalles específicos de cada producto se almacenan en la tabla
+// PRODUCTO_PEDIDO_DETALLE.
 type ProductoPedido struct {
-	PK_ID_PRODUCTO_PEDIDO int64  `orm:"column(PK_ID_PRODUCTO_PEDIDO);pk;auto" json:"productoPedidoId"`
-	DETALLES_PRODUCTOS    string `orm:"column(DETALLES_PRODUCTOS);type(jsonb)" json:"detallesProductos"`
-	PK_ID_PEDIDO          int64  `orm:"column(PK_ID_PEDIDO)" json:"pedidoId"`
+	PK_ID_PRODUCTO_PEDIDO int64 `orm:"column(PK_ID_PRODUCTO_PEDIDO);pk;auto" json:"productoPedidoId"`
+	PK_ID_PEDIDO          int64 `orm:"column(PK_ID_PEDIDO)" json:"pedidoId"`
 }
 
 func (p *ProductoPedido) TableName() string {

--- a/models/ProductoPedidoDetalle.go
+++ b/models/ProductoPedidoDetalle.go
@@ -1,0 +1,21 @@
+package models
+
+import "github.com/beego/beego/v2/client/orm"
+
+// ProductoPedidoDetalle representa un producto específico dentro de un pedido.
+type ProductoPedidoDetalle struct {
+	PK_ID_PRODUCTO_PEDIDO_DETALLE int64   `orm:"column(PK_ID_PRODUCTO_PEDIDO_DETALLE);pk;auto" json:"productoPedidoDetalleId"`
+	PK_ID_PRODUCTO_PEDIDO         int64   `orm:"column(PK_ID_PRODUCTO_PEDIDO)" json:"productoPedidoId"`
+	PK_ID_PRODUCTO                int64   `orm:"column(PK_ID_PRODUCTO)" json:"productoId"`
+	CANTIDAD                      int     `orm:"column(CANTIDAD)" json:"cantidad"`
+	PRECIO_UNITARIO               float64 `orm:"column(PRECIO_UNITARIO)" json:"precioUnitario"`
+	SUBTOTAL                      float64 `orm:"column(SUBTOTAL)" json:"subtotal"`
+}
+
+func (p *ProductoPedidoDetalle) TableName() string {
+	return "PRODUCTO_PEDIDO_DETALLE"
+}
+
+func init() {
+	orm.RegisterModel(new(ProductoPedidoDetalle))
+}


### PR DESCRIPTION
## Summary
- join pedido-related queries to PRODUCTO_PEDIDO_DETALLE
- persist pedido product details within transactions
- expose normalized product details via JSON responses

## Testing
- `go test ./...` *(fails: TestCambiosHorario_GetByCurrentDate_NotFound, TestPagoPostSuccess, TestPagoPostInsertError, TestProductoPedidoPostDBError, TestProductoPedidoUpdateDBError)*

------
https://chatgpt.com/codex/tasks/task_e_68b22ebea8fc83258e107a76bc4bbddb