### PR TITLE
Normalize ORM table and column identifiers

### DIFF
--- a/controllers/CambiosHorarioController.go
+++ b/controllers/CambiosHorarioController.go
@@ -35,13 +35,13 @@ var (
 		return o.Insert(horario)
 	}
 	queryCambioHorarioByID = func(o orm.Ormer, id int64, horario *models.CambiosHorario) error {
-		return o.QueryTable(new(models.CambiosHorario)).Filter("cambioHorarioId", id).One(horario)
+		return o.QueryTable(new(models.CambiosHorario)).Filter("PK_ID_CAMBIO_HORARIO", id).One(horario)
 	}
 	updateCambioHorario = func(o orm.Ormer, horario *models.CambiosHorario) (int64, error) {
 		return o.Update(horario)
 	}
 	deleteCambioHorarioByID = func(o orm.Ormer, id int64) (int64, error) {
-		return o.QueryTable(new(models.CambiosHorario)).Filter("cambioHorarioId", id).Delete()
+		return o.QueryTable(new(models.CambiosHorario)).Filter("PK_ID_CAMBIO_HORARIO", id).Delete()
 	}
 )
 

--- a/models/CambiosHorario.go
+++ b/models/CambiosHorario.go
@@ -8,15 +8,15 @@ import (
 )
 
 type CambiosHorario struct {
-	PK_ID_CAMBIO_HORARIO int64      `orm:"column(PK_ID_CAMBIO_HORARIO);pk;auto" json:"cambioHorarioId"`
-	FECHA                time.Time  `orm:"column(FECHA);type(date)" json:"fechaCambioHorario"`
-	HORA_APERTURA        *time.Time `orm:"column(HORA_APERTURA);type(time);null" json:"horaApertura,omitempty"`
-	HORA_CIERRE          *time.Time `orm:"column(HORA_CIERRE);type(time);null" json:"horaCierre,omitempty"`
-	ABIERTO              bool       `orm:"column(ABIERTO)" json:"abierto"`
+	PK_ID_CAMBIO_HORARIO int64      `orm:"column(pk_id_cambio_horario);pk;auto" json:"cambioHorarioId"`
+	FECHA                time.Time  `orm:"column(fecha);type(date)" json:"fechaCambioHorario"`
+	HORA_APERTURA        *time.Time `orm:"column(hora_apertura);type(time);null" json:"horaApertura,omitempty"`
+	HORA_CIERRE          *time.Time `orm:"column(hora_cierre);type(time);null" json:"horaCierre,omitempty"`
+	ABIERTO              bool       `orm:"column(abierto)" json:"abierto"`
 }
 
 func (t *CambiosHorario) TableName() string {
-	return "CAMBIOS_HORARIO"
+	return "cambios_horario"
 }
 func init() {
 	orm.RegisterModel(new(CambiosHorario))

--- a/models/Incidencia.go
+++ b/models/Incidencia.go
@@ -8,16 +8,16 @@ import (
 )
 
 type Incidencia struct {
-	PK_ID_INCIDENCIA        int64     `orm:"column(PK_ID_INCIDENCIA);pk;auto" json:"incidenciaId"`
-	FECHA                   time.Time `orm:"column(FECHA);type(date)" json:"fechaIncidencia"`
-	MONTO                   int64     `orm:"column(MONTO)" json:"monto"`
-	RESTA                   bool      `orm:"column(RESTA);type(boolean)" json:"resta"`
-	MOTIVO                  string    `orm:"column(MOTIVO);type(text)" json:"motivo"`
-	PK_DOCUMENTO_TRABAJADOR *int64    `orm:"column(PK_DOCUMENTO_TRABAJADOR);null" json:"documentoTrabajador,omitempty"`
+	PK_ID_INCIDENCIA        int64     `orm:"column(pk_id_incidencia);pk;auto" json:"incidenciaId"`
+	FECHA                   time.Time `orm:"column(fecha);type(date)" json:"fechaIncidencia"`
+	MONTO                   int64     `orm:"column(monto)" json:"monto"`
+	RESTA                   bool      `orm:"column(resta);type(boolean)" json:"resta"`
+	MOTIVO                  string    `orm:"column(motivo);type(text)" json:"motivo"`
+	PK_DOCUMENTO_TRABAJADOR *int64    `orm:"column(pk_documento_trabajador);null" json:"documentoTrabajador,omitempty"`
 }
 
 func (i *Incidencia) TableName() string {
-	return "INCIDENCIA"
+	return "incidencia"
 }
 
 func init() {

--- a/models/MetodoPago.go
+++ b/models/MetodoPago.go
@@ -3,13 +3,13 @@ package models
 import "github.com/beego/beego/v2/client/orm"
 
 type MetodoPago struct {
-	PK_ID_METODO_PAGO int    `orm:"column(PK_ID_METODO_PAGO);pk;auto" json:"metodoPagoId"`
-	TIPO              string `orm:"column(TIPO);size(50)" json:"tipo"`
-	DETALLE           string `orm:"column(DETALLE);type(text);null" json:"detalle"`
+	PK_ID_METODO_PAGO int    `orm:"column(pk_id_metodo_pago);pk;auto" json:"metodoPagoId"`
+	TIPO              string `orm:"column(tipo);size(50)" json:"tipo"`
+	DETALLE           string `orm:"column(detalle);type(text);null" json:"detalle"`
 }
 
 func (m *MetodoPago) TableName() string {
-	return "METODO_PAGO"
+	return "metodo_pago"
 }
 
 func init() {

--- a/models/PedidoCliente.go
+++ b/models/PedidoCliente.go
@@ -3,13 +3,13 @@ package models
 import "github.com/beego/beego/v2/client/orm"
 
 type PedidoCliente struct {
-	PK_ID_PEDIDO_CLIENTE int64 `orm:"column(PK_ID_PEDIDO_CLIENTE);pk;auto" json:"pedidoClienteId"`
-	PK_DOCUMENTO_CLIENTE int64 `orm:"column(PK_DOCUMENTO_CLIENTE);null" json:"documentoCliente"`
-	PK_ID_PEDIDO         int   `orm:"column(PK_ID_PEDIDO);null" json:"pedidoId"`
+	PK_ID_PEDIDO_CLIENTE int64 `orm:"column(pk_id_pedido_cliente);pk;auto" json:"pedidoClienteId"`
+	PK_DOCUMENTO_CLIENTE int64 `orm:"column(pk_documento_cliente);null" json:"documentoCliente"`
+	PK_ID_PEDIDO         int   `orm:"column(pk_id_pedido);null" json:"pedidoId"`
 }
 
 func (pc *PedidoCliente) TableName() string {
-	return "PEDIDO_CLIENTE"
+	return "pedido_cliente"
 }
 
 func init() {

--- a/models/Restaurante.go
+++ b/models/Restaurante.go
@@ -9,16 +9,16 @@ import (
 var jsonMarshal = json.Marshal
 
 type Restaurante struct {
-	PK_ID_RESTAURANTE    int    `orm:"column(PK_ID_RESTAURANTE);pk" json:"restauranteId"`
-	NOMBRE_RESTAURANTE   string `orm:"column(NOMBRE_RESTAURANTE)" json:"nombreRestaurante"`
-	HORA_APERTURA        string `orm:"column(HORA_APERTURA);type(time)" json:"horaApertura"`
-	DIAS_LABORALES       string `orm:"column(DIAS_LABORALES)" json:"diasLaborales"`
-	PK_ID_CAMBIO_HORARIO *int   `orm:"column(PK_ID_CAMBIO_HORARIO);null" json:"-"`
-	PK_ID_RESERVA        *int   `orm:"column(PK_ID_RESERVA);null" json:"-"`
+	PK_ID_RESTAURANTE    int    `orm:"column(pk_id_restaurante);pk" json:"restauranteId"`
+	NOMBRE_RESTAURANTE   string `orm:"column(nombre_restaurante)" json:"nombreRestaurante"`
+	HORA_APERTURA        string `orm:"column(hora_apertura);type(time)" json:"horaApertura"`
+	DIAS_LABORALES       string `orm:"column(dias_laborales)" json:"diasLaborales"`
+	PK_ID_CAMBIO_HORARIO *int   `orm:"column(pk_id_cambio_horario);null" json:"-"`
+	PK_ID_RESERVA        *int   `orm:"column(pk_id_reserva);null" json:"-"`
 }
 
 func (t *Restaurante) TableName() string {
-	return "RESTAURANTE"
+	return "restaurante"
 }
 
 // Método para establecer los días laborales como una cadena JSON

--- a/models/Trabajador.go
+++ b/models/Trabajador.go
@@ -8,23 +8,23 @@ import (
 )
 
 type Trabajador struct {
-	PK_DOCUMENTO_TRABAJADOR int64               `orm:"column(PK_DOCUMENTO_TRABAJADOR);pk" json:"documentoTrabajador"`
-	NOMBRE                  string              `orm:"column(NOMBRE);type(text)" json:"nombre"`
-	APELLIDO                string              `orm:"column(APELLIDO);type(text)" json:"apellido"`
-	SUELDO                  int64               `orm:"column(SUELDO)" json:"sueldo"`
-	TELEFONO                *string             `orm:"column(TELEFONO);type(text);null" json:"telefono,omitempty"`
-	FECHA_NACIMIENTO        *time.Time          `orm:"column(FECHA_NACIMIENTO);type(date)" json:"fechaNacimiento,omitempty"`
-	NUEVO                   bool                `orm:"column(NUEVO);type(boolean)" json:"nuevo"`
-	ROL                     string              `orm:"column(ROL);type(text)" json:"rol"`
-	FECHA_INGRESO           time.Time           `orm:"column(FECHA_INGRESO);type(date)" json:"fechaIngreso"`
-	FECHA_RETIRO            *time.Time          `orm:"column(FECHA_RETIRO);type(date);null" json:"fechaRetiro,omitempty"`
-	PASSWORD                string              `orm:"column(PASSWORD)" json:"password"`
+	PK_DOCUMENTO_TRABAJADOR int64               `orm:"column(pk_documento_trabajador);pk" json:"documentoTrabajador"`
+	NOMBRE                  string              `orm:"column(nombre);type(text)" json:"nombre"`
+	APELLIDO                string              `orm:"column(apellido);type(text)" json:"apellido"`
+	SUELDO                  int64               `orm:"column(sueldo)" json:"sueldo"`
+	TELEFONO                *string             `orm:"column(telefono);type(text);null" json:"telefono,omitempty"`
+	FECHA_NACIMIENTO        *time.Time          `orm:"column(fecha_nacimiento);type(date)" json:"fechaNacimiento,omitempty"`
+	NUEVO                   bool                `orm:"column(nuevo);type(boolean)" json:"nuevo"`
+	ROL                     string              `orm:"column(rol);type(text)" json:"rol"`
+	FECHA_INGRESO           time.Time           `orm:"column(fecha_ingreso);type(date)" json:"fechaIngreso"`
+	FECHA_RETIRO            *time.Time          `orm:"column(fecha_retiro);type(date);null" json:"fechaRetiro,omitempty"`
+	PASSWORD                string              `orm:"column(password)" json:"password"`
 	HORARIOS                []HorarioTrabajador `orm:"-" json:"horarios,omitempty"`
-	PK_ID_RESTAURANTE       *int64              `orm:"column(PK_ID_RESTAURANTE);null" json:"restauranteId,omitempty"`
+	PK_ID_RESTAURANTE       *int64              `orm:"column(pk_id_restaurante);null" json:"restauranteId,omitempty"`
 }
 
 func (t *Trabajador) TableName() string {
-	return "TRABAJADOR"
+	return "trabajador"
 }
 
 func init() {

--- a/models/cambioshorario_test.go
+++ b/models/cambioshorario_test.go
@@ -27,7 +27,7 @@ func TestCambiosHorarioMarshalJSON(t *testing.T) {
 
 func TestCambiosHorarioTableName(t *testing.T) {
 	c := CambiosHorario{}
-	if c.TableName() != "CAMBIOS_HORARIO" {
-		t.Errorf("expected table name CAMBIOS_HORARIO, got %s", c.TableName())
+	if c.TableName() != "cambios_horario" {
+		t.Errorf("expected table name cambios_horario, got %s", c.TableName())
 	}
 }

--- a/models/incidencia_test.go
+++ b/models/incidencia_test.go
@@ -27,7 +27,7 @@ func TestIncidenciaMarshalJSON(t *testing.T) {
 
 func TestIncidenciaTableName(t *testing.T) {
 	i := Incidencia{}
-	if i.TableName() != "INCIDENCIA" {
-		t.Errorf("expected table name INCIDENCIA, got %s", i.TableName())
+	if i.TableName() != "incidencia" {
+		t.Errorf("expected table name incidencia, got %s", i.TableName())
 	}
 }

--- a/models/trabajador_test.go
+++ b/models/trabajador_test.go
@@ -39,8 +39,8 @@ func TestTrabajadorMarshalJSON(t *testing.T) {
 
 func TestTrabajadorTableName(t *testing.T) {
 	tr := Trabajador{}
-	if tr.TableName() != "TRABAJADOR" {
-		t.Errorf("expected table name TRABAJADOR, got %s", tr.TableName())
+	if tr.TableName() != "trabajador" {
+		t.Errorf("expected table name trabajador, got %s", tr.TableName())
 	}
 }
 


### PR DESCRIPTION
## Summary
- use lowercase column names and table names in Restaurante, PedidoCliente, Incidencia, Trabajador, CambiosHorario, and MetodoPago models
- align CambiosHorarioController queries with new column names
- update model tests for new table names

## Testing
- `go test ./models -run TestTrabajadorTableName -v` *(fails: field: models.DetallePedido.PKIDProducto, one model must have one pk field only)*

------
https://chatgpt.com/codex/tasks/task_e_68b38ed52be8832584a06e64c1fa64a5