### PR TITLE
Add payroll enum tests and price flow docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,19 @@ Go-based REST API for managing restaurant operations such as customers, orders, 
   go run main.go
   ```
 
+## Enumerated Types and Payroll
+- **States** are modeled with enums under `models/enums.go`:
+  - `EstadoReserva`: `pendiente`, `confirmada`, `cancelada`, `cumplida`.
+  - `EstadoNomina`: `pago`, `no pago`.
+  - Additional enums exist for domicilios, pagos, pedidos, productos y días de la semana.
+- **Price history** for products is stored in the `precio_producto_hist` table. A new entry is
+  created when a product is registered or its price changes, closing the previous record.
+- **Payroll (nómina)** operations:
+  - `POST /nominas` accepts optional `generar_nomina_automatica` parameters
+    (`fecha_inicio` y `fecha_fin`) to auto-generate payments.
+  - `PUT /nominas?id=...` transitions a payroll to `pago`.
+  - `DELETE /nominas?id=...` performs a logical deletion setting the state to `no pago`.
+
 ## Testing
 ```sh
 go test ./...

--- a/controllers/nomina_controller_test.go
+++ b/controllers/nomina_controller_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/beego/beego/v2/server/web/context"
+	"restaurante/models"
 )
 
 func TestNominaGetAllWithoutDB(t *testing.T) {
@@ -150,5 +151,14 @@ func TestNominaDeleteNotFound(t *testing.T) {
 	}
 	if !strings.Contains(w.Body.String(), "Nómina no encontrada") {
 		t.Errorf("unexpected body: %s", w.Body.String())
+	}
+}
+
+func TestEstadosNominaPermitidos(t *testing.T) {
+	if !estadosNominaPermitidos[models.EstadoNominaPago] || !estadosNominaPermitidos[models.EstadoNominaNoPago] {
+		t.Fatalf("expected valid states to be allowed")
+	}
+	if estadosNominaPermitidos[models.EstadoNomina("otro")] {
+		t.Fatalf("unexpected state should not be allowed")
 	}
 }

--- a/controllers/producto_controller_test.go
+++ b/controllers/producto_controller_test.go
@@ -80,7 +80,8 @@ func TestValidateProducto(t *testing.T) {
 
 	tests := []models.Producto{
 		{PRECIO: 10, ESTADO_PRODUCTO: "disponible"},                                      // missing name
-		{NOMBRE: "B", PRECIO: 0, ESTADO_PRODUCTO: "disponible"},                          // invalid price
+		{NOMBRE: "B", PRECIO: 0, ESTADO_PRODUCTO: "disponible"},                          // zero price
+		{NOMBRE: "B", PRECIO: -5, ESTADO_PRODUCTO: "disponible"},                         // negative price
 		{NOMBRE: "B", PRECIO: 10, CALORIAS: int64Ptr(-1), ESTADO_PRODUCTO: "disponible"}, // negative calories
 		{NOMBRE: "B", PRECIO: 10, ESTADO_PRODUCTO: "OTRO"},                               // invalid estado
 	}

--- a/controllers/reserva_controller_test.go
+++ b/controllers/reserva_controller_test.go
@@ -694,3 +694,48 @@ func TestReservaDeleteScenarios(t *testing.T) {
 		t.Fatalf("expected 200, got %d", w.Code)
 	}
 }
+
+func TestReservaPutInvalidEstadoIgnored(t *testing.T) {
+	pend := "pendiente"
+	db := map[int]models.Reserva{1: {PK_ID_RESERVA: 1, ESTADO_RESERVA: &pend}}
+	ormNew = func() orm.Ormer { return nil }
+	readReserva = func(o orm.Ormer, r *models.Reserva) error {
+		if res, ok := db[int(r.PK_ID_RESERVA)]; ok {
+			*r = res
+			return nil
+		}
+		return orm.ErrNoRows
+	}
+	var updated models.Reserva
+	updateReserva = func(o orm.Ormer, r *models.Reserva, cols ...string) (int64, error) {
+		updated = *r
+		return 1, nil
+	}
+	t.Cleanup(resetReservaMocks)
+
+	payload := map[string]interface{}{
+		"estadoReserva":    "invalido",
+		"fechaReserva":     "2024-01-01",
+		"horaReserva":      "12:00:00",
+		"personas":         2,
+		"documentoCliente": 123,
+	}
+	body, _ := json.Marshal(payload)
+	r := httptest.NewRequest(http.MethodPut, "/reservas?id=1", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	ctx.Input.RequestBody = body
+	c := ReservaController{}
+	c.Ctx = ctx
+	c.Data = map[interface{}]interface{}{}
+
+	c.Put()
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if updated.ESTADO_RESERVA == nil || *updated.ESTADO_RESERVA != pend {
+		t.Fatalf("estado should remain %s, got %v", pend, updated.ESTADO_RESERVA)
+	}
+}

--- a/tests/enums_test.go
+++ b/tests/enums_test.go
@@ -1,0 +1,31 @@
+package test
+
+import (
+	"restaurante/models"
+	"testing"
+)
+
+// TestEstadoEnums verifies that the enumerated constants map to the expected string values.
+func TestEstadoEnums(t *testing.T) {
+	reservas := map[string]models.EstadoReserva{
+		"pendiente":  models.EstadoReservaPendiente,
+		"confirmada": models.EstadoReservaConfirmada,
+		"cancelada":  models.EstadoReservaCancelada,
+		"cumplida":   models.EstadoReservaCumplida,
+	}
+	for expect, val := range reservas {
+		if string(val) != expect {
+			t.Errorf("EstadoReserva %s mismatched", expect)
+		}
+	}
+
+	nominas := map[string]models.EstadoNomina{
+		"pago":    models.EstadoNominaPago,
+		"no pago": models.EstadoNominaNoPago,
+	}
+	for expect, val := range nominas {
+		if string(val) != expect {
+			t.Errorf("EstadoNomina %s mismatched", expect)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- test enum constants for nominas and reservas
- validate product price including negative values
- cover reserva update when state is invalid
- document enum usage, price history table, and payroll flow

## Testing
- `go test ./...` *(fails: TestNominaPostMissingDatesForAutoGeneration, TestPedidoAssignDomicilioUpdateError, TestPedidoAssignDomicilioSuccess, TestPedidoAssignPagoUpdateError, TestPedidoAssignPagoSuccess, TestPedidoUpdateEstadoPedidoUpdateError, TestPedidoUpdateEstadoPedidoSuccess, TestInitDBSuccess, TestDomicilioTableName, TestNominaTableName, TestPedidoTableName, TestReservaTableName)*

------
https://chatgpt.com/codex/tasks/task_e_68b381ace9608325b5eefd96f7c14054