### PR TITLE
Refactor controllers for enums and price history

### DIFF
--- a/controllers/DomicilioController.go
+++ b/controllers/DomicilioController.go
@@ -149,14 +149,14 @@ func (c *DomicilioController) GetById() {
 
 	qCliente := `
 SELECT
-  pc."PK_DOCUMENTO_CLIENTE" AS documento,
-  c."NOMBRE"                AS nombre,
-  c."APELLIDO"              AS apellido
-FROM "PEDIDO" p
-JOIN "PEDIDO_CLIENTE" pc ON pc."PK_ID_PEDIDO" = p."PK_ID_PEDIDO"
-JOIN "CLIENTE" c        ON c."PK_DOCUMENTO_CLIENTE" = pc."PK_DOCUMENTO_CLIENTE"
-WHERE p."PK_ID_DOMICILIO" = ?
-ORDER BY p."PK_ID_PEDIDO" DESC
+  pc.pk_documento_cliente AS documento,
+  c.nombre                AS nombre,
+  c.apellido              AS apellido
+FROM pedido p
+JOIN pedido_cliente pc ON pc.pk_id_pedido = p.pk_id_pedido
+JOIN cliente c        ON c.pk_documento_cliente = pc.pk_documento_cliente
+WHERE p.pk_id_domicilio = ?
+ORDER BY p.pk_id_pedido DESC
 LIMIT 1;`
 
 	cliErr := o.Raw(qCliente, id).QueryRow(&cli)
@@ -173,30 +173,30 @@ LIMIT 1;`
 
 	qPedido := `
 SELECT
-  p."PK_ID_PEDIDO" AS pedido_id,
-  pa."PK_ID_PAGO"  AS pago_id,
-  pa."MONTO"::numeric AS pago_monto,
+  p.pk_id_pedido AS pedido_id,
+  pa.pk_id_pago  AS pago_id,
+  pa.monto::numeric AS pago_monto,
   (
-    SELECT COALESCE(SUM(d."SUBTOTAL"), 0)
-    FROM "PRODUCTO_PEDIDO_DETALLE" d
-    WHERE d."PK_ID_PEDIDO" = p."PK_ID_PEDIDO"
+    SELECT COALESCE(SUM(d.subtotal), 0)
+    FROM producto_pedido_detalle d
+    WHERE d.pk_id_pedido = p.pk_id_pedido
   ) AS subtotal_productos,
   (
     SELECT COALESCE(jsonb_agg(json_build_object(
-      'PK_ID_PRODUCTO', d."PK_ID_PRODUCTO",
-      'NOMBRE', pr."NOMBRE",
-      'CANTIDAD', d."CANTIDAD",
-      'PRECIO_UNITARIO', d."PRECIO_UNITARIO",
-      'SUBTOTAL', d."SUBTOTAL"
+      'pk_id_producto', d.pk_id_producto,
+      'nombre', pr.nombre,
+      'cantidad', d.cantidad,
+      'precio_unitario', d.precio_unitario,
+      'subtotal', d.subtotal
     )), '[]'::jsonb)::text
-    FROM "PRODUCTO_PEDIDO_DETALLE" d
-    JOIN "PRODUCTO" pr ON pr."PK_ID_PRODUCTO" = d."PK_ID_PRODUCTO"
-    WHERE d."PK_ID_PEDIDO" = p."PK_ID_PEDIDO"
+    FROM producto_pedido_detalle d
+    JOIN producto pr ON pr.pk_id_producto = d.pk_id_producto
+    WHERE d.pk_id_pedido = p.pk_id_pedido
   ) AS productos
-FROM "PEDIDO" p
-LEFT JOIN "PAGO" pa ON pa."PK_ID_PAGO" = p."PK_ID_PAGO"
-WHERE p."PK_ID_DOMICILIO" = ?
-ORDER BY p."PK_ID_PEDIDO" DESC
+FROM pedido p
+LEFT JOIN pago pa ON pa.pk_id_pago = p.pk_id_pago
+WHERE p.pk_id_domicilio = ?
+ORDER BY p.pk_id_pedido DESC
 LIMIT 1;`
 
 	pedErr := o.Raw(qPedido, id).QueryRow(&ped)

--- a/controllers/NominaController.go
+++ b/controllers/NominaController.go
@@ -16,9 +16,9 @@ type NominaController struct {
 }
 
 // Estados permitidos para la nómina
-var estadosNominaPermitidos = map[string]bool{
-	"PAGO":    true,
-	"NO PAGO": true,
+var estadosNominaPermitidos = map[models.EstadoNomina]bool{
+	models.EstadoNominaPago:   true,
+	models.EstadoNominaNoPago: true,
 }
 
 // @Title GetAll
@@ -119,7 +119,7 @@ func (c *NominaController) Post() {
 	}
 
 	if !estadosNominaPermitidos[input.ESTADO_NOMINA] {
-		input.ESTADO_NOMINA = "NO PAGO"
+		input.ESTADO_NOMINA = models.EstadoNominaNoPago
 	}
 
 	input.MONTO = 0 // Dejar en 0 para que sea calculado automáticamente por la función
@@ -134,6 +134,33 @@ func (c *NominaController) Post() {
 		}
 		c.ServeJSON()
 		return
+	}
+
+	// Ejecutar funciones adicionales si se solicitan
+	if gen, _ := c.GetBool("generar_nomina_automatica", false); gen {
+		if _, err := o.Raw("CALL generar_nomina_automatica()").Exec(); err != nil {
+			c.Ctx.Output.SetStatus(http.StatusInternalServerError)
+			c.Data["json"] = models.ApiResponse{
+				Code:    http.StatusInternalServerError,
+				Message: "Error al generar nómina automática",
+				Cause:   err.Error(),
+			}
+			c.ServeJSON()
+			return
+		}
+	}
+
+	if ver, _ := c.GetBool("verificar_nomina", false); ver {
+		if _, err := o.Raw("CALL verificar_nomina()").Exec(); err != nil {
+			c.Ctx.Output.SetStatus(http.StatusInternalServerError)
+			c.Data["json"] = models.ApiResponse{
+				Code:    http.StatusInternalServerError,
+				Message: "Error al verificar nómina",
+				Cause:   err.Error(),
+			}
+			c.ServeJSON()
+			return
+		}
 	}
 
 	var updatedNomina models.Nomina
@@ -203,7 +230,7 @@ func (c *NominaController) Put() {
 	}
 
 	// Cambiar el estado a "PAGO" si no lo está ya
-	if nomina.ESTADO_NOMINA == "PAGO" {
+	if nomina.ESTADO_NOMINA == models.EstadoNominaPago {
 		c.Ctx.Output.SetStatus(http.StatusBadRequest)
 		c.Data["json"] = models.ApiResponse{
 			Code:    http.StatusBadRequest,
@@ -212,7 +239,7 @@ func (c *NominaController) Put() {
 		c.ServeJSON()
 		return
 	}
-	nomina.ESTADO_NOMINA = "PAGO"
+	nomina.ESTADO_NOMINA = models.EstadoNominaPago
 
 	// Guardar los cambios
 	if _, err := o.Update(&nomina, "ESTADO_NOMINA"); err != nil {
@@ -274,7 +301,7 @@ func (c *NominaController) Delete() {
 		return
 	}
 
-	nomina.ESTADO_NOMINA = "NO PAGO"
+	nomina.ESTADO_NOMINA = models.EstadoNominaNoPago
 	if _, err := o.Update(&nomina, "ESTADO_NOMINA"); err != nil {
 		c.Ctx.Output.SetStatus(http.StatusInternalServerError)
 		c.Data["json"] = models.ApiResponse{

--- a/controllers/PedidoController.go
+++ b/controllers/PedidoController.go
@@ -37,11 +37,11 @@ func (c *PedidoController) GetAll() {
 
 	// Construcción de la consulta SQL
 	query := `
-        SELECT p.* 
-        FROM "PEDIDO" p
-        LEFT JOIN "PEDIDO_CLIENTE" pc ON p."PK_ID_PEDIDO" = pc."PK_ID_PEDIDO"
-        LEFT JOIN "PAGO" pa ON p."PK_ID_PAGO" = pa."PK_ID_PAGO"
-        LEFT JOIN "METODO_PAGO" mp ON pa."PK_ID_METODO_PAGO" = mp."PK_ID_METODO_PAGO"
+        SELECT p.*
+        FROM pedido p
+        LEFT JOIN pedido_cliente pc ON p.pk_id_pedido = pc.pk_id_pedido
+        LEFT JOIN pago pa ON p.pk_id_pago = pa.pk_id_pago
+        LEFT JOIN metodo_pago mp ON pa.pk_id_metodo_pago = mp.pk_id_metodo_pago
         WHERE 1 = 1
     `
 
@@ -58,39 +58,39 @@ func (c *PedidoController) GetAll() {
 
 	// Agregar filtros según los parámetros proporcionados
 	if fecha != "" {
-		query += ` AND p."FECHA" = ?`
+		query += ` AND p.fecha = ?`
 		params = append(params, fecha)
 	}
 
 	if desde != "" && hasta != "" {
-		query += ` AND p."FECHA" BETWEEN ? AND ?`
+		query += ` AND p.fecha BETWEEN ? AND ?`
 		params = append(params, desde, hasta)
 	}
 
 	if mes > 0 && mes <= 12 {
-		query += ` AND EXTRACT(MONTH FROM p."FECHA") = ?`
+		query += ` AND EXTRACT(MONTH FROM p.fecha) = ?`
 		params = append(params, mes)
 		if anio > 0 {
-			query += ` AND EXTRACT(YEAR FROM p."FECHA") = ?`
+			query += ` AND EXTRACT(YEAR FROM p.fecha) = ?`
 			params = append(params, anio)
 		}
 	}
 
 	if cliente > 0 {
-		query += ` AND pc."PK_DOCUMENTO_CLIENTE" = ?`
+		query += ` AND pc.pk_documento_cliente = ?`
 		params = append(params, cliente)
 	}
 
 	if metodoPago != "" {
-		query += ` AND mp."TIPO" ILIKE ?`
+		query += ` AND mp.tipo ILIKE ?`
 		params = append(params, metodoPago)
 	}
 
 	if errDomicilio == nil {
 		if domicilio {
-			query += ` AND p."PK_ID_DOMICILIO" IS NOT NULL`
+			query += ` AND p.pk_id_domicilio IS NOT NULL`
 		} else {
-			query += ` AND p."PK_ID_DOMICILIO" IS NULL`
+			query += ` AND p.pk_id_domicilio IS NULL`
 		}
 	}
 
@@ -163,7 +163,7 @@ func (c *PedidoController) Post() {
 	var pedido models.Pedido
 	pedido.FECHA = now
 	pedido.HORA = now.Format("15:04:05") // string HH:mm:ss
-	pedido.ESTADO_PEDIDO = "INICIADO"
+	pedido.ESTADO_PEDIDO = models.EstadoPedidoIniciado
 
 	// Si el cliente mandó delivery en el body, lo respetamos; si no, false
 	if in.Delivery != nil {
@@ -262,7 +262,7 @@ func (c *PedidoController) AssignPago() {
 
 	// Actualizamos la FK al pago y marcamos la orden como terminada
 	pedido.PK_ID_PAGO = &pagoID
-	pedido.ESTADO_PEDIDO = "TERMINADO"
+	pedido.ESTADO_PEDIDO = models.EstadoPedidoTerminado
 	if _, err := o.Update(&pedido, "PK_ID_PAGO", "ESTADO_PEDIDO"); err != nil {
 		c.Ctx.Output.SetStatus(500)
 		c.Data["json"] = models.ApiResponse{Code: 500, Message: "Error al asignar pago", Cause: err.Error()}
@@ -273,7 +273,7 @@ func (c *PedidoController) AssignPago() {
 	// También cambiamos el estado en la tabla PAGO
 	pago := models.Pago{PK_ID_PAGO: pagoID}
 	if err := o.Read(&pago); err == nil {
-		pago.ESTADO_PAGO = "PAGADO"
+		pago.ESTADO_PAGO = models.EstadoPagoPagado
 		o.Update(&pago, "ESTADO_PAGO")
 	}
 
@@ -365,33 +365,33 @@ func (c *PedidoController) GetPedidoDetails() {
 	// Consulta para obtener detalles del pedido
 	query := `
 SELECT
-    p."PK_ID_PEDIDO"                                   AS pk_id_pedido,
-    COALESCE(TO_CHAR(p."FECHA", 'YYYY-MM-DD'), '')     AS fecha,
-    COALESCE(TO_CHAR(p."HORA",  'HH24:MI:SS'), '')     AS hora,
-    COALESCE(p."DELIVERY", false)                      AS delivery,
-    COALESCE(p."ESTADO_PEDIDO", '')                    AS estado_pedido,
-    COALESCE(mp."TIPO", '')                            AS metodo_pago,
+    p.pk_id_pedido                                   AS pk_id_pedido,
+    COALESCE(TO_CHAR(p.fecha, 'YYYY-MM-DD'), '')     AS fecha,
+    COALESCE(TO_CHAR(p.hora,  'HH24:MI:SS'), '')     AS hora,
+    COALESCE(p.delivery, false)                      AS delivery,
+    COALESCE(p.estado_pedido, '')                    AS estado_pedido,
+    COALESCE(mp.tipo, '')                            AS metodo_pago,
     COALESCE((
         SELECT jsonb_agg(json_build_object(
-            'PK_ID_PRODUCTO', d."PK_ID_PRODUCTO",
-            'NOMBRE', pr."NOMBRE",
-            'CANTIDAD', d."CANTIDAD",
-            'PRECIO_UNITARIO', d."PRECIO_UNITARIO",
-            'SUBTOTAL', d."SUBTOTAL"
+            'pk_id_producto', d.pk_id_producto,
+            'nombre', pr.nombre,
+            'cantidad', d.cantidad,
+            'precio_unitario', d.precio_unitario,
+            'subtotal', d.subtotal
         ))::text
-        FROM "PRODUCTO_PEDIDO_DETALLE" d
-        JOIN "PRODUCTO" pr ON pr."PK_ID_PRODUCTO" = d."PK_ID_PRODUCTO"
-        WHERE d."PK_ID_PEDIDO" = p."PK_ID_PEDIDO"
+        FROM producto_pedido_detalle d
+        JOIN producto pr ON pr.pk_id_producto = d.pk_id_producto
+        WHERE d.pk_id_pedido = p.pk_id_pedido
     ), '[]')                                           AS productos,
-    COALESCE(p."PK_ID_PAGO", 0)                        AS pago_id,
-    COALESCE(pa."PK_ID_METODO_PAGO", 0)                AS metodo_pago_id,
-    COALESCE(p."PK_ID_DOMICILIO", 0)                   AS domicilio_id,
-    COALESCE(pc."PK_DOCUMENTO_CLIENTE", 0)             AS documento_cliente
-FROM "PEDIDO" p
-LEFT JOIN "PAGO" pa        ON p."PK_ID_PAGO" = pa."PK_ID_PAGO"
-LEFT JOIN "METODO_PAGO" mp ON pa."PK_ID_METODO_PAGO" = mp."PK_ID_METODO_PAGO"
-LEFT JOIN "PEDIDO_CLIENTE" pc ON p."PK_ID_PEDIDO" = pc."PK_ID_PEDIDO"
-WHERE p."PK_ID_PEDIDO" = ?;
+    COALESCE(p.pk_id_pago, 0)                        AS pago_id,
+    COALESCE(pa.pk_id_metodo_pago, 0)                AS metodo_pago_id,
+    COALESCE(p.pk_id_domicilio, 0)                   AS domicilio_id,
+    COALESCE(pc.pk_documento_cliente, 0)             AS documento_cliente
+FROM pedido p
+LEFT JOIN pago pa        ON p.pk_id_pago = pa.pk_id_pago
+LEFT JOIN metodo_pago mp ON pa.pk_id_metodo_pago = mp.pk_id_metodo_pago
+LEFT JOIN pedido_cliente pc ON p.pk_id_pedido = pc.pk_id_pedido
+WHERE p.pk_id_pedido = ?;
     `
 
 	var details models.PedidoDetails

--- a/controllers/ProductoController.go
+++ b/controllers/ProductoController.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"restaurante/models"
 	"strconv"
+	"time"
 
 	"github.com/beego/beego/v2/client/orm"
 	"github.com/beego/beego/v2/server/web"
@@ -42,7 +43,7 @@ func (c *ProductoController) GetAll() {
 	// Construir la consulta con filtros
 	query := o.QueryTable(new(models.Producto))
 	if onlyActive {
-		query = query.Filter("ESTADO_PRODUCTO", "DISPONIBLE")
+		query = query.Filter("ESTADO_PRODUCTO", models.EstadoProductoDisponible)
 	}
 	if categoria != "" {
 		query = query.Filter("CATEGORIA__icontains", categoria)
@@ -196,6 +197,23 @@ func (c *ProductoController) Post() {
 		return
 	}
 
+	// Registrar historial de precios
+	hist := models.PrecioProductoHist{
+		PKIDProducto: producto.PK_ID_PRODUCTO,
+		Precio:       float64(producto.PRECIO),
+		FechaInicio:  time.Now(),
+	}
+	if _, err := o.Insert(&hist); err != nil {
+		c.Ctx.Output.SetStatus(http.StatusInternalServerError)
+		c.Data["json"] = models.ApiResponse{
+			Code:    http.StatusInternalServerError,
+			Message: "Error al registrar historial de precios",
+			Cause:   err.Error(),
+		}
+		c.ServeJSON()
+		return
+	}
+
 	c.Ctx.Output.SetStatus(http.StatusCreated)
 	c.Data["json"] = models.ApiResponse{
 		Code:    http.StatusCreated,
@@ -303,6 +321,40 @@ func (c *ProductoController) Put() {
 			return
 		}
 
+		// Si cambió el precio, actualizar historial
+		if producto.PRECIO != original.PRECIO {
+			now := time.Now()
+			if _, err := o.QueryTable(new(models.PrecioProductoHist)).
+				Filter("pk_id_producto", producto.PK_ID_PRODUCTO).
+				Filter("fecha_fin__isnull", true).
+				Update(orm.Params{"fecha_fin": now}); err != nil {
+				c.Ctx.Output.SetStatus(http.StatusInternalServerError)
+				c.Data["json"] = models.ApiResponse{
+					Code:    http.StatusInternalServerError,
+					Message: "Error al actualizar historial de precios",
+					Cause:   err.Error(),
+				}
+				c.ServeJSON()
+				return
+			}
+
+			hist := models.PrecioProductoHist{
+				PKIDProducto: producto.PK_ID_PRODUCTO,
+				Precio:       float64(producto.PRECIO),
+				FechaInicio:  now,
+			}
+			if _, err := o.Insert(&hist); err != nil {
+				c.Ctx.Output.SetStatus(http.StatusInternalServerError)
+				c.Data["json"] = models.ApiResponse{
+					Code:    http.StatusInternalServerError,
+					Message: "Error al registrar historial de precios",
+					Cause:   err.Error(),
+				}
+				c.ServeJSON()
+				return
+			}
+		}
+
 		c.Ctx.Output.SetStatus(http.StatusOK)
 		c.Data["json"] = models.ApiResponse{
 			Code:    http.StatusOK,
@@ -360,7 +412,7 @@ func (c *ProductoController) Delete() {
 		c.ServeJSON()
 		return
 	}
-	if producto.ESTADO_PRODUCTO == "NO DISPONIBLE" {
+	if producto.ESTADO_PRODUCTO == models.EstadoProductoNoDisponible {
 		c.Ctx.Output.SetStatus(http.StatusBadRequest)
 		c.Data["json"] = models.ApiResponse{
 			Code:    http.StatusBadRequest,
@@ -370,7 +422,7 @@ func (c *ProductoController) Delete() {
 		return
 	}
 	// Cambiar el estado del producto a "NO DISPONIBLE" para el borrado lógico
-	producto.ESTADO_PRODUCTO = "NO DISPONIBLE"
+	producto.ESTADO_PRODUCTO = models.EstadoProductoNoDisponible
 	if _, err := o.Update(producto, "ESTADO_PRODUCTO"); err != nil {
 		c.Ctx.Output.SetStatus(http.StatusInternalServerError)
 		c.Data["json"] = models.ApiResponse{
@@ -422,7 +474,7 @@ func validateProducto(producto *models.Producto) error {
 	if producto.CALORIAS != nil && *producto.CALORIAS < 0 {
 		return fmt.Errorf("el campo 'CALORIAS' debe ser un número positivo")
 	}
-	if producto.ESTADO_PRODUCTO != "DISPONIBLE" && producto.ESTADO_PRODUCTO != "NO DISPONIBLE" {
+	if producto.ESTADO_PRODUCTO != models.EstadoProductoDisponible && producto.ESTADO_PRODUCTO != models.EstadoProductoNoDisponible {
 		return fmt.Errorf("el campo 'ESTADO_PRODUCTO' debe ser 'DISPONIBLE' o 'NO DISPONIBLE'")
 	}
 	return nil

--- a/controllers/ProductoPedidoController.go
+++ b/controllers/ProductoPedidoController.go
@@ -161,11 +161,9 @@ func (c *ProductoPedidoController) Post() {
 
 	for _, d := range input.Detalles {
 		detalle := models.ProductoPedidoDetalle{
-			PKIDPedido:     input.PedidoId,
-			PKIDProducto:   d.PKIDProducto,
-			CANTIDAD:       d.CANTIDAD,
-			PRECIOUNITARIO: d.PRECIOUNITARIO,
-			SUBTOTAL:       d.SUBTOTAL,
+			PKIDPedido:   input.PedidoId,
+			PKIDProducto: d.PKIDProducto,
+			CANTIDAD:     d.CANTIDAD,
 		}
 		if _, err := o.Insert(&detalle); err != nil {
 			c.Data["json"] = models.ApiResponse{
@@ -271,11 +269,9 @@ func (c *ProductoPedidoController) Update() {
 
 	for _, d := range nuevosProductos {
 		detalle := models.ProductoPedidoDetalle{
-			PKIDPedido:     pedidoID,
-			PKIDProducto:   d.PKIDProducto,
-			CANTIDAD:       d.CANTIDAD,
-			PRECIOUNITARIO: d.PRECIOUNITARIO,
-			SUBTOTAL:       d.SUBTOTAL,
+			PKIDPedido:   pedidoID,
+			PKIDProducto: d.PKIDProducto,
+			CANTIDAD:     d.CANTIDAD,
 		}
 		if _, err := o.Insert(&detalle); err != nil {
 			c.Data["json"] = models.ApiResponse{


### PR DESCRIPTION
## Summary
- Normalize SQL identifiers and use enum constants across controllers
- Add payroll automation hooks to NominaController
- Track product price history and rely on DB trigger for order pricing

## Testing
- `go test ./...` *(fails: models.DetallePedido.PKIDProducto, one model must have one pk field only)*

------
https://chatgpt.com/codex/tasks/task_e_68b363f5c7ec8325957ce651145f2986