### PR TITLE
Refactor ProductoPedidoDetalle model to use composite key

### DIFF
--- a/models/ProductoPedidoDetalle.go
+++ b/models/ProductoPedidoDetalle.go
@@ -4,12 +4,10 @@ import "github.com/beego/beego/v2/client/orm"
 
 // ProductoPedidoDetalle representa cada producto asociado a un pedido.
 type ProductoPedidoDetalle struct {
-	PKIDProductoPedidoDetalle int64   `orm:"column(PK_ID_PRODUCTO_PEDIDO_DETALLE);pk;auto" json:"detalleId"`
-	PKIDPedido                int64   `orm:"column(PK_ID_PEDIDO)" json:"pedidoId"`
-	PKIDProducto              int64   `orm:"column(PK_ID_PRODUCTO)" json:"productoId"`
-	CANTIDAD                  int     `orm:"column(CANTIDAD)" json:"cantidad"`
-	PRECIOUNITARIO            float64 `orm:"column(PRECIO_UNITARIO);null" json:"precioUnitario,omitempty"`
-	SUBTOTAL                  float64 `orm:"column(SUBTOTAL);null" json:"subtotal,omitempty"`
+	PKIDProductoPedido int64   `orm:"column(PK_ID_PRODUCTO_PEDIDO);pk" json:"productoPedidoId"`
+	PKIDProducto       int64   `orm:"column(PK_ID_PRODUCTO);pk" json:"productoId"`
+	CANTIDAD           int     `orm:"column(CANTIDAD)" json:"cantidad"`
+	PRECIO             float64 `orm:"column(PRECIO);null" json:"precio,omitempty"`
 }
 
 // TableName especifica el nombre de la tabla en la base de datos.

--- a/tests/seed_data.go
+++ b/tests/seed_data.go
@@ -16,11 +16,10 @@ func SeedTestData() {
 	}
 
 	if _, err := o.Insert(&models.ProductoPedidoDetalle{
-		PKIDPedido:     1,
-		PKIDProducto:   1,
-		CANTIDAD:       1,
-		PRECIOUNITARIO: 1000,
-		SUBTOTAL:       1000,
+		PKIDProductoPedido: 1,
+		PKIDProducto:       1,
+		CANTIDAD:           1,
+		PRECIO:             1000,
 	}); err != nil {
 		log.Println("seed PRODUCTO_PEDIDO_DETALLE:", err)
 	}


### PR DESCRIPTION
## Summary
- refactor `ProductoPedidoDetalle` to use composite primary key and unified `PRECIO` field
- update seed data for new model layout

## Testing
- `go build ./models`
- `go test ./...` *(fails: command hung and was interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68b234ed72e883259fa76066f7878d8e