### PR TITLE
Add database migrations and seeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,16 @@ Go-based REST API for managing restaurant operations such as customers, orders, 
   go run main.go
   ```
 
+## Database Migrations
+Migration scripts live under `migrations/`. Apply them in numeric order and run the seed script after the schema is created:
+
+```sh
+psql -f migrations/001_create_schema.sql
+psql -f migrations/seed/001_seed.sql
+```
+
+To rollback, execute the `Down` section of `001_create_schema.sql` in reverse order.
+
 ## Testing
 ```sh
 go test ./...

--- a/migrations/001_create_schema.sql
+++ b/migrations/001_create_schema.sql
@@ -1,0 +1,130 @@
+-- +migrate Up
+CREATE TYPE estado_domicilio AS ENUM ('pendiente','en_camino','entregado','cancelado');
+CREATE TYPE estado_reserva AS ENUM ('pendiente','confirmada','cancelada');
+CREATE TYPE tipo_nomina AS ENUM ('mensual','semanal');
+CREATE TYPE dia_semana AS ENUM ('lunes','martes','miercoles','jueves','viernes','sabado','domingo');
+
+CREATE TABLE domicilio (
+    id SERIAL PRIMARY KEY,
+    pedido_id INT,
+    direccion TEXT NOT NULL,
+    estado estado_domicilio NOT NULL DEFAULT 'pendiente',
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    deleted_at TIMESTAMP
+);
+
+CREATE TABLE nomina (
+    id SERIAL PRIMARY KEY,
+    trabajador_id INT NOT NULL,
+    fecha DATE NOT NULL,
+    tipo tipo_nomina NOT NULL,
+    monto NUMERIC(10,2) NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    deleted_at TIMESTAMP
+);
+
+CREATE TABLE control_nomina (
+    id SERIAL PRIMARY KEY,
+    nomina_id INT REFERENCES nomina(id),
+    aprobado BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    deleted_at TIMESTAMP
+);
+
+CREATE TABLE precio_producto_hist (
+    id SERIAL PRIMARY KEY,
+    producto_id INT NOT NULL,
+    precio NUMERIC(10,2) NOT NULL,
+    vigente_desde TIMESTAMP NOT NULL DEFAULT NOW(),
+    vigente_hasta TIMESTAMP,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    deleted_at TIMESTAMP
+);
+
+CREATE TABLE detalle_pedido (
+    id SERIAL PRIMARY KEY,
+    pedido_id INT NOT NULL,
+    producto_id INT NOT NULL,
+    cantidad INT NOT NULL,
+    precio NUMERIC(10,2) NOT NULL DEFAULT 0,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    deleted_at TIMESTAMP
+);
+
+CREATE OR REPLACE FUNCTION set_precio_detalle_pedido() RETURNS TRIGGER AS $$
+BEGIN
+    SELECT p.precio INTO NEW.precio
+    FROM precio_producto_hist p
+    WHERE p.producto_id = NEW.producto_id
+      AND p.vigente_hasta IS NULL
+    ORDER BY p.vigente_desde DESC
+    LIMIT 1;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER set_precio_detalle_pedido
+BEFORE INSERT ON detalle_pedido
+FOR EACH ROW EXECUTE PROCEDURE set_precio_detalle_pedido();
+
+CREATE TABLE reserva (
+    id SERIAL PRIMARY KEY,
+    cliente_id INT NOT NULL,
+    fecha_reserva TIMESTAMP NOT NULL,
+    estado estado_reserva NOT NULL DEFAULT 'pendiente',
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    deleted_at TIMESTAMP
+);
+
+CREATE TABLE reserva_contacto (
+    id SERIAL PRIMARY KEY,
+    reserva_id INT REFERENCES reserva(id),
+    nombre TEXT NOT NULL,
+    telefono TEXT NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    deleted_at TIMESTAMP
+);
+
+CREATE TABLE restaurante_dia (
+    id SERIAL PRIMARY KEY,
+    dia dia_semana NOT NULL,
+    abierto BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    deleted_at TIMESTAMP
+);
+
+CREATE TABLE horario_trabajador (
+    id SERIAL PRIMARY KEY,
+    trabajador_id INT NOT NULL,
+    dia dia_semana NOT NULL,
+    hora_inicio TIME NOT NULL,
+    hora_fin TIME NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    deleted_at TIMESTAMP
+);
+
+-- +migrate Down
+DROP TRIGGER IF EXISTS set_precio_detalle_pedido ON detalle_pedido;
+DROP FUNCTION IF EXISTS set_precio_detalle_pedido;
+DROP TABLE IF EXISTS horario_trabajador;
+DROP TABLE IF EXISTS restaurante_dia;
+DROP TABLE IF EXISTS reserva_contacto;
+DROP TABLE IF EXISTS reserva;
+DROP TABLE IF EXISTS detalle_pedido;
+DROP TABLE IF EXISTS precio_producto_hist;
+DROP TABLE IF EXISTS control_nomina;
+DROP TABLE IF EXISTS nomina;
+DROP TABLE IF EXISTS domicilio;
+DROP TYPE IF EXISTS dia_semana;
+DROP TYPE IF EXISTS tipo_nomina;
+DROP TYPE IF EXISTS estado_reserva;
+DROP TYPE IF EXISTS estado_domicilio;

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -1,0 +1,17 @@
+# Database Migrations
+
+This directory contains SQL scripts for schema changes and seeds.
+
+## Execution Order
+1. `001_create_schema.sql` – creates enums, tables, triggers, and audit columns.
+2. `seed/001_seed.sql` – inserts seed data aligned with the new schema.
+
+Run each script in order using your preferred PostgreSQL tool, e.g.:
+
+```sh
+psql -f migrations/001_create_schema.sql
+psql -f migrations/seed/001_seed.sql
+```
+
+## Rollback
+To revert the changes, execute the SQL statements in the `Down` section of `001_create_schema.sql` (reverse order of creation). If you are using a migration tool, run the corresponding down migration.

--- a/migrations/seed/001_seed.sql
+++ b/migrations/seed/001_seed.sql
@@ -1,0 +1,35 @@
+-- Seed initial data for new tables
+
+INSERT INTO restaurante_dia (dia) VALUES
+  ('lunes'),
+  ('martes'),
+  ('miercoles'),
+  ('jueves'),
+  ('viernes'),
+  ('sabado'),
+  ('domingo');
+
+INSERT INTO precio_producto_hist (producto_id, precio) VALUES
+  (1, 10.00),
+  (2, 15.50);
+
+INSERT INTO nomina (trabajador_id, fecha, tipo, monto) VALUES
+  (1, CURRENT_DATE, 'mensual', 1000.00);
+
+INSERT INTO control_nomina (nomina_id, aprobado) VALUES
+  (1, true);
+
+INSERT INTO reserva (cliente_id, fecha_reserva, estado) VALUES
+  (1, NOW() + INTERVAL '1 day', 'pendiente');
+
+INSERT INTO reserva_contacto (reserva_id, nombre, telefono) VALUES
+  (1, 'Contacto', '0000000000');
+
+INSERT INTO domicilio (pedido_id, direccion, estado) VALUES
+  (1, 'Calle 123', 'pendiente');
+
+INSERT INTO detalle_pedido (pedido_id, producto_id, cantidad) VALUES
+  (1, 1, 2);
+
+INSERT INTO horario_trabajador (trabajador_id, dia, hora_inicio, hora_fin) VALUES
+  (1, 'lunes', '09:00', '17:00');


### PR DESCRIPTION
## Summary
- introduce SQL migrations for new enums, tables, trigger and audit fields
- add seed data aligning with new relationships
- document migration execution and rollback steps
- update README with migration instructions

## Testing
- ⚠️ `go test ./...` (hangs due to missing dependencies)


------
https://chatgpt.com/codex/tasks/task_e_68b365c648fc83258987612b93bfe3cd