### PR TITLE
feat: add product order details model

### DIFF
--- a/controllers/ProductoPedidoController.go
+++ b/controllers/ProductoPedidoController.go
@@ -15,8 +15,8 @@ type ProductoPedidoController struct {
 
 // Estructura para mapear las respuestas en camelCase
 type ProductoPedidoResponse struct {
-	PedidoID          int64       `json:"pedidoId"`
-	DetallesProductos interface{} `json:"detallesProductos"`
+	PedidoID          int64                          `json:"pedidoId"`
+	DetallesProductos []models.ProductoPedidoDetalle `json:"detallesProductos"`
 }
 
 // @Title GetAll
@@ -66,9 +66,11 @@ func (c *ProductoPedidoController) GetAll() {
 		return
 	}
 
-	// Convertir el JSONB a un formato de salida legible
-	var detalles []map[string]interface{}
-	if err := json.Unmarshal([]byte(productoPedido.DETALLES_PRODUCTOS), &detalles); err != nil {
+	var detalles []models.ProductoPedidoDetalle
+	_, err = o.QueryTable(new(models.ProductoPedidoDetalle)).
+		Filter("PK_ID_PRODUCTO_PEDIDO", productoPedido.PK_ID_PRODUCTO_PEDIDO).
+		All(&detalles)
+	if err != nil {
 		c.Data["json"] = models.ApiResponse{
 			Code:    http.StatusInternalServerError,
 			Message: "Error al procesar los detalles del pedido",
@@ -78,23 +80,9 @@ func (c *ProductoPedidoController) GetAll() {
 		return
 	}
 
-	// Transformar las claves de los detalles a camelCase
-	var detallesCamelCase []map[string]interface{}
-	for _, detalle := range detalles {
-		camelCaseDetalle := map[string]interface{}{
-			"cantidad":       detalle["CANTIDAD"],
-			"nombre":         detalle["NOMBRE"],
-			"productoId":     detalle["PK_ID_PRODUCTO"],
-			"precioUnitario": detalle["PRECIO_UNITARIO"],
-			"subtotal":       detalle["SUBTOTAL"],
-		}
-		detallesCamelCase = append(detallesCamelCase, camelCaseDetalle)
-	}
-
-	// Construir la respuesta
-	response := map[string]interface{}{
-		"pedidoId":          productoPedido.PK_ID_PEDIDO,
-		"detallesProductos": detallesCamelCase,
+	response := ProductoPedidoResponse{
+		PedidoID:          productoPedido.PK_ID_PEDIDO,
+		DetallesProductos: detalles,
 	}
 
 	c.Data["json"] = models.ApiResponse{
@@ -119,8 +107,8 @@ func (c *ProductoPedidoController) GetAll() {
 // @Router /producto_pedido [post]
 func (c *ProductoPedidoController) Post() {
 	var input struct {
-		PedidoId          int64                    `json:"pedidoId"`
-		DetallesProductos []map[string]interface{} `json:"detallesProductos"`
+		PedidoId          int64                          `json:"pedidoId"`
+		DetallesProductos []models.ProductoPedidoDetalle `json:"detallesProductos"`
 	}
 
 	if err := json.Unmarshal(c.Ctx.Input.RequestBody, &input); err != nil {
@@ -133,7 +121,6 @@ func (c *ProductoPedidoController) Post() {
 		return
 	}
 
-	// Validar que se proporcione el pedido y los detalles
 	if input.PedidoId == 0 || len(input.DetallesProductos) == 0 {
 		c.Data["json"] = models.ApiResponse{
 			Code:    http.StatusBadRequest,
@@ -143,25 +130,13 @@ func (c *ProductoPedidoController) Post() {
 		return
 	}
 
-	// Convertir los detalles a JSON
-	detallesJSON, err := json.Marshal(input.DetallesProductos)
-	if err != nil {
-		c.Data["json"] = models.ApiResponse{
-			Code:    http.StatusInternalServerError,
-			Message: "Error al procesar los detalles del pedido",
-			Cause:   err.Error(),
-		}
-		c.ServeJSON()
-		return
-	}
-
 	productoPedido := models.ProductoPedido{
-		PK_ID_PEDIDO:       input.PedidoId,
-		DETALLES_PRODUCTOS: string(detallesJSON),
+		PK_ID_PEDIDO:      input.PedidoId,
+		DetallesProductos: input.DetallesProductos,
 	}
 
 	o := orm.NewOrm()
-	_, err = o.Insert(&productoPedido)
+	_, err := o.Insert(&productoPedido)
 	if err != nil {
 		c.Data["json"] = models.ApiResponse{
 			Code:    http.StatusInternalServerError,
@@ -170,6 +145,19 @@ func (c *ProductoPedidoController) Post() {
 		}
 		c.ServeJSON()
 		return
+	}
+
+	for _, det := range input.DetallesProductos {
+		det.PK_ID_PRODUCTO_PEDIDO = productoPedido.PK_ID_PRODUCTO_PEDIDO
+		if _, err := o.Insert(&det); err != nil {
+			c.Data["json"] = models.ApiResponse{
+				Code:    http.StatusInternalServerError,
+				Message: "Error al crear el pedido con productos",
+				Cause:   err.Error(),
+			}
+			c.ServeJSON()
+			return
+		}
 	}
 
 	c.Data["json"] = models.ApiResponse{
@@ -187,7 +175,7 @@ func (c *ProductoPedidoController) Post() {
 // @Accept json
 // @Produce json
 // @Param pedido_id query int true "ID del pedido a actualizar"
-// @Param body body []map[string]interface{} true "Lista actualizada de productos"
+// @Param body body []models.ProductoPedidoDetalle true "Lista actualizada de productos"
 // @Success 200 {object} models.ApiResponse "Productos actualizados exitosamente"
 // @Failure 400 {object} models.ApiResponse "Datos inválidos"
 // @Failure 404 {object} models.ApiResponse "Pedido no encontrado"
@@ -206,7 +194,7 @@ func (c *ProductoPedidoController) Update() {
 	}
 
 	// Parsear los datos del cuerpo de la solicitud
-	var nuevosProductos []map[string]interface{}
+	var nuevosProductos []models.ProductoPedidoDetalle
 	if err := json.Unmarshal(c.Ctx.Input.RequestBody, &nuevosProductos); err != nil {
 		c.Data["json"] = models.ApiResponse{
 			Code:    http.StatusBadRequest,
@@ -250,21 +238,10 @@ func (c *ProductoPedidoController) Update() {
 		return
 	}
 
-	// Convertir la nueva lista de productos a JSON
-	nuevosDetallesJSON, err := json.Marshal(nuevosProductos)
-	if err != nil {
-		c.Data["json"] = models.ApiResponse{
-			Code:    http.StatusInternalServerError,
-			Message: "Error al procesar los detalles actualizados",
-			Cause:   err.Error(),
-		}
-		c.ServeJSON()
-		return
-	}
-
 	// Actualizar los detalles en la base de datos
-	productoPedido.DETALLES_PRODUCTOS = string(nuevosDetallesJSON)
-	if _, err := o.Update(&productoPedido, "DETALLES_PRODUCTOS"); err != nil {
+	if _, err := o.QueryTable(new(models.ProductoPedidoDetalle)).
+		Filter("PK_ID_PRODUCTO_PEDIDO", productoPedido.PK_ID_PRODUCTO_PEDIDO).
+		Delete(); err != nil {
 		c.Data["json"] = models.ApiResponse{
 			Code:    http.StatusInternalServerError,
 			Message: "Error al actualizar los productos del pedido",
@@ -272,6 +249,19 @@ func (c *ProductoPedidoController) Update() {
 		}
 		c.ServeJSON()
 		return
+	}
+
+	for _, det := range nuevosProductos {
+		det.PK_ID_PRODUCTO_PEDIDO = productoPedido.PK_ID_PRODUCTO_PEDIDO
+		if _, err := o.Insert(&det); err != nil {
+			c.Data["json"] = models.ApiResponse{
+				Code:    http.StatusInternalServerError,
+				Message: "Error al actualizar los productos del pedido",
+				Cause:   err.Error(),
+			}
+			c.ServeJSON()
+			return
+		}
 	}
 
 	c.Data["json"] = models.ApiResponse{

--- a/models/ProductoPedido.go
+++ b/models/ProductoPedido.go
@@ -3,9 +3,9 @@ package models
 import "github.com/beego/beego/v2/client/orm"
 
 type ProductoPedido struct {
-	PK_ID_PRODUCTO_PEDIDO int64  `orm:"column(PK_ID_PRODUCTO_PEDIDO);pk;auto" json:"productoPedidoId"`
-	DETALLES_PRODUCTOS    string `orm:"column(DETALLES_PRODUCTOS);type(jsonb)" json:"detallesProductos"`
-	PK_ID_PEDIDO          int64  `orm:"column(PK_ID_PEDIDO)" json:"pedidoId"`
+	PK_ID_PRODUCTO_PEDIDO int64                   `orm:"column(PK_ID_PRODUCTO_PEDIDO);pk;auto" json:"productoPedidoId"`
+	PK_ID_PEDIDO          int64                   `orm:"column(PK_ID_PEDIDO)" json:"pedidoId"`
+	DetallesProductos     []ProductoPedidoDetalle `orm:"-" json:"detallesProductos"`
 }
 
 func (p *ProductoPedido) TableName() string {
@@ -13,5 +13,5 @@ func (p *ProductoPedido) TableName() string {
 }
 
 func init() {
-	orm.RegisterModel(new(ProductoPedido))
+	orm.RegisterModel(new(ProductoPedido), new(ProductoPedidoDetalle))
 }

--- a/models/ProductoPedidoDetalle.go
+++ b/models/ProductoPedidoDetalle.go
@@ -1,0 +1,12 @@
+package models
+
+type ProductoPedidoDetalle struct {
+	PK_ID_PRODUCTO_PEDIDO int64 `orm:"column(PK_ID_PRODUCTO_PEDIDO);pk" json:"productoPedidoId"`
+	PK_ID_PRODUCTO        int64 `orm:"column(PK_ID_PRODUCTO)" json:"productoId"`
+	CANTIDAD              int64 `orm:"column(CANTIDAD)" json:"cantidad"`
+	PRECIO                int64 `orm:"column(PRECIO)" json:"precio"`
+}
+
+func (p *ProductoPedidoDetalle) TableName() string {
+	return "PRODUCTO_PEDIDO_DETALLE"
+}


### PR DESCRIPTION
## Summary
- add ProductoPedidoDetalle model for order product details
- refactor ProductoPedido to use structured details and register both models
- update ProductoPedidoController to handle detail records

## Testing
- `go test ./...` *(fails: TestCambiosHorario_GetByCurrentDate_NotFound, TestPagoPostSuccess, TestPagoPostInsertError)*

------
https://chatgpt.com/codex/tasks/task_e_68b22ebda1908325891069d812bff427