### PR TITLE
feat: use composite key for worker schedule

### DIFF
--- a/controllers/HorarioTrabajadorController.go
+++ b/controllers/HorarioTrabajadorController.go
@@ -160,12 +160,9 @@ func (c *HorarioTrabajadorController) Put() {
 		return
 	}
 
-	var horario models.HorarioTrabajador
+	horario := models.HorarioTrabajador{PK_DOCUMENTO_TRABAJADOR: doc, DIA: dia}
 	o := orm.NewOrm()
-	if err := o.QueryTable(new(models.HorarioTrabajador)).
-		Filter("PK_DOCUMENTO_TRABAJADOR", doc).
-		Filter("DIA", dia).
-		One(&horario); err == orm.ErrNoRows {
+	if err := o.Read(&horario); err == orm.ErrNoRows {
 		c.Ctx.Output.SetStatus(http.StatusOK)
 		c.Data["json"] = models.ApiResponse{Code: http.StatusNotFound, Message: "Horario no encontrado"}
 		c.ServeJSON()
@@ -248,11 +245,21 @@ func (c *HorarioTrabajadorController) Delete() {
 		return
 	}
 
+	horario := models.HorarioTrabajador{PK_DOCUMENTO_TRABAJADOR: doc, DIA: dia}
 	o := orm.NewOrm()
-	if _, err := o.QueryTable(new(models.HorarioTrabajador)).
-		Filter("PK_DOCUMENTO_TRABAJADOR", doc).
-		Filter("DIA", dia).
-		Delete(); err != nil {
+	if err := o.Read(&horario); err == orm.ErrNoRows {
+		c.Ctx.Output.SetStatus(http.StatusOK)
+		c.Data["json"] = models.ApiResponse{Code: http.StatusNotFound, Message: "Horario no encontrado"}
+		c.ServeJSON()
+		return
+	} else if err != nil {
+		c.Ctx.Output.SetStatus(http.StatusInternalServerError)
+		c.Data["json"] = models.ApiResponse{Code: http.StatusInternalServerError, Message: "Error al eliminar horario", Cause: err.Error()}
+		c.ServeJSON()
+		return
+	}
+
+	if _, err := o.Delete(&horario); err != nil {
 		c.Ctx.Output.SetStatus(http.StatusInternalServerError)
 		c.Data["json"] = models.ApiResponse{Code: http.StatusInternalServerError, Message: "Error al eliminar horario", Cause: err.Error()}
 		c.ServeJSON()

--- a/models/HorarioTrabajador.go
+++ b/models/HorarioTrabajador.go
@@ -9,7 +9,7 @@ import (
 
 type HorarioTrabajador struct {
 	PK_DOCUMENTO_TRABAJADOR int64     `orm:"column(PK_DOCUMENTO_TRABAJADOR);pk" json:"documentoTrabajador"`
-	DIA                     string    `orm:"column(DIA);type(text)" json:"dia"`
+	DIA                     string    `orm:"column(DIA);type(text);pk" json:"dia"`
 	HORA_INICIO             time.Time `orm:"column(HORA_INICIO);type(time)" json:"horaInicio"`
 	HORA_FIN                time.Time `orm:"column(HORA_FIN);type(time)" json:"horaFin"`
 }

--- a/tests/seed_data.go
+++ b/tests/seed_data.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"log"
+	"time"
 
 	"github.com/beego/beego/v2/client/orm"
 	"restaurante/models"
@@ -25,11 +26,13 @@ func SeedTestData() {
 		log.Println("seed PRODUCTO_PEDIDO_DETALLE:", err)
 	}
 
+	inicio, _ := time.Parse("15:04:05", "08:00:00")
+	fin, _ := time.Parse("15:04:05", "16:00:00")
 	if _, err := o.Insert(&models.HorarioTrabajador{
-		DocumentoTrabajador: 1,
-		Dia:                 "Lunes",
-		HoraInicio:          "08:00:00",
-		HoraFin:             "16:00:00",
+		PK_DOCUMENTO_TRABAJADOR: 1,
+		DIA:                     "Lunes",
+		HORA_INICIO:             inicio,
+		HORA_FIN:                fin,
 	}); err != nil {
 		log.Println("seed HORARIO_TRABAJADOR:", err)
 	}


### PR DESCRIPTION
## Summary
- use composite key (documentoTrabajador and dia) for HorarioTrabajador
- update HorarioTrabajador controller to pass both key fields
- fix test seed for HorarioTrabajador

## Testing
- `go test ./...` *(fails: models.HorarioTrabajador.DIA, one model must have one pk field only)*

------
https://chatgpt.com/codex/tasks/task_e_68b234efb1ac83258ec783761702c153