### PR TITLE
test: cover product orders and schedules

### DIFF
--- a/controllers/HorarioTrabajadorController.go
+++ b/controllers/HorarioTrabajadorController.go
@@ -10,6 +10,15 @@ import (
 	"github.com/beego/beego/v2/server/web"
 )
 
+type horarioOrmer interface {
+	QueryTable(interface{}) orm.QuerySeter
+	Insert(interface{}) (int64, error)
+	Update(interface{}, ...string) (int64, error)
+}
+
+// horarioTrabajadorNewOrm allows tests to stub orm.NewOrm.
+var horarioTrabajadorNewOrm = func() horarioOrmer { return orm.NewOrm() }
+
 type HorarioTrabajadorController struct {
 	web.Controller
 }
@@ -27,7 +36,7 @@ type HorarioTrabajadorController struct {
 // @Security BearerAuth
 // @Router /horario_trabajador [get]
 func (c *HorarioTrabajadorController) GetAll() {
-	o := orm.NewOrm()
+	o := horarioTrabajadorNewOrm()
 	qs := o.QueryTable(new(models.HorarioTrabajador))
 
 	if doc, err := c.GetInt64("documento"); err == nil && doc != 0 {
@@ -108,7 +117,7 @@ func (c *HorarioTrabajadorController) Post() {
 		HORA_FIN:                horaFin,
 	}
 
-	o := orm.NewOrm()
+	o := horarioTrabajadorNewOrm()
 	if _, err := o.Insert(&horario); err != nil {
 		c.Ctx.Output.SetStatus(http.StatusInternalServerError)
 		c.Data["json"] = models.ApiResponse{
@@ -161,7 +170,7 @@ func (c *HorarioTrabajadorController) Put() {
 	}
 
 	var horario models.HorarioTrabajador
-	o := orm.NewOrm()
+	o := horarioTrabajadorNewOrm()
 	if err := o.QueryTable(new(models.HorarioTrabajador)).
 		Filter("PK_DOCUMENTO_TRABAJADOR", doc).
 		Filter("DIA", dia).
@@ -248,7 +257,7 @@ func (c *HorarioTrabajadorController) Delete() {
 		return
 	}
 
-	o := orm.NewOrm()
+	o := horarioTrabajadorNewOrm()
 	if _, err := o.QueryTable(new(models.HorarioTrabajador)).
 		Filter("PK_DOCUMENTO_TRABAJADOR", doc).
 		Filter("DIA", dia).

--- a/controllers/horario_trabajador_controller_test.go
+++ b/controllers/horario_trabajador_controller_test.go
@@ -1,0 +1,285 @@
+package controllers
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/beego/beego/v2/client/orm"
+	"github.com/beego/beego/v2/server/web/context"
+	"restaurante/models"
+)
+
+type fakeHorarioQuery struct {
+	orm.QuerySeter
+	all func(interface{}, ...string) (int64, error)
+	one func(interface{}, ...string) error
+	del func() (int64, error)
+}
+
+func (f fakeHorarioQuery) Filter(string, ...interface{}) orm.QuerySeter { return f }
+func (f fakeHorarioQuery) All(res interface{}, cols ...string) (int64, error) {
+	if f.all != nil {
+		return f.all(res, cols...)
+	}
+	return 0, nil
+}
+func (f fakeHorarioQuery) One(res interface{}, cols ...string) error {
+	if f.one != nil {
+		return f.one(res, cols...)
+	}
+	return nil
+}
+func (f fakeHorarioQuery) Delete() (int64, error) {
+	if f.del != nil {
+		return f.del()
+	}
+	return 1, nil
+}
+
+type fakeHorarioOrm struct {
+	query  func(interface{}) orm.QuerySeter
+	insert func(interface{}) (int64, error)
+	update func(interface{}, ...string) (int64, error)
+}
+
+func (f fakeHorarioOrm) QueryTable(i interface{}) orm.QuerySeter { return f.query(i) }
+func (f fakeHorarioOrm) Insert(m interface{}) (int64, error) {
+	if f.insert != nil {
+		return f.insert(m)
+	}
+	return 1, nil
+}
+func (f fakeHorarioOrm) Update(m interface{}, cols ...string) (int64, error) {
+	if f.update != nil {
+		return f.update(m, cols...)
+	}
+	return 1, nil
+}
+
+func buildHorarioContext(method, url, body string) (*HorarioTrabajadorController, *httptest.ResponseRecorder) {
+	r := httptest.NewRequest(method, url, strings.NewReader(body))
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	ctx.Input.RequestBody = []byte(body)
+	c := &HorarioTrabajadorController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+	return c, w
+}
+
+func TestHorarioTrabajadorGetAllDBError(t *testing.T) {
+	original := horarioTrabajadorNewOrm
+	horarioTrabajadorNewOrm = func() horarioOrmer {
+		return fakeHorarioOrm{query: func(interface{}) orm.QuerySeter {
+			return fakeHorarioQuery{all: func(interface{}, ...string) (int64, error) {
+				return 0, errors.New("db")
+			}}
+		}}
+	}
+	defer func() { horarioTrabajadorNewOrm = original }()
+
+	c, w := buildHorarioContext(http.MethodGet, "/horario_trabajador?documento=1", "")
+	c.GetAll()
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("got %d", w.Code)
+	}
+}
+
+func TestHorarioTrabajadorGetAllSuccess(t *testing.T) {
+	original := horarioTrabajadorNewOrm
+	horarioTrabajadorNewOrm = func() horarioOrmer {
+		return fakeHorarioOrm{query: func(interface{}) orm.QuerySeter {
+			return fakeHorarioQuery{all: func(res interface{}, cols ...string) (int64, error) {
+				out := res.(*[]models.HorarioTrabajador)
+				*out = []models.HorarioTrabajador{{PK_DOCUMENTO_TRABAJADOR: 1}}
+				return 1, nil
+			}}
+		}}
+	}
+	defer func() { horarioTrabajadorNewOrm = original }()
+
+	c, w := buildHorarioContext(http.MethodGet, "/horario_trabajador", "")
+	c.GetAll()
+	if w.Code != http.StatusOK {
+		t.Fatalf("got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "Horarios obtenidos") {
+		t.Fatalf("unexpected %s", w.Body.String())
+	}
+}
+
+func TestHorarioTrabajadorPostInvalidJSON(t *testing.T) {
+	c, w := buildHorarioContext(http.MethodPost, "/horario_trabajador", "notjson")
+	c.Post()
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("got %d", w.Code)
+	}
+}
+
+func TestHorarioTrabajadorPostInvalidTime(t *testing.T) {
+	body := `{"documentoTrabajador":1,"dia":"Lunes","horaInicio":"bad","horaFin":"10:00:00"}`
+	c, w := buildHorarioContext(http.MethodPost, "/horario_trabajador", body)
+	c.Post()
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("got %d", w.Code)
+	}
+}
+
+func TestHorarioTrabajadorPostDBError(t *testing.T) {
+	original := horarioTrabajadorNewOrm
+	horarioTrabajadorNewOrm = func() horarioOrmer {
+		return fakeHorarioOrm{insert: func(interface{}) (int64, error) { return 0, errors.New("db") }}
+	}
+	defer func() { horarioTrabajadorNewOrm = original }()
+	body := `{"documentoTrabajador":1,"dia":"Lunes","horaInicio":"09:00:00","horaFin":"10:00:00"}`
+	c, w := buildHorarioContext(http.MethodPost, "/horario_trabajador", body)
+	c.Post()
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("got %d", w.Code)
+	}
+}
+
+func TestHorarioTrabajadorPostSuccess(t *testing.T) {
+	original := horarioTrabajadorNewOrm
+	horarioTrabajadorNewOrm = func() horarioOrmer { return fakeHorarioOrm{insert: func(interface{}) (int64, error) { return 1, nil }} }
+	defer func() { horarioTrabajadorNewOrm = original }()
+	body := `{"documentoTrabajador":1,"dia":"Lunes","horaInicio":"09:00:00","horaFin":"10:00:00"}`
+	c, w := buildHorarioContext(http.MethodPost, "/horario_trabajador", body)
+	c.Post()
+	if w.Code != http.StatusCreated {
+		t.Fatalf("got %d", w.Code)
+	}
+}
+
+func TestHorarioTrabajadorPutInvalidParams(t *testing.T) {
+	c, w := buildHorarioContext(http.MethodPut, "/horario_trabajador", "{}")
+	c.Put()
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("got %d", w.Code)
+	}
+}
+
+func TestHorarioTrabajadorPutNotFound(t *testing.T) {
+	original := horarioTrabajadorNewOrm
+	horarioTrabajadorNewOrm = func() horarioOrmer {
+		return fakeHorarioOrm{query: func(interface{}) orm.QuerySeter {
+			return fakeHorarioQuery{one: func(interface{}, ...string) error { return orm.ErrNoRows }}
+		}}
+	}
+	defer func() { horarioTrabajadorNewOrm = original }()
+
+	c, w := buildHorarioContext(http.MethodPut, "/horario_trabajador?documento=1&dia=Lunes", "{}")
+	c.Put()
+	if w.Code != http.StatusOK {
+		t.Fatalf("got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "Horario no encontrado") {
+		t.Fatalf("unexpected %s", w.Body.String())
+	}
+}
+
+func TestHorarioTrabajadorPutInvalidJSON(t *testing.T) {
+	original := horarioTrabajadorNewOrm
+	horarioTrabajadorNewOrm = func() horarioOrmer {
+		return fakeHorarioOrm{query: func(interface{}) orm.QuerySeter {
+			return fakeHorarioQuery{one: func(interface{}, ...string) error { return nil }}
+		}}
+	}
+	defer func() { horarioTrabajadorNewOrm = original }()
+
+	c, w := buildHorarioContext(http.MethodPut, "/horario_trabajador?documento=1&dia=Lunes", "notjson")
+	c.Put()
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("got %d", w.Code)
+	}
+}
+
+func TestHorarioTrabajadorPutInvalidTime(t *testing.T) {
+	original := horarioTrabajadorNewOrm
+	horarioTrabajadorNewOrm = func() horarioOrmer {
+		return fakeHorarioOrm{query: func(interface{}) orm.QuerySeter {
+			return fakeHorarioQuery{one: func(interface{}, ...string) error { return nil }}
+		}}
+	}
+	defer func() { horarioTrabajadorNewOrm = original }()
+	body := `{"horaInicio":"bad"}`
+	c, w := buildHorarioContext(http.MethodPut, "/horario_trabajador?documento=1&dia=Lunes", body)
+	c.Put()
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("got %d", w.Code)
+	}
+}
+
+func TestHorarioTrabajadorPutUpdateError(t *testing.T) {
+	original := horarioTrabajadorNewOrm
+	horarioTrabajadorNewOrm = func() horarioOrmer {
+		return fakeHorarioOrm{query: func(interface{}) orm.QuerySeter {
+			return fakeHorarioQuery{one: func(interface{}, ...string) error { return nil }}
+		}, update: func(interface{}, ...string) (int64, error) { return 0, errors.New("db") }}
+	}
+	defer func() { horarioTrabajadorNewOrm = original }()
+	body := `{"horaInicio":"09:00:00"}`
+	c, w := buildHorarioContext(http.MethodPut, "/horario_trabajador?documento=1&dia=Lunes", body)
+	c.Put()
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("got %d", w.Code)
+	}
+}
+
+func TestHorarioTrabajadorPutSuccess(t *testing.T) {
+	original := horarioTrabajadorNewOrm
+	horarioTrabajadorNewOrm = func() horarioOrmer {
+		return fakeHorarioOrm{query: func(interface{}) orm.QuerySeter {
+			return fakeHorarioQuery{one: func(interface{}, ...string) error { return nil }}
+		}, update: func(interface{}, ...string) (int64, error) { return 1, nil }}
+	}
+	defer func() { horarioTrabajadorNewOrm = original }()
+	body := `{"horaInicio":"09:00:00"}`
+	c, w := buildHorarioContext(http.MethodPut, "/horario_trabajador?documento=1&dia=Lunes", body)
+	c.Put()
+	if w.Code != http.StatusOK {
+		t.Fatalf("got %d", w.Code)
+	}
+}
+
+func TestHorarioTrabajadorDeleteInvalidParams(t *testing.T) {
+	c, w := buildHorarioContext(http.MethodDelete, "/horario_trabajador", "")
+	c.Delete()
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("got %d", w.Code)
+	}
+}
+
+func TestHorarioTrabajadorDeleteDBError(t *testing.T) {
+	original := horarioTrabajadorNewOrm
+	horarioTrabajadorNewOrm = func() horarioOrmer {
+		return fakeHorarioOrm{query: func(interface{}) orm.QuerySeter {
+			return fakeHorarioQuery{del: func() (int64, error) { return 0, errors.New("db") }}
+		}}
+	}
+	defer func() { horarioTrabajadorNewOrm = original }()
+
+	c, w := buildHorarioContext(http.MethodDelete, "/horario_trabajador?documento=1&dia=Lunes", "")
+	c.Delete()
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("got %d", w.Code)
+	}
+}
+
+func TestHorarioTrabajadorDeleteSuccess(t *testing.T) {
+	original := horarioTrabajadorNewOrm
+	horarioTrabajadorNewOrm = func() horarioOrmer {
+		return fakeHorarioOrm{query: func(interface{}) orm.QuerySeter { return fakeHorarioQuery{} }}
+	}
+	defer func() { horarioTrabajadorNewOrm = original }()
+
+	c, w := buildHorarioContext(http.MethodDelete, "/horario_trabajador?documento=1&dia=Lunes", "")
+	c.Delete()
+	if w.Code != http.StatusOK {
+		t.Fatalf("got %d", w.Code)
+	}
+}

--- a/controllers/producto_pedido_controller_test.go
+++ b/controllers/producto_pedido_controller_test.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"bytes"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -60,6 +61,14 @@ func TestProductoPedidoGetAllMissingParam(t *testing.T) {
 }
 
 func TestProductoPedidoGetAllDBError(t *testing.T) {
+	original := productoPedidoNewOrm
+	productoPedidoNewOrm = func() productoPedidoOrmer {
+		return fakeOrmerPP{query: func(interface{}) orm.QuerySeter {
+			return fakeQueryPP{one: func(interface{}, ...string) error { return errors.New("db") }}
+		}}
+	}
+	defer func() { productoPedidoNewOrm = original }()
+
 	r := httptest.NewRequest(http.MethodGet, "/producto_pedido?pedido_id=1", nil)
 	w := httptest.NewRecorder()
 	ctx := context.NewContext()
@@ -122,7 +131,7 @@ func TestProductoPedidoPostMissingFields(t *testing.T) {
 }
 
 func TestProductoPedidoPostDBError(t *testing.T) {
-	body := `{"pedidoId":1,"detallesProductos":[{"productoId":1,"cantidad":1}]}`
+	body := `{"pedidoId":1,"detallesProductos":[{"productoId":1,"cantidad":1,"precioUnitario":10,"subtotal":10}]}`
 	r := httptest.NewRequest(http.MethodPost, "/producto_pedido", strings.NewReader(body))
 	r.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
@@ -209,7 +218,15 @@ func TestProductoPedidoUpdateEmptyList(t *testing.T) {
 }
 
 func TestProductoPedidoUpdateDBError(t *testing.T) {
-	body := `[{"productoId":1,"cantidad":1}]`
+	original := productoPedidoNewOrm
+	productoPedidoNewOrm = func() productoPedidoOrmer {
+		return fakeOrmerPP{query: func(interface{}) orm.QuerySeter {
+			return fakeQueryPP{one: func(interface{}, ...string) error { return errors.New("db") }}
+		}}
+	}
+	defer func() { productoPedidoNewOrm = original }()
+
+	body := `[{"productoId":1,"cantidad":1,"precioUnitario":10,"subtotal":10}]`
 	r := httptest.NewRequest(http.MethodPut, "/producto_pedido?pedido_id=1", strings.NewReader(body))
 	r.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
@@ -269,7 +286,7 @@ func TestProductoPedidoPostSuccess(t *testing.T) {
 	}
 	defer func() { productoPedidoNewOrm = original }()
 
-	body := `{"pedidoId":1,"detallesProductos":[{"productoId":1,"cantidad":1}]}`
+	body := `{"pedidoId":1,"detallesProductos":[{"productoId":1,"cantidad":1,"precioUnitario":10,"subtotal":10}]}`
 	r := httptest.NewRequest(http.MethodPost, "/producto_pedido", strings.NewReader(body))
 	r.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()

--- a/controllers/trabajador_controller_test.go
+++ b/controllers/trabajador_controller_test.go
@@ -380,22 +380,6 @@ func TestPutSuccess(t *testing.T) {
 	}
 }
 
-func TestPutHorarioUpdated(t *testing.T) {
-	m := &mockOrm{}
-	original := newTrabajadorOrm
-	newTrabajadorOrm = func() orm.Ormer { return m }
-	defer func() { newTrabajadorOrm = original }()
-	body := `{"HORARIO":"08:00-16:00"}`
-	c, w := buildContext(http.MethodPut, "/trabajadores?id=1", body)
-	c.Put()
-	if w.Code != http.StatusOK {
-		t.Fatalf("%d", w.Code)
-	}
-	if m.trabajador.HORARIO == nil || *m.trabajador.HORARIO != "08:00-16:00" {
-		t.Fatalf("horario not updated")
-	}
-}
-
 // Delete tests
 func TestDeleteInvalidID(t *testing.T) {
 	c, w := buildContext(http.MethodDelete, "/trabajadores", "")

--- a/tests/seed_data.go
+++ b/tests/seed_data.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"log"
+	"time"
 
 	"github.com/beego/beego/v2/client/orm"
 	"restaurante/models"
@@ -26,10 +27,10 @@ func SeedTestData() {
 	}
 
 	if _, err := o.Insert(&models.HorarioTrabajador{
-		DocumentoTrabajador: 1,
-		Dia:                 "Lunes",
-		HoraInicio:          "08:00:00",
-		HoraFin:             "16:00:00",
+		PK_DOCUMENTO_TRABAJADOR: 1,
+		DIA:                     "Lunes",
+		HORA_INICIO:             time.Date(0, 1, 1, 8, 0, 0, 0, time.UTC),
+		HORA_FIN:                time.Date(0, 1, 1, 16, 0, 0, 0, time.UTC),
 	}); err != nil {
 		log.Println("seed HORARIO_TRABAJADOR:", err)
 	}


### PR DESCRIPTION
## Summary
- update product-pedido tests to use detailed product lists
- drop legacy horario assertions in trabajador tests
- add coverage for HorarioTrabajador endpoints and seed data

## Testing
- `go test ./controllers -count=1`
- `go test ./tests -count=1`
- `go test ./...` *(fails: unknown db alias `default`)*

------
https://chatgpt.com/codex/tasks/task_e_68b234f4bf08832597a50025d1fde2b6