### PR TITLE
chore: update payroll procedures

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,9 @@ Go-based REST API for managing restaurant operations such as customers, orders, 
 - `POST /producto_pedido` and `PUT /producto_pedido` no longer accept `precio` in the payload; the
   database trigger assigns it automatically.
 - **Payroll (nómina)** operations:
-  - `POST /nominas` accepts optional `generar_nomina_automatica` parameters
-    (`fecha_inicio` y `fecha_fin`) to auto-generate payments.
+  - `POST /nominas` accepts optional `generar_nomina_automatica` and
+    `verificar_nomina` parameters (`fecha_inicio` y `fecha_fin`) to
+    auto-generate payments and verify payroll records.
   - `PUT /nominas?id=...` transitions a payroll to `pago`.
   - `DELETE /nominas?id=...` performs a logical deletion setting the state to `no pago`.
 

--- a/controllers/NominaController.go
+++ b/controllers/NominaController.go
@@ -127,7 +127,7 @@ func (c *NominaController) Post() {
 	input.MONTO = 0 // Dejar en 0 para que sea calculado automáticamente por la función
 
 	var fechaInicio, fechaFin time.Time
-	if gen {
+	if gen || ver {
 		fechaInicioStr := c.GetString("fecha_inicio")
 		fechaFinStr := c.GetString("fecha_fin")
 		if fechaInicioStr == "" || fechaFinStr == "" {
@@ -177,31 +177,31 @@ func (c *NominaController) Post() {
 	}
 
 	// Ejecutar funciones adicionales si se solicitan
-	if gen {
-		if _, err := o.Raw("CALL generar_nomina_automatica(?, ?)", fechaInicio.Format("2006-01-02"), fechaFin.Format("2006-01-02")).Exec(); err != nil {
-			c.Ctx.Output.SetStatus(http.StatusInternalServerError)
-			c.Data["json"] = models.ApiResponse{
-				Code:    http.StatusInternalServerError,
-				Message: "Error al generar nómina automática",
-				Cause:   err.Error(),
-			}
-			c.ServeJSON()
-			return
-		}
-	}
+       if gen {
+               if _, err := o.Raw("CALL generar_nomina_automatica(?, ?, ?)", input.PK_ID_NOMINA, fechaInicio.Format("2006-01-02"), fechaFin.Format("2006-01-02")).Exec(); err != nil {
+                       c.Ctx.Output.SetStatus(http.StatusInternalServerError)
+                       c.Data["json"] = models.ApiResponse{
+                               Code:    http.StatusInternalServerError,
+                               Message: "Error al generar nómina automática",
+                               Cause:   err.Error(),
+                       }
+                       c.ServeJSON()
+                       return
+               }
+       }
 
-	if ver {
-		if _, err := o.Raw("CALL verificar_nomina(?)", input.PK_ID_NOMINA).Exec(); err != nil {
-			c.Ctx.Output.SetStatus(http.StatusInternalServerError)
-			c.Data["json"] = models.ApiResponse{
-				Code:    http.StatusInternalServerError,
-				Message: "Error al verificar nómina",
-				Cause:   err.Error(),
-			}
-			c.ServeJSON()
-			return
-		}
-	}
+       if ver {
+               if _, err := o.Raw("CALL verificar_nomina(?, ?, ?)", input.PK_ID_NOMINA, fechaInicio.Format("2006-01-02"), fechaFin.Format("2006-01-02")).Exec(); err != nil {
+                       c.Ctx.Output.SetStatus(http.StatusInternalServerError)
+                       c.Data["json"] = models.ApiResponse{
+                               Code:    http.StatusInternalServerError,
+                               Message: "Error al verificar nómina",
+                               Cause:   err.Error(),
+                       }
+                       c.ServeJSON()
+                       return
+               }
+       }
 
 	var updatedNomina models.Nomina
 	err = o.QueryTable(new(models.Nomina)).

--- a/controllers/nomina_controller_test.go
+++ b/controllers/nomina_controller_test.go
@@ -64,6 +64,25 @@ func TestNominaPostMissingDatesForAutoGeneration(t *testing.T) {
 	}
 }
 
+func TestNominaPostMissingDatesForVerification(t *testing.T) {
+	r := httptest.NewRequest(http.MethodPost, "/nominas?verificar_nomina=true", strings.NewReader("{}"))
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	c := NominaController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	c.Post()
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "fecha_inicio") {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
+}
+
 func TestNominaPostDBError(t *testing.T) {
 	r := httptest.NewRequest(http.MethodPost, "/nominas", nil)
 	w := httptest.NewRecorder()


### PR DESCRIPTION
## Summary
- require fecha_inicio and fecha_fin when generating or verifying payroll
- pass payroll ID and dates to generar_nomina_automatica and verificar_nomina procedures
- cover date validation for verification in tests and document new parameters

## Testing
- `go test ./...` *(fails: field: models.DetallePedido.PKIDProducto, one model must have one pk field only)*

------
https://chatgpt.com/codex/tasks/task_e_68b393717d4c8325b87889fd01a2bf27