### PR TITLE
Refactor ProductoPedido to use detail records

### DIFF
--- a/controllers/DomicilioController.go
+++ b/controllers/DomicilioController.go
@@ -177,20 +177,21 @@ SELECT
   pa."PK_ID_PAGO"  AS pago_id,
   pa."MONTO"::numeric AS pago_monto,
   (
-    SELECT COALESCE(SUM((elem->>'SUBTOTAL')::numeric), 0)
-    FROM (
-      SELECT jsonb_array_elements(pp."DETALLES_PRODUCTOS") AS elem
-      FROM "PRODUCTO_PEDIDO" pp
-      WHERE pp."PK_ID_PEDIDO" = p."PK_ID_PEDIDO"
-    ) s
+    SELECT COALESCE(SUM(d."SUBTOTAL"), 0)
+    FROM "PRODUCTO_PEDIDO_DETALLE" d
+    WHERE d."PK_ID_PEDIDO" = p."PK_ID_PEDIDO"
   ) AS subtotal_productos,
   (
-    SELECT COALESCE(jsonb_agg(elem), '[]'::jsonb)::text
-    FROM (
-      SELECT jsonb_array_elements(pp."DETALLES_PRODUCTOS") AS elem
-      FROM "PRODUCTO_PEDIDO" pp
-      WHERE pp."PK_ID_PEDIDO" = p."PK_ID_PEDIDO"
-    ) s
+    SELECT COALESCE(jsonb_agg(json_build_object(
+      'PK_ID_PRODUCTO', d."PK_ID_PRODUCTO",
+      'NOMBRE', pr."NOMBRE",
+      'CANTIDAD', d."CANTIDAD",
+      'PRECIO_UNITARIO', d."PRECIO_UNITARIO",
+      'SUBTOTAL', d."SUBTOTAL"
+    )), '[]'::jsonb)::text
+    FROM "PRODUCTO_PEDIDO_DETALLE" d
+    JOIN "PRODUCTO" pr ON pr."PK_ID_PRODUCTO" = d."PK_ID_PRODUCTO"
+    WHERE d."PK_ID_PEDIDO" = p."PK_ID_PEDIDO"
   ) AS productos
 FROM "PEDIDO" p
 LEFT JOIN "PAGO" pa ON pa."PK_ID_PAGO" = p."PK_ID_PAGO"

--- a/controllers/PedidoController.go
+++ b/controllers/PedidoController.go
@@ -372,12 +372,16 @@ SELECT
     COALESCE(p."ESTADO_PEDIDO", '')                    AS estado_pedido,
     COALESCE(mp."TIPO", '')                            AS metodo_pago,
     COALESCE((
-        SELECT jsonb_agg(elementos)::text
-        FROM (
-            SELECT jsonb_array_elements(pp."DETALLES_PRODUCTOS") AS elementos
-            FROM "PRODUCTO_PEDIDO" pp
-            WHERE pp."PK_ID_PEDIDO" = p."PK_ID_PEDIDO"
-        ) subq
+        SELECT jsonb_agg(json_build_object(
+            'PK_ID_PRODUCTO', d."PK_ID_PRODUCTO",
+            'NOMBRE', pr."NOMBRE",
+            'CANTIDAD', d."CANTIDAD",
+            'PRECIO_UNITARIO', d."PRECIO_UNITARIO",
+            'SUBTOTAL', d."SUBTOTAL"
+        ))::text
+        FROM "PRODUCTO_PEDIDO_DETALLE" d
+        JOIN "PRODUCTO" pr ON pr."PK_ID_PRODUCTO" = d."PK_ID_PRODUCTO"
+        WHERE d."PK_ID_PEDIDO" = p."PK_ID_PEDIDO"
     ), '[]')                                           AS productos,
     COALESCE(p."PK_ID_PAGO", 0)                        AS pago_id,
     COALESCE(pa."PK_ID_METODO_PAGO", 0)                AS metodo_pago_id,

--- a/controllers/ProductoPedidoController.go
+++ b/controllers/ProductoPedidoController.go
@@ -24,8 +24,8 @@ type ProductoPedidoController struct {
 
 // Estructura para mapear las respuestas en camelCase
 type ProductoPedidoResponse struct {
-	PedidoID          int64       `json:"pedidoId"`
-	DetallesProductos interface{} `json:"detallesProductos"`
+	PedidoID int64       `json:"pedidoId"`
+	Detalles interface{} `json:"detalles"`
 }
 
 // @Title GetAll
@@ -75,35 +75,31 @@ func (c *ProductoPedidoController) GetAll() {
 		return
 	}
 
-	// Convertir el JSONB a un formato de salida legible
-	var detalles []map[string]interface{}
-	if err := json.Unmarshal([]byte(productoPedido.DETALLES_PRODUCTOS), &detalles); err != nil {
+	var detalles []models.ProductoPedidoDetalle
+	if _, err := o.QueryTable(new(models.ProductoPedidoDetalle)).
+		Filter("PK_ID_PEDIDO", pedidoID).
+		All(&detalles); err != nil {
 		c.Data["json"] = models.ApiResponse{
 			Code:    http.StatusInternalServerError,
-			Message: "Error al procesar los detalles del pedido",
+			Message: "Error al obtener los productos del pedido",
 			Cause:   err.Error(),
 		}
 		c.ServeJSON()
 		return
 	}
 
-	// Transformar las claves de los detalles a camelCase
-	var detallesCamelCase []map[string]interface{}
-	for _, detalle := range detalles {
-		camelCaseDetalle := map[string]interface{}{
-			"cantidad":       detalle["CANTIDAD"],
-			"nombre":         detalle["NOMBRE"],
-			"productoId":     detalle["PK_ID_PRODUCTO"],
-			"precioUnitario": detalle["PRECIO_UNITARIO"],
-			"subtotal":       detalle["SUBTOTAL"],
+	if len(detalles) == 0 {
+		c.Data["json"] = models.ApiResponse{
+			Code:    http.StatusNotFound,
+			Message: "No se encontraron productos asociados a este pedido",
 		}
-		detallesCamelCase = append(detallesCamelCase, camelCaseDetalle)
+		c.ServeJSON()
+		return
 	}
 
-	// Construir la respuesta
 	response := map[string]interface{}{
-		"pedidoId":          productoPedido.PK_ID_PEDIDO,
-		"detallesProductos": detallesCamelCase,
+		"pedidoId": productoPedido.PK_ID_PEDIDO,
+		"detalles": detalles,
 	}
 
 	c.Data["json"] = models.ApiResponse{
@@ -128,8 +124,8 @@ func (c *ProductoPedidoController) GetAll() {
 // @Router /producto_pedido [post]
 func (c *ProductoPedidoController) Post() {
 	var input struct {
-		PedidoId          int64                    `json:"pedidoId"`
-		DetallesProductos []map[string]interface{} `json:"detallesProductos"`
+		PedidoId int64                          `json:"pedidoId"`
+		Detalles []models.ProductoPedidoDetalle `json:"detalles"`
 	}
 
 	if err := json.Unmarshal(c.Ctx.Input.RequestBody, &input); err != nil {
@@ -142,8 +138,7 @@ func (c *ProductoPedidoController) Post() {
 		return
 	}
 
-	// Validar que se proporcione el pedido y los detalles
-	if input.PedidoId == 0 || len(input.DetallesProductos) == 0 {
+	if input.PedidoId == 0 || len(input.Detalles) == 0 {
 		c.Data["json"] = models.ApiResponse{
 			Code:    http.StatusBadRequest,
 			Message: "El pedido y los detalles de los productos son obligatorios",
@@ -152,26 +147,9 @@ func (c *ProductoPedidoController) Post() {
 		return
 	}
 
-	// Convertir los detalles a JSON
-	detallesJSON, err := json.Marshal(input.DetallesProductos)
-	if err != nil {
-		c.Data["json"] = models.ApiResponse{
-			Code:    http.StatusInternalServerError,
-			Message: "Error al procesar los detalles del pedido",
-			Cause:   err.Error(),
-		}
-		c.ServeJSON()
-		return
-	}
-
-	productoPedido := models.ProductoPedido{
-		PK_ID_PEDIDO:       input.PedidoId,
-		DETALLES_PRODUCTOS: string(detallesJSON),
-	}
-
+	productoPedido := models.ProductoPedido{PK_ID_PEDIDO: input.PedidoId}
 	o := productoPedidoNewOrm()
-	_, err = o.Insert(&productoPedido)
-	if err != nil {
+	if _, err := o.Insert(&productoPedido); err != nil {
 		c.Data["json"] = models.ApiResponse{
 			Code:    http.StatusInternalServerError,
 			Message: "Error al crear el pedido con productos",
@@ -179,6 +157,26 @@ func (c *ProductoPedidoController) Post() {
 		}
 		c.ServeJSON()
 		return
+	}
+
+	for _, d := range input.Detalles {
+		detalle := models.ProductoPedidoDetalle{
+			PKIDPedido:     input.PedidoId,
+			PKIDProducto:   d.PKIDProducto,
+			CANTIDAD:       d.CANTIDAD,
+			PRECIOUNITARIO: d.PRECIOUNITARIO,
+			SUBTOTAL:       d.SUBTOTAL,
+		}
+		if _, err := o.Insert(&detalle); err != nil {
+			c.Data["json"] = models.ApiResponse{
+				Code:    http.StatusInternalServerError,
+				Message: "Error al crear el pedido con productos",
+				Cause:   err.Error(),
+			}
+			c.ServeJSON()
+			return
+		}
+		productoPedido.Detalles = append(productoPedido.Detalles, detalle)
 	}
 
 	c.Data["json"] = models.ApiResponse{
@@ -215,7 +213,7 @@ func (c *ProductoPedidoController) Update() {
 	}
 
 	// Parsear los datos del cuerpo de la solicitud
-	var nuevosProductos []map[string]interface{}
+	var nuevosProductos []models.ProductoPedidoDetalle
 	if err := json.Unmarshal(c.Ctx.Input.RequestBody, &nuevosProductos); err != nil {
 		c.Data["json"] = models.ApiResponse{
 			Code:    http.StatusBadRequest,
@@ -259,21 +257,9 @@ func (c *ProductoPedidoController) Update() {
 		return
 	}
 
-	// Convertir la nueva lista de productos a JSON
-	nuevosDetallesJSON, err := json.Marshal(nuevosProductos)
-	if err != nil {
-		c.Data["json"] = models.ApiResponse{
-			Code:    http.StatusInternalServerError,
-			Message: "Error al procesar los detalles actualizados",
-			Cause:   err.Error(),
-		}
-		c.ServeJSON()
-		return
-	}
-
-	// Actualizar los detalles en la base de datos
-	productoPedido.DETALLES_PRODUCTOS = string(nuevosDetallesJSON)
-	if _, err := o.Update(&productoPedido, "DETALLES_PRODUCTOS"); err != nil {
+	if _, err := o.QueryTable(new(models.ProductoPedidoDetalle)).
+		Filter("PK_ID_PEDIDO", pedidoID).
+		Delete(); err != nil {
 		c.Data["json"] = models.ApiResponse{
 			Code:    http.StatusInternalServerError,
 			Message: "Error al actualizar los productos del pedido",
@@ -281,6 +267,26 @@ func (c *ProductoPedidoController) Update() {
 		}
 		c.ServeJSON()
 		return
+	}
+
+	for _, d := range nuevosProductos {
+		detalle := models.ProductoPedidoDetalle{
+			PKIDPedido:     pedidoID,
+			PKIDProducto:   d.PKIDProducto,
+			CANTIDAD:       d.CANTIDAD,
+			PRECIOUNITARIO: d.PRECIOUNITARIO,
+			SUBTOTAL:       d.SUBTOTAL,
+		}
+		if _, err := o.Insert(&detalle); err != nil {
+			c.Data["json"] = models.ApiResponse{
+				Code:    http.StatusInternalServerError,
+				Message: "Error al actualizar los productos del pedido",
+				Cause:   err.Error(),
+			}
+			c.ServeJSON()
+			return
+		}
+		productoPedido.Detalles = append(productoPedido.Detalles, detalle)
 	}
 
 	c.Data["json"] = models.ApiResponse{

--- a/controllers/producto_pedido_controller_test.go
+++ b/controllers/producto_pedido_controller_test.go
@@ -15,10 +15,22 @@ import (
 type fakeQueryPP struct {
 	orm.QuerySeter
 	one func(interface{}, ...string) error
+	all func(interface{}, ...string) (int64, error)
 }
 
 func (f fakeQueryPP) Filter(string, ...interface{}) orm.QuerySeter { return f }
-func (f fakeQueryPP) One(res interface{}, cols ...string) error    { return f.one(res, cols...) }
+func (f fakeQueryPP) One(res interface{}, cols ...string) error {
+	if f.one != nil {
+		return f.one(res, cols...)
+	}
+	return nil
+}
+func (f fakeQueryPP) All(res interface{}, cols ...string) (int64, error) {
+	if f.all != nil {
+		return f.all(res, cols...)
+	}
+	return 0, nil
+}
 
 type fakeOrmerPP struct {
 	query  func(interface{}) orm.QuerySeter
@@ -100,7 +112,7 @@ func TestProductoPedidoPostInvalidJSON(t *testing.T) {
 }
 
 func TestProductoPedidoPostMissingFields(t *testing.T) {
-	body := `{"pedidoId":0,"detallesProductos":[]}`
+	body := `{"pedidoId":0,"detalles":[]}`
 	r := httptest.NewRequest(http.MethodPost, "/producto_pedido", strings.NewReader(body))
 	r.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
@@ -122,7 +134,7 @@ func TestProductoPedidoPostMissingFields(t *testing.T) {
 }
 
 func TestProductoPedidoPostDBError(t *testing.T) {
-	body := `{"pedidoId":1,"detallesProductos":[{"productoId":1,"cantidad":1}]}`
+	body := `{"pedidoId":1,"detalles":[{"productoId":1,"cantidad":1}]}`
 	r := httptest.NewRequest(http.MethodPost, "/producto_pedido", strings.NewReader(body))
 	r.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
@@ -233,13 +245,23 @@ func TestProductoPedidoUpdateDBError(t *testing.T) {
 func TestProductoPedidoGetAllSuccess(t *testing.T) {
 	original := productoPedidoNewOrm
 	productoPedidoNewOrm = func() productoPedidoOrmer {
-		return fakeOrmerPP{query: func(interface{}) orm.QuerySeter {
-			return fakeQueryPP{one: func(res interface{}, cols ...string) error {
-				pp := res.(*models.ProductoPedido)
-				pp.PK_ID_PEDIDO = 1
-				pp.DETALLES_PRODUCTOS = `[{"PK_ID_PRODUCTO":1,"NOMBRE":"Cafe","CANTIDAD":1,"PRECIO_UNITARIO":10,"SUBTOTAL":10}]`
-				return nil
-			}}
+		return fakeOrmerPP{query: func(i interface{}) orm.QuerySeter {
+			switch i.(type) {
+			case *models.ProductoPedido:
+				return fakeQueryPP{one: func(res interface{}, cols ...string) error {
+					pp := res.(*models.ProductoPedido)
+					pp.PK_ID_PEDIDO = 1
+					return nil
+				}}
+			case *models.ProductoPedidoDetalle:
+				return fakeQueryPP{all: func(res interface{}, cols ...string) (int64, error) {
+					detalles := res.(*[]models.ProductoPedidoDetalle)
+					*detalles = append(*detalles, models.ProductoPedidoDetalle{PKIDPedido: 1, PKIDProducto: 1, CANTIDAD: 1})
+					return 1, nil
+				}}
+			default:
+				return fakeQueryPP{}
+			}
 		}}
 	}
 	defer func() { productoPedidoNewOrm = original }()
@@ -257,7 +279,7 @@ func TestProductoPedidoGetAllSuccess(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected status 200, got %d", w.Code)
 	}
-	if !strings.Contains(w.Body.String(), "detallesProductos") {
+	if !strings.Contains(w.Body.String(), "detalles") {
 		t.Errorf("unexpected body: %s", w.Body.String())
 	}
 }
@@ -269,7 +291,7 @@ func TestProductoPedidoPostSuccess(t *testing.T) {
 	}
 	defer func() { productoPedidoNewOrm = original }()
 
-	body := `{"pedidoId":1,"detallesProductos":[{"productoId":1,"cantidad":1}]}`
+	body := `{"pedidoId":1,"detalles":[{"productoId":1,"cantidad":1}]}`
 	r := httptest.NewRequest(http.MethodPost, "/producto_pedido", strings.NewReader(body))
 	r.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()

--- a/models/ProductoPedido.go
+++ b/models/ProductoPedido.go
@@ -3,9 +3,9 @@ package models
 import "github.com/beego/beego/v2/client/orm"
 
 type ProductoPedido struct {
-	PK_ID_PRODUCTO_PEDIDO int64  `orm:"column(PK_ID_PRODUCTO_PEDIDO);pk;auto" json:"productoPedidoId"`
-	DETALLES_PRODUCTOS    string `orm:"column(DETALLES_PRODUCTOS);type(jsonb)" json:"detallesProductos"`
-	PK_ID_PEDIDO          int64  `orm:"column(PK_ID_PEDIDO)" json:"pedidoId"`
+	PK_ID_PRODUCTO_PEDIDO int64                   `orm:"column(PK_ID_PRODUCTO_PEDIDO);pk;auto" json:"productoPedidoId"`
+	PK_ID_PEDIDO          int64                   `orm:"column(PK_ID_PEDIDO)" json:"pedidoId"`
+	Detalles              []ProductoPedidoDetalle `orm:"-" json:"detalles,omitempty"`
 }
 
 func (p *ProductoPedido) TableName() string {


### PR DESCRIPTION
## Summary
- drop DETALLES_PRODUCTOS JSON column and add Detalles slice in ProductoPedido model
- query PRODUCTO_PEDIDO_DETALLE records for listing, creating and updating productos
- replace JSON extraction with joins to PRODUCTO_PEDIDO_DETALLE in Domicilio and Pedido controllers

## Testing
- `go test ./controllers -run ProductoPedido -count=1 -v` *(fails: Trabajador has no field or method HORARIO)*

------
https://chatgpt.com/codex/tasks/task_e_68b234ed206c8325aca8f26db96a3d8d