### PR TITLE
Refactor pedido product details into relational table

### DIFF
--- a/controllers/DomicilioController.go
+++ b/controllers/DomicilioController.go
@@ -161,13 +161,12 @@ LIMIT 1;`
 
 	cliErr := o.Raw(qCliente, id).QueryRow(&cli)
 
-	// 3) Pedido asociado — también UN struct
+	// 3) Pedido asociado y productos
 	type pedidoRow struct {
 		PedidoID          int64           `orm:"column(pedido_id)"`
 		PagoID            sql.NullInt64   `orm:"column(pago_id)"`
 		PagoMonto         sql.NullFloat64 `orm:"column(pago_monto)"`
 		SubtotalProductos sql.NullFloat64 `orm:"column(subtotal_productos)"`
-		Productos         string          `orm:"column(productos)"` // json string
 	}
 	var ped pedidoRow
 
@@ -176,29 +175,49 @@ SELECT
   p."PK_ID_PEDIDO" AS pedido_id,
   pa."PK_ID_PAGO"  AS pago_id,
   pa."MONTO"::numeric AS pago_monto,
-  (
-    SELECT COALESCE(SUM((elem->>'SUBTOTAL')::numeric), 0)
-    FROM (
-      SELECT jsonb_array_elements(pp."DETALLES_PRODUCTOS") AS elem
-      FROM "PRODUCTO_PEDIDO" pp
-      WHERE pp."PK_ID_PEDIDO" = p."PK_ID_PEDIDO"
-    ) s
-  ) AS subtotal_productos,
-  (
-    SELECT COALESCE(jsonb_agg(elem), '[]'::jsonb)::text
-    FROM (
-      SELECT jsonb_array_elements(pp."DETALLES_PRODUCTOS") AS elem
-      FROM "PRODUCTO_PEDIDO" pp
-      WHERE pp."PK_ID_PEDIDO" = p."PK_ID_PEDIDO"
-    ) s
-  ) AS productos
+  COALESCE(SUM(ppd."SUBTOTAL"),0) AS subtotal_productos
 FROM "PEDIDO" p
 LEFT JOIN "PAGO" pa ON pa."PK_ID_PAGO" = p."PK_ID_PAGO"
+LEFT JOIN "PRODUCTO_PEDIDO_DETALLE" ppd ON ppd."PK_ID_PEDIDO" = p."PK_ID_PEDIDO"
 WHERE p."PK_ID_DOMICILIO" = ?
+GROUP BY p."PK_ID_PEDIDO", pa."PK_ID_PAGO", pa."MONTO"
 ORDER BY p."PK_ID_PEDIDO" DESC
 LIMIT 1;`
 
 	pedErr := o.Raw(qPedido, id).QueryRow(&ped)
+
+	var productos []map[string]interface{}
+	if pedErr == nil {
+		type prodRow struct {
+			ProductoID     int64   `orm:"column(producto_id)"`
+			Nombre         string  `orm:"column(nombre)"`
+			Cantidad       int     `orm:"column(cantidad)"`
+			PrecioUnitario float64 `orm:"column(precio_unitario)"`
+			Subtotal       float64 `orm:"column(subtotal)"`
+		}
+		var prodRows []prodRow
+		qProductos := `
+SELECT pr."PK_ID_PRODUCTO" AS producto_id,
+       pr."NOMBRE" AS nombre,
+       ppd."CANTIDAD" AS cantidad,
+       ppd."PRECIO_UNITARIO" AS precio_unitario,
+       ppd."SUBTOTAL" AS subtotal
+FROM "PEDIDO" p
+JOIN "PRODUCTO_PEDIDO_DETALLE" ppd ON ppd."PK_ID_PEDIDO" = p."PK_ID_PEDIDO"
+JOIN "PRODUCTO" pr ON pr."PK_ID_PRODUCTO" = ppd."PK_ID_PRODUCTO"
+WHERE p."PK_ID_DOMICILIO" = ?
+ORDER BY p."PK_ID_PEDIDO" DESC`
+		_, _ = o.Raw(qProductos, id).QueryRows(&prodRows)
+		for _, r := range prodRows {
+			productos = append(productos, map[string]interface{}{
+				"productoId":     r.ProductoID,
+				"nombre":         r.Nombre,
+				"cantidad":       r.Cantidad,
+				"precioUnitario": r.PrecioUnitario,
+				"subtotal":       r.Subtotal,
+			})
+		}
+	}
 
 	// 4) Construir respuesta
 	resp := map[string]interface{}{
@@ -214,13 +233,6 @@ LIMIT 1;`
 	}
 
 	if pedErr == nil {
-		// Parsear productos
-		var productos []map[string]interface{}
-		if ped.Productos != "" {
-			_ = json.Unmarshal([]byte(ped.Productos), &productos)
-		}
-
-		// Total: prioriza pago; si no hay, usa subtotal de productos
 		total := 0.0
 		if ped.PagoMonto.Valid {
 			total = ped.PagoMonto.Float64
@@ -236,9 +248,9 @@ LIMIT 1;`
 
 		resp["pedido"] = map[string]interface{}{
 			"pedidoId":          ped.PedidoID,
-			"pagoId":            pagoIdPtr,                     // puede ser null
-			"montoPago":         ped.PagoMonto.Float64,         // 0 si null
-			"subtotalProductos": ped.SubtotalProductos.Float64, // 0 si null
+			"pagoId":            pagoIdPtr,
+			"montoPago":         ped.PagoMonto.Float64,
+			"subtotalProductos": ped.SubtotalProductos.Float64,
 			"total":             total,
 			"productos":         productos,
 		}

--- a/controllers/PedidoController.go
+++ b/controllers/PedidoController.go
@@ -351,7 +351,6 @@ func (c *PedidoController) UpdateEstadoPedido() {
 func (c *PedidoController) GetPedidoDetails() {
 	o := orm.NewOrm()
 
-	// Parámetro
 	pedidoID, _ := c.GetInt64("pedido_id")
 	if pedidoID == 0 {
 		c.Data["json"] = models.ApiResponse{
@@ -362,8 +361,22 @@ func (c *PedidoController) GetPedidoDetails() {
 		return
 	}
 
-	// Consulta para obtener detalles del pedido
-	query := `
+	// Información base del pedido
+	type pedidoRow struct {
+		PedidoID         int64  `orm:"column(pk_id_pedido)"`
+		Fecha            string `orm:"column(fecha)"`
+		Hora             string `orm:"column(hora)"`
+		Delivery         bool   `orm:"column(delivery)"`
+		EstadoPedido     string `orm:"column(estado_pedido)"`
+		MetodoPago       string `orm:"column(metodo_pago)"`
+		PagoID           int64  `orm:"column(pago_id)"`
+		MetodoPagoID     int64  `orm:"column(metodo_pago_id)"`
+		DomicilioID      int64  `orm:"column(domicilio_id)"`
+		DocumentoCliente int64  `orm:"column(documento_cliente)"`
+	}
+
+	var base pedidoRow
+	baseQuery := `
 SELECT
     p."PK_ID_PEDIDO"                                   AS pk_id_pedido,
     COALESCE(TO_CHAR(p."FECHA", 'YYYY-MM-DD'), '')     AS fecha,
@@ -371,14 +384,6 @@ SELECT
     COALESCE(p."DELIVERY", false)                      AS delivery,
     COALESCE(p."ESTADO_PEDIDO", '')                    AS estado_pedido,
     COALESCE(mp."TIPO", '')                            AS metodo_pago,
-    COALESCE((
-        SELECT jsonb_agg(elementos)::text
-        FROM (
-            SELECT jsonb_array_elements(pp."DETALLES_PRODUCTOS") AS elementos
-            FROM "PRODUCTO_PEDIDO" pp
-            WHERE pp."PK_ID_PEDIDO" = p."PK_ID_PEDIDO"
-        ) subq
-    ), '[]')                                           AS productos,
     COALESCE(p."PK_ID_PAGO", 0)                        AS pago_id,
     COALESCE(pa."PK_ID_METODO_PAGO", 0)                AS metodo_pago_id,
     COALESCE(p."PK_ID_DOMICILIO", 0)                   AS domicilio_id,
@@ -387,13 +392,37 @@ FROM "PEDIDO" p
 LEFT JOIN "PAGO" pa        ON p."PK_ID_PAGO" = pa."PK_ID_PAGO"
 LEFT JOIN "METODO_PAGO" mp ON pa."PK_ID_METODO_PAGO" = mp."PK_ID_METODO_PAGO"
 LEFT JOIN "PEDIDO_CLIENTE" pc ON p."PK_ID_PEDIDO" = pc."PK_ID_PEDIDO"
-WHERE p."PK_ID_PEDIDO" = ?;
-    `
+WHERE p."PK_ID_PEDIDO" = ?`
 
-	var details models.PedidoDetails
+	if err := o.Raw(baseQuery, pedidoID).QueryRow(&base); err != nil {
+		c.Data["json"] = models.ApiResponse{
+			Code:    500,
+			Message: "Error al obtener los detalles del pedido",
+			Cause:   err.Error(),
+		}
+		c.ServeJSON()
+		return
+	}
 
-	// Ejecutar consulta
-	err := o.Raw(query, pedidoID).QueryRow(&details)
+	type prodRow struct {
+		ProductoID     int64   `orm:"column(producto_id)"`
+		Nombre         string  `orm:"column(nombre)"`
+		Cantidad       int     `orm:"column(cantidad)"`
+		PrecioUnitario float64 `orm:"column(precio_unitario)"`
+		Subtotal       float64 `orm:"column(subtotal)"`
+	}
+
+	var prodRows []prodRow
+	_, err := o.Raw(`
+SELECT pr."PK_ID_PRODUCTO" AS producto_id,
+       pr."NOMBRE" AS nombre,
+       ppd."CANTIDAD" AS cantidad,
+       ppd."PRECIO_UNITARIO" AS precio_unitario,
+       ppd."SUBTOTAL" AS subtotal
+FROM "PRODUCTO_PEDIDO" pp
+JOIN "PRODUCTO_PEDIDO_DETALLE" ppd ON pp."PK_ID_PEDIDO" = ppd."PK_ID_PEDIDO"
+JOIN "PRODUCTO" pr ON pr."PK_ID_PRODUCTO" = ppd."PK_ID_PRODUCTO"
+WHERE pp."PK_ID_PEDIDO" = ?`, pedidoID).QueryRows(&prodRows)
 	if err != nil {
 		c.Data["json"] = models.ApiResponse{
 			Code:    500,
@@ -404,11 +433,35 @@ WHERE p."PK_ID_PEDIDO" = ?;
 		return
 	}
 
-	// Respuesta exitosa
+	productos := make([]map[string]interface{}, 0, len(prodRows))
+	for _, r := range prodRows {
+		productos = append(productos, map[string]interface{}{
+			"productoId":     r.ProductoID,
+			"nombre":         r.Nombre,
+			"cantidad":       r.Cantidad,
+			"precioUnitario": r.PrecioUnitario,
+			"subtotal":       r.Subtotal,
+		})
+	}
+
+	resp := map[string]interface{}{
+		"pedidoId":         base.PedidoID,
+		"fechaPedido":      base.Fecha,
+		"horaPedido":       base.Hora,
+		"delivery":         base.Delivery,
+		"estadoPedido":     base.EstadoPedido,
+		"metodoPago":       base.MetodoPago,
+		"pagoId":           base.PagoID,
+		"metodoPagoId":     base.MetodoPagoID,
+		"domicilioId":      base.DomicilioID,
+		"documentoCliente": base.DocumentoCliente,
+		"productos":        productos,
+	}
+
 	c.Data["json"] = models.ApiResponse{
 		Code:    200,
 		Message: "Detalles del pedido obtenidos exitosamente",
-		Data:    details,
+		Data:    resp,
 	}
 	c.ServeJSON()
 }

--- a/controllers/ProductoPedidoController.go
+++ b/controllers/ProductoPedidoController.go
@@ -9,23 +9,8 @@ import (
 	"github.com/beego/beego/v2/server/web"
 )
 
-type productoPedidoOrmer interface {
-	QueryTable(interface{}) orm.QuerySeter
-	Insert(interface{}) (int64, error)
-	Update(interface{}, ...string) (int64, error)
-}
-
-// productoPedidoNewOrm allows tests to stub orm.NewOrm.
-var productoPedidoNewOrm = func() productoPedidoOrmer { return orm.NewOrm() }
-
 type ProductoPedidoController struct {
 	web.Controller
-}
-
-// Estructura para mapear las respuestas en camelCase
-type ProductoPedidoResponse struct {
-	PedidoID          int64       `json:"pedidoId"`
-	DetallesProductos interface{} `json:"detallesProductos"`
 }
 
 // @Title GetAll
@@ -51,21 +36,28 @@ func (c *ProductoPedidoController) GetAll() {
 		return
 	}
 
-	o := productoPedidoNewOrm()
-	var productoPedido models.ProductoPedido
+	o := orm.NewOrm()
 
-	err = o.QueryTable(new(models.ProductoPedido)).
-		Filter("PK_ID_PEDIDO", pedidoID).
-		One(&productoPedido)
+	type detalleRow struct {
+		ProductoID     int64   `orm:"column(producto_id)"`
+		Nombre         string  `orm:"column(nombre)"`
+		Cantidad       int     `orm:"column(cantidad)"`
+		PrecioUnitario float64 `orm:"column(precio_unitario)"`
+		Subtotal       float64 `orm:"column(subtotal)"`
+	}
 
-	if err == orm.ErrNoRows {
-		c.Data["json"] = models.ApiResponse{
-			Code:    http.StatusNotFound,
-			Message: "No se encontraron productos asociados a este pedido",
-		}
-		c.ServeJSON()
-		return
-	} else if err != nil {
+	var rows []detalleRow
+	count, err := o.Raw(`
+SELECT pr."PK_ID_PRODUCTO" AS producto_id,
+       pr."NOMBRE" AS nombre,
+       ppd."CANTIDAD" AS cantidad,
+       ppd."PRECIO_UNITARIO" AS precio_unitario,
+       ppd."SUBTOTAL" AS subtotal
+FROM "PRODUCTO_PEDIDO" pp
+JOIN "PRODUCTO_PEDIDO_DETALLE" ppd ON pp."PK_ID_PEDIDO" = ppd."PK_ID_PEDIDO"
+JOIN "PRODUCTO" pr ON pr."PK_ID_PRODUCTO" = ppd."PK_ID_PRODUCTO"
+WHERE pp."PK_ID_PEDIDO" = ?`, pedidoID).QueryRows(&rows)
+	if err != nil {
 		c.Data["json"] = models.ApiResponse{
 			Code:    http.StatusInternalServerError,
 			Message: "Error al obtener los productos del pedido",
@@ -74,36 +66,29 @@ func (c *ProductoPedidoController) GetAll() {
 		c.ServeJSON()
 		return
 	}
-
-	// Convertir el JSONB a un formato de salida legible
-	var detalles []map[string]interface{}
-	if err := json.Unmarshal([]byte(productoPedido.DETALLES_PRODUCTOS), &detalles); err != nil {
+	if count == 0 {
 		c.Data["json"] = models.ApiResponse{
-			Code:    http.StatusInternalServerError,
-			Message: "Error al procesar los detalles del pedido",
-			Cause:   err.Error(),
+			Code:    http.StatusNotFound,
+			Message: "No se encontraron productos asociados a este pedido",
 		}
 		c.ServeJSON()
 		return
 	}
 
-	// Transformar las claves de los detalles a camelCase
-	var detallesCamelCase []map[string]interface{}
-	for _, detalle := range detalles {
-		camelCaseDetalle := map[string]interface{}{
-			"cantidad":       detalle["CANTIDAD"],
-			"nombre":         detalle["NOMBRE"],
-			"productoId":     detalle["PK_ID_PRODUCTO"],
-			"precioUnitario": detalle["PRECIO_UNITARIO"],
-			"subtotal":       detalle["SUBTOTAL"],
-		}
-		detallesCamelCase = append(detallesCamelCase, camelCaseDetalle)
+	detalles := make([]map[string]interface{}, 0, len(rows))
+	for _, r := range rows {
+		detalles = append(detalles, map[string]interface{}{
+			"productoId":     r.ProductoID,
+			"nombre":         r.Nombre,
+			"cantidad":       r.Cantidad,
+			"precioUnitario": r.PrecioUnitario,
+			"subtotal":       r.Subtotal,
+		})
 	}
 
-	// Construir la respuesta
 	response := map[string]interface{}{
-		"pedidoId":          productoPedido.PK_ID_PEDIDO,
-		"detallesProductos": detallesCamelCase,
+		"pedidoId":          pedidoID,
+		"detallesProductos": detalles,
 	}
 
 	c.Data["json"] = models.ApiResponse{
@@ -116,7 +101,7 @@ func (c *ProductoPedidoController) GetAll() {
 
 // @Title Post
 // @Summary Crear un pedido con productos consolidados
-// @Description Crea un registro de productos consolidados en un pedido
+// @Description Crea registros de productos asociados a un pedido
 // @Tags producto_pedido
 // @Accept json
 // @Produce json
@@ -128,8 +113,8 @@ func (c *ProductoPedidoController) GetAll() {
 // @Router /producto_pedido [post]
 func (c *ProductoPedidoController) Post() {
 	var input struct {
-		PedidoId          int64                    `json:"pedidoId"`
-		DetallesProductos []map[string]interface{} `json:"detallesProductos"`
+		PedidoId          int64                          `json:"pedidoId"`
+		DetallesProductos []models.ProductoPedidoDetalle `json:"detallesProductos"`
 	}
 
 	if err := json.Unmarshal(c.Ctx.Input.RequestBody, &input); err != nil {
@@ -142,7 +127,6 @@ func (c *ProductoPedidoController) Post() {
 		return
 	}
 
-	// Validar que se proporcione el pedido y los detalles
 	if input.PedidoId == 0 || len(input.DetallesProductos) == 0 {
 		c.Data["json"] = models.ApiResponse{
 			Code:    http.StatusBadRequest,
@@ -152,26 +136,46 @@ func (c *ProductoPedidoController) Post() {
 		return
 	}
 
-	// Convertir los detalles a JSON
-	detallesJSON, err := json.Marshal(input.DetallesProductos)
+	o := orm.NewOrm()
+	tx, err := o.Begin()
 	if err != nil {
 		c.Data["json"] = models.ApiResponse{
 			Code:    http.StatusInternalServerError,
-			Message: "Error al procesar los detalles del pedido",
+			Message: "Error al iniciar la transacción",
 			Cause:   err.Error(),
 		}
 		c.ServeJSON()
 		return
 	}
 
-	productoPedido := models.ProductoPedido{
-		PK_ID_PEDIDO:       input.PedidoId,
-		DETALLES_PRODUCTOS: string(detallesJSON),
+	pp := models.ProductoPedido{PK_ID_PEDIDO: input.PedidoId, DETALLES_PRODUCTOS: "[]"}
+	if _, err := tx.Insert(&pp); err != nil {
+		_ = tx.Rollback()
+		c.Data["json"] = models.ApiResponse{
+			Code:    http.StatusInternalServerError,
+			Message: "Error al crear el pedido con productos",
+			Cause:   err.Error(),
+		}
+		c.ServeJSON()
+		return
 	}
 
-	o := productoPedidoNewOrm()
-	_, err = o.Insert(&productoPedido)
-	if err != nil {
+	for _, d := range input.DetallesProductos {
+		d.PKIDPedido = input.PedidoId
+		if _, err := tx.Insert(&d); err != nil {
+			_ = tx.Rollback()
+			c.Data["json"] = models.ApiResponse{
+				Code:    http.StatusInternalServerError,
+				Message: "Error al crear el pedido con productos",
+				Cause:   err.Error(),
+			}
+			c.ServeJSON()
+			return
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		_ = tx.Rollback()
 		c.Data["json"] = models.ApiResponse{
 			Code:    http.StatusInternalServerError,
 			Message: "Error al crear el pedido con productos",
@@ -184,7 +188,7 @@ func (c *ProductoPedidoController) Post() {
 	c.Data["json"] = models.ApiResponse{
 		Code:    http.StatusCreated,
 		Message: "Pedido con productos agregado exitosamente",
-		Data:    productoPedido,
+		Data:    map[string]interface{}{"pedidoId": input.PedidoId},
 	}
 	c.ServeJSON()
 }
@@ -214,8 +218,7 @@ func (c *ProductoPedidoController) Update() {
 		return
 	}
 
-	// Parsear los datos del cuerpo de la solicitud
-	var nuevosProductos []map[string]interface{}
+	var nuevosProductos []models.ProductoPedidoDetalle
 	if err := json.Unmarshal(c.Ctx.Input.RequestBody, &nuevosProductos); err != nil {
 		c.Data["json"] = models.ApiResponse{
 			Code:    http.StatusBadRequest,
@@ -225,7 +228,6 @@ func (c *ProductoPedidoController) Update() {
 		c.ServeJSON()
 		return
 	}
-
 	if len(nuevosProductos) == 0 {
 		c.Data["json"] = models.ApiResponse{
 			Code:    http.StatusBadRequest,
@@ -235,45 +237,64 @@ func (c *ProductoPedidoController) Update() {
 		return
 	}
 
-	o := productoPedidoNewOrm()
-	productoPedido := models.ProductoPedido{}
-
-	// Verificar si existe el pedido en la base de datos
-	err = o.QueryTable(new(models.ProductoPedido)).
-		Filter("PK_ID_PEDIDO", pedidoID).
-		One(&productoPedido)
-	if err == orm.ErrNoRows {
-		c.Data["json"] = models.ApiResponse{
-			Code:    http.StatusNotFound,
-			Message: "Pedido no encontrado",
-		}
-		c.ServeJSON()
-		return
-	} else if err != nil {
-		c.Data["json"] = models.ApiResponse{
-			Code:    http.StatusInternalServerError,
-			Message: "Error al buscar el pedido",
-			Cause:   err.Error(),
+	o := orm.NewOrm()
+	// Verificar existencia del pedido
+	var productoPedido models.ProductoPedido
+	if err := o.QueryTable(new(models.ProductoPedido)).Filter("PK_ID_PEDIDO", pedidoID).One(&productoPedido); err != nil {
+		if err == orm.ErrNoRows {
+			c.Data["json"] = models.ApiResponse{
+				Code:    http.StatusNotFound,
+				Message: "Pedido no encontrado",
+			}
+		} else {
+			c.Data["json"] = models.ApiResponse{
+				Code:    http.StatusInternalServerError,
+				Message: "Error al buscar el pedido",
+				Cause:   err.Error(),
+			}
 		}
 		c.ServeJSON()
 		return
 	}
 
-	// Convertir la nueva lista de productos a JSON
-	nuevosDetallesJSON, err := json.Marshal(nuevosProductos)
+	tx, err := o.Begin()
 	if err != nil {
 		c.Data["json"] = models.ApiResponse{
 			Code:    http.StatusInternalServerError,
-			Message: "Error al procesar los detalles actualizados",
+			Message: "Error al iniciar la transacción",
 			Cause:   err.Error(),
 		}
 		c.ServeJSON()
 		return
 	}
 
-	// Actualizar los detalles en la base de datos
-	productoPedido.DETALLES_PRODUCTOS = string(nuevosDetallesJSON)
-	if _, err := o.Update(&productoPedido, "DETALLES_PRODUCTOS"); err != nil {
+	if _, err := tx.Raw(`DELETE FROM "PRODUCTO_PEDIDO_DETALLE" WHERE "PK_ID_PEDIDO" = ?`, pedidoID).Exec(); err != nil {
+		_ = tx.Rollback()
+		c.Data["json"] = models.ApiResponse{
+			Code:    http.StatusInternalServerError,
+			Message: "Error al actualizar los productos del pedido",
+			Cause:   err.Error(),
+		}
+		c.ServeJSON()
+		return
+	}
+
+	for _, d := range nuevosProductos {
+		d.PKIDPedido = pedidoID
+		if _, err := tx.Insert(&d); err != nil {
+			_ = tx.Rollback()
+			c.Data["json"] = models.ApiResponse{
+				Code:    http.StatusInternalServerError,
+				Message: "Error al actualizar los productos del pedido",
+				Cause:   err.Error(),
+			}
+			c.ServeJSON()
+			return
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		_ = tx.Rollback()
 		c.Data["json"] = models.ApiResponse{
 			Code:    http.StatusInternalServerError,
 			Message: "Error al actualizar los productos del pedido",

--- a/controllers/controller_test_utils_test.go
+++ b/controllers/controller_test_utils_test.go
@@ -1,13 +1,13 @@
 package controllers
 
 import (
-        "context"
-        "database/sql"
-        "database/sql/driver"
-        "errors"
-        "io"
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"io"
 
-        "github.com/beego/beego/v2/client/orm"
+	"github.com/beego/beego/v2/client/orm"
 )
 
 type mockDriver struct{}
@@ -17,9 +17,9 @@ func (d mockDriver) Open(name string) (driver.Conn, error) {
 }
 
 var (
-        // MockExec and MockQuery allow tests to override database behaviour.
-        MockExec  func(ctx context.Context, query string, args []driver.NamedValue) (driver.Result, error)
-        MockQuery func(ctx context.Context, query string, args []driver.NamedValue) (driver.Rows, error)
+	// MockExec and MockQuery allow tests to override database behaviour.
+	MockExec  func(ctx context.Context, query string, args []driver.NamedValue) (driver.Result, error)
+	MockQuery func(ctx context.Context, query string, args []driver.NamedValue) (driver.Rows, error)
 )
 
 type mockConn struct{}
@@ -27,26 +27,32 @@ type mockConn struct{}
 func (c *mockConn) Prepare(query string) (driver.Stmt, error) {
 	return nil, errors.New("not implemented")
 }
-func (c *mockConn) Close() error              { return nil }
-func (c *mockConn) Begin() (driver.Tx, error) { return nil, errors.New("not implemented") }
+func (c *mockConn) Close() error { return nil }
+
+type mockTx struct{}
+
+func (mockTx) Commit() error   { return nil }
+func (mockTx) Rollback() error { return nil }
+
+func (c *mockConn) Begin() (driver.Tx, error) { return mockTx{}, nil }
 func (c *mockConn) ExecContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
-        if MockExec != nil {
-                return MockExec(ctx, query, args)
-        }
-        return nil, errors.New("mock exec error")
+	if MockExec != nil {
+		return MockExec(ctx, query, args)
+	}
+	return nil, errors.New("mock exec error")
 }
 func (c *mockConn) QueryContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
-        if MockQuery != nil {
-                return MockQuery(ctx, query, args)
-        }
-        return nil, errors.New("mock query error")
+	if MockQuery != nil {
+		return MockQuery(ctx, query, args)
+	}
+	return nil, errors.New("mock query error")
 }
 func (c *mockConn) Ping(ctx context.Context) error { return nil }
 
 func init() {
-        sql.Register("mock", mockDriver{})
-        orm.RegisterDriver("mock", orm.DRPostgres)
-        orm.RegisterDataBase("default", "mock", "")
+	sql.Register("mock", mockDriver{})
+	orm.RegisterDriver("mock", orm.DRPostgres)
+	orm.RegisterDataBase("default", "mock", "")
 }
 
 type mockResult struct{}
@@ -55,21 +61,21 @@ func (mockResult) LastInsertId() (int64, error) { return 1, nil }
 func (mockResult) RowsAffected() (int64, error) { return 1, nil }
 
 type mockRows struct {
-        columns []string
-        values  [][]driver.Value
-        idx     int
+	columns []string
+	values  [][]driver.Value
+	idx     int
 }
 
 func (r *mockRows) Columns() []string { return r.columns }
 func (r *mockRows) Close() error      { return nil }
 func (r *mockRows) Next(dest []driver.Value) error {
-        if r.idx >= len(r.values) {
-                return io.EOF
-        }
-        row := r.values[r.idx]
-        for i, v := range row {
-                dest[i] = v
-        }
-        r.idx++
-        return nil
+	if r.idx >= len(r.values) {
+		return io.EOF
+	}
+	row := r.values[r.idx]
+	for i, v := range row {
+		dest[i] = v
+	}
+	r.idx++
+	return nil
 }

--- a/controllers/pedido_controller_test.go
+++ b/controllers/pedido_controller_test.go
@@ -468,9 +468,16 @@ func TestPedidoUpdateEstadoPedidoSuccess(t *testing.T) {
 }
 
 func TestPedidoGetPedidoDetailsSuccess(t *testing.T) {
+	call := 0
 	MockQuery = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
-		cols := []string{"pk_id_pedido", "fecha", "hora", "delivery", "estado_pedido", "metodo_pago", "productos", "pago_id", "metodo_pago_id", "domicilio_id", "documento_cliente"}
-		vals := [][]driver.Value{{int64(1), "2024-01-01", "12:00:00", false, "TERMINADO", "NEQUI", "[]", int64(2), int64(3), int64(4), int64(5)}}
+		if call == 0 {
+			call++
+			cols := []string{"pk_id_pedido", "fecha", "hora", "delivery", "estado_pedido", "metodo_pago", "pago_id", "metodo_pago_id", "domicilio_id", "documento_cliente"}
+			vals := [][]driver.Value{{int64(1), "2024-01-01", "12:00:00", false, "TERMINADO", "NEQUI", int64(2), int64(3), int64(4), int64(5)}}
+			return &mockRows{columns: cols, values: vals}, nil
+		}
+		cols := []string{"producto_id", "nombre", "cantidad", "precio_unitario", "subtotal"}
+		vals := [][]driver.Value{{int64(1), "Cafe", int64(1), float64(10), float64(10)}}
 		return &mockRows{columns: cols, values: vals}, nil
 	}
 	defer func() { MockQuery = nil }()

--- a/controllers/producto_pedido_controller_test.go
+++ b/controllers/producto_pedido_controller_test.go
@@ -2,48 +2,21 @@ package controllers
 
 import (
 	"bytes"
+	stdctx "context"
+	"database/sql/driver"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
-	"github.com/beego/beego/v2/client/orm"
-	"github.com/beego/beego/v2/server/web/context"
-	"restaurante/models"
+	beegoCtx "github.com/beego/beego/v2/server/web/context"
 )
-
-type fakeQueryPP struct {
-	orm.QuerySeter
-	one func(interface{}, ...string) error
-}
-
-func (f fakeQueryPP) Filter(string, ...interface{}) orm.QuerySeter { return f }
-func (f fakeQueryPP) One(res interface{}, cols ...string) error    { return f.one(res, cols...) }
-
-type fakeOrmerPP struct {
-	query  func(interface{}) orm.QuerySeter
-	insert func(interface{}) (int64, error)
-	update func(interface{}, ...string) (int64, error)
-}
-
-func (f fakeOrmerPP) QueryTable(i interface{}) orm.QuerySeter { return f.query(i) }
-func (f fakeOrmerPP) Insert(m interface{}) (int64, error) {
-	if f.insert != nil {
-		return f.insert(m)
-	}
-	return 1, nil
-}
-func (f fakeOrmerPP) Update(m interface{}, cols ...string) (int64, error) {
-	if f.update != nil {
-		return f.update(m, cols...)
-	}
-	return 1, nil
-}
 
 func TestProductoPedidoGetAllMissingParam(t *testing.T) {
 	r := httptest.NewRequest(http.MethodGet, "/producto_pedido", nil)
 	w := httptest.NewRecorder()
-	ctx := context.NewContext()
+	ctx := beegoCtx.NewContext()
 	ctx.Reset(w, r)
 	c := ProductoPedidoController{}
 	c.Ctx = ctx
@@ -60,9 +33,14 @@ func TestProductoPedidoGetAllMissingParam(t *testing.T) {
 }
 
 func TestProductoPedidoGetAllDBError(t *testing.T) {
+	MockQuery = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
+		return nil, errors.New("db error")
+	}
+	defer func() { MockQuery = nil }()
+
 	r := httptest.NewRequest(http.MethodGet, "/producto_pedido?pedido_id=1", nil)
 	w := httptest.NewRecorder()
-	ctx := context.NewContext()
+	ctx := beegoCtx.NewContext()
 	ctx.Reset(w, r)
 	c := ProductoPedidoController{}
 	c.Ctx = ctx
@@ -78,11 +56,37 @@ func TestProductoPedidoGetAllDBError(t *testing.T) {
 	}
 }
 
+func TestProductoPedidoGetAllSuccess(t *testing.T) {
+	MockQuery = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
+		cols := []string{"producto_id", "nombre", "cantidad", "precio_unitario", "subtotal"}
+		vals := [][]driver.Value{{int64(1), "Cafe", int64(1), float64(10), float64(10)}}
+		return &mockRows{columns: cols, values: vals}, nil
+	}
+	defer func() { MockQuery = nil }()
+
+	r := httptest.NewRequest(http.MethodGet, "/producto_pedido?pedido_id=1", nil)
+	w := httptest.NewRecorder()
+	ctx := beegoCtx.NewContext()
+	ctx.Reset(w, r)
+	c := ProductoPedidoController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	c.GetAll()
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "detallesProductos") {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
+}
+
 func TestProductoPedidoPostInvalidJSON(t *testing.T) {
 	body := "{"
 	r := httptest.NewRequest(http.MethodPost, "/producto_pedido", bytes.NewBufferString(body))
 	w := httptest.NewRecorder()
-	ctx := context.NewContext()
+	ctx := beegoCtx.NewContext()
 	ctx.Reset(w, r)
 	ctx.Input.RequestBody = []byte(body)
 	c := ProductoPedidoController{}
@@ -104,7 +108,7 @@ func TestProductoPedidoPostMissingFields(t *testing.T) {
 	r := httptest.NewRequest(http.MethodPost, "/producto_pedido", strings.NewReader(body))
 	r.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
-	ctx := context.NewContext()
+	ctx := beegoCtx.NewContext()
 	ctx.Reset(w, r)
 	ctx.Input.RequestBody = []byte(body)
 	c := ProductoPedidoController{}
@@ -122,11 +126,16 @@ func TestProductoPedidoPostMissingFields(t *testing.T) {
 }
 
 func TestProductoPedidoPostDBError(t *testing.T) {
+	MockExec = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Result, error) {
+		return nil, errors.New("db error")
+	}
+	defer func() { MockExec = nil }()
+
 	body := `{"pedidoId":1,"detallesProductos":[{"productoId":1,"cantidad":1}]}`
 	r := httptest.NewRequest(http.MethodPost, "/producto_pedido", strings.NewReader(body))
 	r.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
-	ctx := context.NewContext()
+	ctx := beegoCtx.NewContext()
 	ctx.Reset(w, r)
 	ctx.Input.RequestBody = []byte(body)
 	c := ProductoPedidoController{}
@@ -143,12 +152,39 @@ func TestProductoPedidoPostDBError(t *testing.T) {
 	}
 }
 
+func TestProductoPedidoPostSuccess(t *testing.T) {
+	MockExec = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Result, error) {
+		return mockResult{}, nil
+	}
+	defer func() { MockExec = nil }()
+
+	body := `{"pedidoId":1,"detallesProductos":[{"productoId":1,"cantidad":1}]}`
+	r := httptest.NewRequest(http.MethodPost, "/producto_pedido", strings.NewReader(body))
+	r.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	ctx := beegoCtx.NewContext()
+	ctx.Reset(w, r)
+	ctx.Input.RequestBody = []byte(body)
+	c := ProductoPedidoController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	c.Post()
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "pedidoId") {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
+}
+
 func TestProductoPedidoUpdateMissingParam(t *testing.T) {
 	body := "[]"
 	r := httptest.NewRequest(http.MethodPut, "/producto_pedido", strings.NewReader(body))
 	r.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
-	ctx := context.NewContext()
+	ctx := beegoCtx.NewContext()
 	ctx.Reset(w, r)
 	ctx.Input.RequestBody = []byte(body)
 	c := ProductoPedidoController{}
@@ -169,7 +205,7 @@ func TestProductoPedidoUpdateInvalidJSON(t *testing.T) {
 	body := "{"
 	r := httptest.NewRequest(http.MethodPut, "/producto_pedido?pedido_id=1", bytes.NewBufferString(body))
 	w := httptest.NewRecorder()
-	ctx := context.NewContext()
+	ctx := beegoCtx.NewContext()
 	ctx.Reset(w, r)
 	ctx.Input.RequestBody = []byte(body)
 	c := ProductoPedidoController{}
@@ -191,7 +227,7 @@ func TestProductoPedidoUpdateEmptyList(t *testing.T) {
 	r := httptest.NewRequest(http.MethodPut, "/producto_pedido?pedido_id=1", strings.NewReader(body))
 	r.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
-	ctx := context.NewContext()
+	ctx := beegoCtx.NewContext()
 	ctx.Reset(w, r)
 	ctx.Input.RequestBody = []byte(body)
 	c := ProductoPedidoController{}
@@ -209,11 +245,16 @@ func TestProductoPedidoUpdateEmptyList(t *testing.T) {
 }
 
 func TestProductoPedidoUpdateDBError(t *testing.T) {
+	MockQuery = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
+		return nil, errors.New("db error")
+	}
+	defer func() { MockQuery = nil }()
+
 	body := `[{"productoId":1,"cantidad":1}]`
 	r := httptest.NewRequest(http.MethodPut, "/producto_pedido?pedido_id=1", strings.NewReader(body))
 	r.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
-	ctx := context.NewContext()
+	ctx := beegoCtx.NewContext()
 	ctx.Reset(w, r)
 	ctx.Input.RequestBody = []byte(body)
 	c := ProductoPedidoController{}
@@ -226,66 +267,6 @@ func TestProductoPedidoUpdateDBError(t *testing.T) {
 		t.Fatalf("expected status 200, got %d", w.Code)
 	}
 	if !strings.Contains(w.Body.String(), "Error al buscar el pedido") {
-		t.Errorf("unexpected body: %s", w.Body.String())
-	}
-}
-
-func TestProductoPedidoGetAllSuccess(t *testing.T) {
-	original := productoPedidoNewOrm
-	productoPedidoNewOrm = func() productoPedidoOrmer {
-		return fakeOrmerPP{query: func(interface{}) orm.QuerySeter {
-			return fakeQueryPP{one: func(res interface{}, cols ...string) error {
-				pp := res.(*models.ProductoPedido)
-				pp.PK_ID_PEDIDO = 1
-				pp.DETALLES_PRODUCTOS = `[{"PK_ID_PRODUCTO":1,"NOMBRE":"Cafe","CANTIDAD":1,"PRECIO_UNITARIO":10,"SUBTOTAL":10}]`
-				return nil
-			}}
-		}}
-	}
-	defer func() { productoPedidoNewOrm = original }()
-
-	r := httptest.NewRequest(http.MethodGet, "/producto_pedido?pedido_id=1", nil)
-	w := httptest.NewRecorder()
-	ctx := context.NewContext()
-	ctx.Reset(w, r)
-	c := ProductoPedidoController{}
-	c.Ctx = ctx
-	c.Data = make(map[interface{}]interface{})
-
-	c.GetAll()
-
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected status 200, got %d", w.Code)
-	}
-	if !strings.Contains(w.Body.String(), "detallesProductos") {
-		t.Errorf("unexpected body: %s", w.Body.String())
-	}
-}
-
-func TestProductoPedidoPostSuccess(t *testing.T) {
-	original := productoPedidoNewOrm
-	productoPedidoNewOrm = func() productoPedidoOrmer {
-		return fakeOrmerPP{insert: func(interface{}) (int64, error) { return 1, nil }}
-	}
-	defer func() { productoPedidoNewOrm = original }()
-
-	body := `{"pedidoId":1,"detallesProductos":[{"productoId":1,"cantidad":1}]}`
-	r := httptest.NewRequest(http.MethodPost, "/producto_pedido", strings.NewReader(body))
-	r.Header.Set("Content-Type", "application/json")
-	w := httptest.NewRecorder()
-	ctx := context.NewContext()
-	ctx.Reset(w, r)
-	ctx.Input.RequestBody = []byte(body)
-	c := ProductoPedidoController{}
-	c.Ctx = ctx
-	c.Data = make(map[interface{}]interface{})
-
-	c.Post()
-
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected status 200, got %d", w.Code)
-	}
-	if !strings.Contains(w.Body.String(), "pedidoId") {
 		t.Errorf("unexpected body: %s", w.Body.String())
 	}
 }


### PR DESCRIPTION
## Summary
- Replace JSONB storage with PRODUCTO_PEDIDO_DETALLE rows managed in transactions
- Join PRODUCTO_PEDIDO with PRODUCTO_PEDIDO_DETALLE and PRODUCTO to build responses
- Revise domicilio and pedido detail endpoints to use relational joins
- Expand test utilities with mock transactions and update controller tests

## Testing
- `go test ./...` *(fails: trabajador_controller_test.go:394:18: m.trabajador.HORARIO undefined)*

------
https://chatgpt.com/codex/tasks/task_e_68b234ee2dd4832583047dc5d3e137d9