### PR TITLE
Eliminar precio de entradas de ProductoPedido

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ Go-based REST API for managing restaurant operations such as customers, orders, 
   - Additional enums exist for domicilios, pagos, pedidos, productos y días de la semana.
 - **Price history** for products is stored in the `precio_producto_hist` table. A new entry is
   created when a product is registered or its price changes, closing the previous record.
+- `POST /producto_pedido` and `PUT /producto_pedido` no longer accept `precio` in the payload; the
+  database trigger assigns it automatically.
 - **Payroll (nómina)** operations:
   - `POST /nominas` accepts optional `generar_nomina_automatica` parameters
     (`fecha_inicio` y `fecha_fin`) to auto-generate payments.

--- a/controllers/ProductoPedidoController.go
+++ b/controllers/ProductoPedidoController.go
@@ -27,6 +27,12 @@ type ProductoPedidoResponse struct {
 	Detalles interface{} `json:"detalles"`
 }
 
+// detallePedidoInput represents the payload for DetallePedido without precio.
+type detallePedidoInput struct {
+	PKIDProducto int64 `json:"productoId"`
+	Cantidad     int   `json:"cantidad"`
+}
+
 // @Title GetAll
 // @Summary Obtener los productos de un pedido
 // @Description Devuelve los productos consolidados en un pedido específico
@@ -100,8 +106,8 @@ func (c *ProductoPedidoController) GetAll() {
 // @Router /producto_pedido [post]
 func (c *ProductoPedidoController) Post() {
 	var input struct {
-		PedidoId int64                  `json:"pedidoId"`
-		Detalles []models.DetallePedido `json:"detalles"`
+		PedidoId int64                `json:"pedidoId"`
+		Detalles []detallePedidoInput `json:"detalles"`
 	}
 
 	if err := json.Unmarshal(c.Ctx.Input.RequestBody, &input); err != nil {
@@ -182,7 +188,7 @@ func (c *ProductoPedidoController) Update() {
 	}
 
 	// Parsear los datos del cuerpo de la solicitud
-	var nuevosProductos []models.DetallePedido
+	var nuevosProductos []detallePedidoInput
 	if err := json.Unmarshal(c.Ctx.Input.RequestBody, &nuevosProductos); err != nil {
 		c.Data["json"] = models.ApiResponse{
 			Code:    http.StatusBadRequest,

--- a/controllers/producto_pedido_controller_test.go
+++ b/controllers/producto_pedido_controller_test.go
@@ -266,8 +266,12 @@ func TestProductoPedidoGetAllSuccess(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected status 200, got %d", w.Code)
 	}
-	if !strings.Contains(w.Body.String(), "detalles") {
-		t.Errorf("unexpected body: %s", w.Body.String())
+	body := w.Body.String()
+	if !strings.Contains(body, "detalles") {
+		t.Errorf("unexpected body: %s", body)
+	}
+	if !strings.Contains(body, "\"precio\":1000") {
+		t.Errorf("expected price in response, got %s", body)
 	}
 }
 

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -2510,7 +2510,7 @@ const docTemplate = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "Permite agregar o modificar productos en un pedido consolidado",
+                "description": "Permite agregar o modificar productos en un pedido consolidado. Los precios se establecen automáticamente en la base de datos, por lo que los detalles no deben enviar el campo 'precio'.",
                 "consumes": [
                     "application/json"
                 ],
@@ -2576,7 +2576,7 @@ const docTemplate = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "Crea un registro de productos consolidados en un pedido",
+                "description": "Crea un registro de productos consolidados en un pedido. Los precios de cada producto se calculan mediante un trigger en la base de datos; no incluir el campo 'precio' en los detalles.",
                 "consumes": [
                     "application/json"
                 ],

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -2503,7 +2503,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Permite agregar o modificar productos en un pedido consolidado",
+                "description": "Permite agregar o modificar productos en un pedido consolidado. Los precios se establecen automáticamente en la base de datos, por lo que los detalles no deben enviar el campo 'precio'.",
                 "consumes": [
                     "application/json"
                 ],
@@ -2569,7 +2569,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Crea un registro de productos consolidados en un pedido",
+                "description": "Crea un registro de productos consolidados en un pedido. Los precios de cada producto se calculan mediante un trigger en la base de datos; no incluir el campo `precio` en los detalles.",
                 "consumes": [
                     "application/json"
                 ],

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1928,7 +1928,9 @@ paths:
     post:
       consumes:
       - application/json
-      description: Crea un registro de productos consolidados en un pedido
+      description: Crea un registro de productos consolidados en un pedido. Los precios de cada
+        producto se calculan mediante un trigger en la base de datos; no incluir el campo
+        'precio' en los detalles.
       parameters:
       - description: Datos del pedido con productos
         in: body
@@ -1959,7 +1961,9 @@ paths:
     put:
       consumes:
       - application/json
-      description: Permite agregar o modificar productos en un pedido consolidado
+      description: Permite agregar o modificar productos en un pedido consolidado. Los precios se
+        establecen automáticamente en la base de datos, por lo que los detalles no deben enviar
+        el campo 'precio'.
       parameters:
       - description: ID del pedido a actualizar
         in: query


### PR DESCRIPTION
## Summary
- Remove `precio` from ProductoPedido request payloads and rely on DB trigger
- Verify database-generated prices in ProductoPedido controller tests
- Document that `precio` is omitted from ProductoPedido operations

## Testing
- `go test ./...` *(fails: field: models.DetallePedido.PKIDProducto, one model must have one pk field only)*

------
https://chatgpt.com/codex/tasks/task_e_68b38aa9e38c83258af22bdbc920f67f