### PR TITLE
Add estado field to Domicilio model and controller

### DIFF
--- a/controllers/DomicilioController.go
+++ b/controllers/DomicilioController.go
@@ -25,6 +25,7 @@ type DomicilioController struct {
 // @Param   direccion    query   string   false   "Filtrar por dirección"
 // @Param   telefono     query   string   false   "Filtrar por teléfono"
 // @Param   fecha        query   string   false   "Filtrar por fecha"
+// @Param   estado       query   string   false   "Filtrar por estado del domicilio"
 // @Param   updated_by   query   string   false   "Filtrar por usuario que realizó la última actualización"
 // @Param   trabajador   query   int      false   "ID del domiciliario solicitante"
 // @Success 200 {array} models.Domicilio "Lista de domicilios"
@@ -40,6 +41,7 @@ func (c *DomicilioController) GetAll() {
 	telefono := c.GetString("telefono")
 	updatedBy := c.GetString("updated_by")
 	fecha := c.GetString("fecha")
+	estado := c.GetString("estado")
 	trabajadorID, _ := c.GetInt("trabajador") // ID del domiciliario solicitante
 
 	// Aplicar filtros opcionales SOLO si se proporcionan
@@ -54,6 +56,9 @@ func (c *DomicilioController) GetAll() {
 	}
 	if fecha != "" {
 		qs = qs.Filter("FECHA", fecha)
+	}
+	if estado != "" {
+		qs = qs.Filter("ESTADO_DOMICILIO", estado)
 	}
 
 	// Aplicar condición para que los domiciliarios solo vean pedidos que pueden tomar
@@ -331,6 +336,9 @@ func (c *DomicilioController) Post() {
 	}
 
 	// Procesar campos opcionales
+	if estado, ok := input["estado"].(string); ok {
+		domicilio.ESTADO_DOMICILIO = estado
+	}
 	if estadoPago, ok := input["estadoPago"].(string); ok {
 		domicilio.ESTADO_PAGO = estadoPago
 	}
@@ -431,6 +439,9 @@ func (c *DomicilioController) Put() {
 	}
 	if telefono, ok := input["telefono"].(string); ok {
 		domicilio.TELEFONO = telefono
+	}
+	if estado, ok := input["estado"].(string); ok {
+		domicilio.ESTADO_DOMICILIO = estado
 	}
 	if estadoPago, ok := input["estadoPago"].(string); ok {
 		domicilio.ESTADO_PAGO = estadoPago

--- a/controllers/domicilio_controller_test.go
+++ b/controllers/domicilio_controller_test.go
@@ -44,7 +44,7 @@ func TestDomicilioPostInvalidJSON(t *testing.T) {
 }
 
 func TestDomicilioGetAllWithoutDB(t *testing.T) {
-	r := httptest.NewRequest(http.MethodGet, "/domicilios", nil)
+	r := httptest.NewRequest(http.MethodGet, "/domicilios?estado=pendiente", nil)
 	w := httptest.NewRecorder()
 	ctx := context.NewContext()
 	ctx.Reset(w, r)
@@ -117,7 +117,7 @@ func TestDomicilioPostMissingTelefono(t *testing.T) {
 }
 
 func TestDomicilioPostValidWithoutDB(t *testing.T) {
-	body := "{\"direccion\":\"A\",\"fechaDomicilio\":\"2024-01-01\",\"telefono\":\"123\"}"
+	body := "{\"direccion\":\"A\",\"fechaDomicilio\":\"2024-01-01\",\"telefono\":\"123\",\"estado\":\"pendiente\"}"
 	r := httptest.NewRequest(http.MethodPost, "/domicilios", strings.NewReader(body))
 	r.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()

--- a/models/Domicilio.go
+++ b/models/Domicilio.go
@@ -8,18 +8,19 @@ import (
 )
 
 type Domicilio struct {
-	PK_ID_DOMICILIO         int        `orm:"column(pk_id_domicilio);pk;auto" json:"domicilioId"`
-	DIRECCION               string     `orm:"column(direccion);type(text)" json:"direccion"`
-	TELEFONO                string     `orm:"column(telefono);type(text)" json:"telefono"`
-	ESTADO_PAGO             EstadoPago `orm:"column(estado_pago);type(text)" json:"estadoPago"`
-	ENTREGADO               bool       `orm:"column(entregado);type(boolean)" json:"entregado"`
-	FECHA                   time.Time  `orm:"column(fecha);type(date)" json:"fechaDomicilio"`
-	OBSERVACIONES           string     `orm:"column(observaciones);type(text)" json:"observaciones"`
-	CREATED_AT              time.Time  `orm:"column(created_at);type(timestamp);auto_now_add" json:"createdAt"`
-	UPDATED_AT              time.Time  `orm:"column(updated_at);type(timestamp);auto_now" json:"updatedAt"`
-	CREATED_BY              *string    `orm:"column(created_by);type(text)" json:"createdBy,omitempty"`
-	UPDATED_BY              *string    `orm:"column(updated_by);type(text)" json:"updatedBy,omitempty"`
-	PK_DOCUMENTO_TRABAJADOR *int       `orm:"column(pk_documento_trabajador);null" json:"trabajadorAsignado,omitempty"`
+	PK_ID_DOMICILIO         int             `orm:"column(pk_id_domicilio);pk;auto" json:"domicilioId"`
+	DIRECCION               string          `orm:"column(direccion);type(text)" json:"direccion"`
+	TELEFONO                string          `orm:"column(telefono);type(text)" json:"telefono"`
+	ESTADO_DOMICILIO        EstadoDomicilio `orm:"column(estado);type(text)" json:"estado"`
+	ESTADO_PAGO             EstadoPago      `orm:"column(estado_pago);type(text)" json:"estadoPago"`
+	ENTREGADO               bool            `orm:"column(entregado);type(boolean)" json:"entregado"`
+	FECHA                   time.Time       `orm:"column(fecha);type(date)" json:"fechaDomicilio"`
+	OBSERVACIONES           string          `orm:"column(observaciones);type(text)" json:"observaciones"`
+	CREATED_AT              time.Time       `orm:"column(created_at);type(timestamp);auto_now_add" json:"createdAt"`
+	UPDATED_AT              time.Time       `orm:"column(updated_at);type(timestamp);auto_now" json:"updatedAt"`
+	CREATED_BY              *string         `orm:"column(created_by);type(text)" json:"createdBy,omitempty"`
+	UPDATED_BY              *string         `orm:"column(updated_by);type(text)" json:"updatedBy,omitempty"`
+	PK_DOCUMENTO_TRABAJADOR *int            `orm:"column(pk_documento_trabajador);null" json:"trabajadorAsignado,omitempty"`
 }
 
 func (d *Domicilio) TableName() string {

--- a/models/domicilio_test.go
+++ b/models/domicilio_test.go
@@ -11,9 +11,10 @@ func TestDomicilioMarshalJSON(t *testing.T) {
 	created := time.Date(2024, time.August, 9, 14, 30, 0, 0, time.UTC)
 	updated := time.Date(2024, time.August, 11, 15, 45, 0, 0, time.UTC)
 	d := Domicilio{
-		FECHA:      fecha,
-		CREATED_AT: created,
-		UPDATED_AT: updated,
+		FECHA:            fecha,
+		ESTADO_DOMICILIO: EstadoDomicilioEnCamino,
+		CREATED_AT:       created,
+		UPDATED_AT:       updated,
 	}
 
 	b, err := json.Marshal(d)
@@ -28,6 +29,9 @@ func TestDomicilioMarshalJSON(t *testing.T) {
 
 	if data["fechaDomicilio"] != "10-08-2024" {
 		t.Errorf("expected fechaDomicilio 10-08-2024, got %v", data["fechaDomicilio"])
+	}
+	if data["estado"] != EstadoDomicilioEnCamino {
+		t.Errorf("expected estado %s, got %v", EstadoDomicilioEnCamino, data["estado"])
 	}
 	if data["createdAt"] != "09-08-2024 14:30:00" {
 		t.Errorf("expected createdAt 09-08-2024 14:30:00, got %v", data["createdAt"])


### PR DESCRIPTION
## Summary
- add `ESTADO_DOMICILIO` field with `estado` column and JSON tag
- allow filtering and updating domicilio `estado`
- extend domicilio tests for new status field

## Testing
- `go test ./...` *(fails: m.trabajador.HORARIO undefined; DetallePedido requires single pk)*

------
https://chatgpt.com/codex/tasks/task_e_68b3698c13d483258599547696984d25