### PR TITLE
Update schedule and product seeds with proper types

### DIFF
--- a/tests/seed_data.go
+++ b/tests/seed_data.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"log"
+	"time"
 
 	"github.com/beego/beego/v2/client/orm"
 	"restaurante/models"
@@ -11,7 +12,7 @@ import (
 func SeedTestData() {
 	o := orm.NewOrm()
 
-	if _, err := o.Insert(&models.MetodoPago{PK_ID_METODO_PAGO: 1, TIPO: "Efectivo"}); err != nil {
+	if _, err := o.Insert(&models.MetodoPago{TIPO: "Efectivo"}); err != nil {
 		log.Println("seed METODO_PAGO:", err)
 	}
 
@@ -19,17 +20,19 @@ func SeedTestData() {
 		PKIDPedido:     1,
 		PKIDProducto:   1,
 		CANTIDAD:       1,
-		PRECIOUNITARIO: 1000,
-		SUBTOTAL:       1000,
+		PRECIOUNITARIO: 1000.0,
+		SUBTOTAL:       1000.0,
 	}); err != nil {
 		log.Println("seed PRODUCTO_PEDIDO_DETALLE:", err)
 	}
 
+	horaInicio, _ := time.Parse("15:04:05", "08:00:00")
+	horaFin, _ := time.Parse("15:04:05", "16:00:00")
 	if _, err := o.Insert(&models.HorarioTrabajador{
-		DocumentoTrabajador: 1,
-		Dia:                 "Lunes",
-		HoraInicio:          "08:00:00",
-		HoraFin:             "16:00:00",
+		PK_DOCUMENTO_TRABAJADOR: 1,
+		DIA:                     "Lunes",
+		HORA_INICIO:             horaInicio,
+		HORA_FIN:                horaFin,
 	}); err != nil {
 		log.Println("seed HORARIO_TRABAJADOR:", err)
 	}


### PR DESCRIPTION
## Summary
- use `time.Parse` and new field names in schedule test seed
- add example seed for product details with float types
- insert MetodoPago without PAGO dependency

## Testing
- `go test ./...` *(fails: m.trabajador.HORARIO undefined; unknown db alias)*

------
https://chatgpt.com/codex/tasks/task_e_68b234f05b9c8325bb1b85a6781947f1