### PR TITLE
Use EstadoReserva enum for reservation validation

### DIFF
--- a/controllers/ReservaController.go
+++ b/controllers/ReservaController.go
@@ -17,11 +17,11 @@ type ReservaController struct {
 }
 
 // Estados permitidos para la reserva
-var estadosPermitidos = map[string]bool{
-	"pendiente":  true,
-	"confirmada": true,
-	"cancelada":  true,
-	"cumplida":   true,
+var estadosPermitidos = map[models.EstadoReserva]bool{
+	models.EstadoReservaPendiente:  true,
+	models.EstadoReservaConfirmada: true,
+	models.EstadoReservaCancelada:  true,
+	models.EstadoReservaCumplida:   true,
 }
 
 var queryAllReservas = func(o orm.Ormer, reservas *[]models.Reserva) (int64, error) {
@@ -241,18 +241,21 @@ func (c *ReservaController) Post() {
 	}
 
 	// Procesar ESTADO_RESERVA si existe
-	if estado, ok := input["estadoReserva"].(string); ok && estado != "" {
-		if !estadosPermitidos[estado] {
-			c.Ctx.Output.SetStatus(http.StatusBadRequest)
-			c.Data["json"] = models.ApiResponse{
-				Code:    http.StatusBadRequest,
-				Message: "Estado de reserva inválido",
-				Cause:   "El estado debe ser uno de los siguientes: pendiente, confirmada, cancelada, cumplida",
+	if estadoStr, ok := input["estadoReserva"].(string); ok {
+		estado := models.EstadoReserva(estadoStr)
+		if estado != "" {
+			if !estadosPermitidos[estado] {
+				c.Ctx.Output.SetStatus(http.StatusBadRequest)
+				c.Data["json"] = models.ApiResponse{
+					Code:    http.StatusBadRequest,
+					Message: "Estado de reserva inválido",
+					Cause:   "El estado debe ser uno de los siguientes: pendiente, confirmada, cancelada, cumplida",
+				}
+				c.ServeJSON()
+				return
 			}
-			c.ServeJSON()
-			return
+			reserva.ESTADO_RESERVA = &estado
 		}
-		reserva.ESTADO_RESERVA = &estado
 	}
 
 	// Procesar INDICACIONES si existe
@@ -399,8 +402,11 @@ func (c *ReservaController) Put() {
 		reserva.PERSONAS = int(personas)
 	}
 
-	if estado, ok := input["estadoReserva"].(string); ok && estadosPermitidos[estado] {
-		reserva.ESTADO_RESERVA = &estado
+	if estadoStr, ok := input["estadoReserva"].(string); ok {
+		estado := models.EstadoReserva(estadoStr)
+		if estadosPermitidos[estado] {
+			reserva.ESTADO_RESERVA = &estado
+		}
 	}
 
 	if indicaciones, ok := input["indicaciones"].(string); ok {

--- a/controllers/reserva_controller_test.go
+++ b/controllers/reserva_controller_test.go
@@ -446,7 +446,7 @@ func TestReservaPostSuccess(t *testing.T) {
 		"horaReserva":      "12:00:00",
 		"personas":         2,
 		"documentoCliente": 123,
-		"estadoReserva":    "confirmada",
+		"estadoReserva":    models.EstadoReservaConfirmada,
 		"indicaciones":     "Ninguna",
 		"createdBy":        "admin",
 		"nombreCompleto":   "John Doe",
@@ -586,7 +586,7 @@ func TestReservaPutScenarios(t *testing.T) {
 		"fechaReserva":     "2024-01-02",
 		"horaReserva":      "13:00:00",
 		"personas":         3,
-		"estadoReserva":    "confirmada",
+		"estadoReserva":    models.EstadoReservaConfirmada,
 		"indicaciones":     "OK",
 		"updatedBy":        "admin",
 		"nombreCompleto":   "John",
@@ -696,7 +696,7 @@ func TestReservaDeleteScenarios(t *testing.T) {
 }
 
 func TestReservaPutInvalidEstadoIgnored(t *testing.T) {
-	pend := "pendiente"
+	pend := models.EstadoReservaPendiente
 	db := map[int]models.Reserva{1: {PK_ID_RESERVA: 1, ESTADO_RESERVA: &pend}}
 	ormNew = func() orm.Ormer { return nil }
 	readReserva = func(o orm.Ormer, r *models.Reserva) error {

--- a/models/reserva_test.go
+++ b/models/reserva_test.go
@@ -8,7 +8,8 @@ import (
 
 func TestReservaMarshalJSON(t *testing.T) {
 	fecha := time.Date(2024, time.September, 12, 0, 0, 0, 0, time.UTC)
-	r := Reserva{FECHA: fecha}
+	estado := EstadoReservaConfirmada
+	r := Reserva{FECHA: fecha, ESTADO_RESERVA: &estado}
 
 	b, err := json.Marshal(r)
 	if err != nil {
@@ -22,6 +23,9 @@ func TestReservaMarshalJSON(t *testing.T) {
 
 	if data["fechaReserva"] != "12-09-2024" {
 		t.Errorf("expected fechaReserva 12-09-2024, got %v", data["fechaReserva"])
+	}
+	if data["estadoReserva"] != string(EstadoReservaConfirmada) {
+		t.Errorf("expected estadoReserva %s, got %v", EstadoReservaConfirmada, data["estadoReserva"])
 	}
 }
 


### PR DESCRIPTION
## Summary
- enforce ReservaController state validation using `models.EstadoReserva`
- update reservation controller and model tests to rely on enum values

## Testing
- `go test ./...` *(fails: models.DetallePedido.PKIDProducto, one model must have one pk field only)*

------
https://chatgpt.com/codex/tasks/task_e_68b38c968b84832583fb2775130848f3