### PR TITLE
feat: use camelCase tags for nomina trabajador

### DIFF
--- a/controllers/NominaTrabajadorController.go
+++ b/controllers/NominaTrabajadorController.go
@@ -42,26 +42,12 @@ func (c *NominaTrabajadorController) GetAll() {
 		return
 	}
 
-	// Convertir las claves a camelCase
-	var relacionesCamelCase []map[string]interface{}
-	for _, rel := range relaciones {
-		relacionesCamelCase = append(relacionesCamelCase, map[string]interface{}{
-			"nominaTrabajadorId":  rel.PK_ID_NOMINA_TRABAJADOR,
-			"sueldoBase":          rel.SUELDO_BASE,
-			"montoIncidencias":    rel.MONTO_INCIDENCIAS,
-			"total":               rel.TOTAL,
-			"detalles":            rel.DETALLES,
-			"documentoTrabajador": rel.PK_DOCUMENTO_TRABAJADOR,
-			"nominaId":            rel.PK_ID_NOMINA,
-		})
-	}
-
 	// Responder con éxito
 	c.Ctx.Output.SetStatus(http.StatusOK)
 	c.Data["json"] = models.ApiResponse{
 		Code:    http.StatusOK,
 		Message: "Relaciones nómina-trabajador obtenidas correctamente",
-		Data:    relacionesCamelCase,
+		Data:    relaciones,
 	}
 	c.ServeJSON()
 }
@@ -100,7 +86,7 @@ func (c *NominaTrabajadorController) Post() {
 		c.Ctx.Output.SetStatus(http.StatusBadRequest)
 		c.Data["json"] = models.ApiResponse{
 			Code:    http.StatusBadRequest,
-			Message: "El campo PK_DOCUMENTO_TRABAJADOR es obligatorio y debe ser válido",
+			Message: "El campo documentoTrabajador es obligatorio y debe ser válido",
 		}
 		c.ServeJSON()
 		return

--- a/controllers/nomina_trabajador_controller_test.go
+++ b/controllers/nomina_trabajador_controller_test.go
@@ -47,7 +47,7 @@ func TestNominaTrabajadorPostInvalidJSON(t *testing.T) {
 }
 
 func TestNominaTrabajadorPostMissingDocumento(t *testing.T) {
-	body := `{"PK_DOCUMENTO_TRABAJADOR":0}`
+	body := `{"documentoTrabajador":0}`
 	r := httptest.NewRequest(http.MethodPost, "/nomina_trabajador", strings.NewReader(body))
 	w := httptest.NewRecorder()
 	ctx := context.NewContext()
@@ -62,13 +62,13 @@ func TestNominaTrabajadorPostMissingDocumento(t *testing.T) {
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("expected status 400, got %d", w.Code)
 	}
-	if !strings.Contains(w.Body.String(), "PK_DOCUMENTO_TRABAJADOR") {
+	if !strings.Contains(w.Body.String(), "documentoTrabajador") {
 		t.Errorf("unexpected body: %s", w.Body.String())
 	}
 }
 
 func TestNominaTrabajadorPostDBError(t *testing.T) {
-	body := `{"PK_DOCUMENTO_TRABAJADOR":123}`
+	body := `{"documentoTrabajador":123}`
 	r := httptest.NewRequest(http.MethodPost, "/nomina_trabajador", strings.NewReader(body))
 	w := httptest.NewRecorder()
 	ctx := context.NewContext()

--- a/models/NominaTrabajador.go
+++ b/models/NominaTrabajador.go
@@ -3,26 +3,26 @@ package models
 import "github.com/beego/beego/v2/client/orm"
 
 type NominaTrabajador struct {
-	PK_ID_NOMINA_TRABAJADOR int64   `orm:"column(pk_id_nomina_trabajador);pk;auto" json:"PK_ID_NOMINA_TRABAJADOR"`
-	SUELDO_BASE             int64   `orm:"column(sueldo_base)" json:"SUELDO_BASE"`
-	MONTO_INCIDENCIAS       *int64  `orm:"column(monto_incidencias);null" json:"MONTO_INCIDENCIAS,omitempty"`
-	TOTAL                   *int64  `orm:"column(total);null" json:"TOTAL,omitempty"`
-	DETALLES                *string `orm:"column(detalles);type(text);null" json:"DETALLES,omitempty"`
-	PK_DOCUMENTO_TRABAJADOR int64   `orm:"column(pk_documento_trabajador);null" json:"PK_DOCUMENTO_TRABAJADOR,omitempty"`
-	PK_ID_NOMINA            *int64  `orm:"column(pk_id_nomina);null" json:"PK_ID_NOMINA,omitempty"`
+	PK_ID_NOMINA_TRABAJADOR int64   `orm:"column(pk_id_nomina_trabajador);pk;auto" json:"nominaTrabajadorId"`
+	SUELDO_BASE             int64   `orm:"column(sueldo_base)" json:"sueldoBase"`
+	MONTO_INCIDENCIAS       *int64  `orm:"column(monto_incidencias);null" json:"montoIncidencias,omitempty"`
+	TOTAL                   *int64  `orm:"column(total);null" json:"total,omitempty"`
+	DETALLES                *string `orm:"column(detalles);type(text);null" json:"detalles,omitempty"`
+	PK_DOCUMENTO_TRABAJADOR int64   `orm:"column(pk_documento_trabajador);null" json:"documentoTrabajador,omitempty"`
+	PK_ID_NOMINA            *int64  `orm:"column(pk_id_nomina);null" json:"nominaId,omitempty"`
 }
 
 type NominaTrabajadorRequest struct {
-	PK_DOCUMENTO_TRABAJADOR int64  `json:"PK_DOCUMENTO_TRABAJADOR" example:"1015466494"`
-	DETALLES                string `json:"DETALLES,omitempty" example:"Pago correspondiente al mes de enero"`
+	PK_DOCUMENTO_TRABAJADOR int64  `json:"documentoTrabajador" example:"1015466494"`
+	DETALLES                string `json:"detalles,omitempty" example:"Pago correspondiente al mes de enero"`
 }
 
 type NominaTrabajadorResponse struct {
-	PK_ID_NOMINA_TRABAJADOR int64  `json:"PK_ID_NOMINA_TRABAJADOR" example:"1"`
-	SUELDO_BASE             int64  `json:"SUELDO_BASE" example:"2000000"`
-	MONTO_INCIDENCIAS       int64  `json:"MONTO_INCIDENCIAS" example:"50000"`
-	TOTAL                   int64  `json:"TOTAL" example:"2050000"`
-	DETALLES                string `json:"DETALLES,omitempty" example:"Pago correspondiente al mes de enero"`
+	PK_ID_NOMINA_TRABAJADOR int64  `json:"nominaTrabajadorId" example:"1"`
+	SUELDO_BASE             int64  `json:"sueldoBase" example:"2000000"`
+	MONTO_INCIDENCIAS       int64  `json:"montoIncidencias" example:"50000"`
+	TOTAL                   int64  `json:"total" example:"2050000"`
+	DETALLES                string `json:"detalles,omitempty" example:"Pago correspondiente al mes de enero"`
 }
 
 type NominaTrabajadorDetalle struct {


### PR DESCRIPTION
## Summary
- use camelCase json tags on NominaTrabajador structs
- simplify NominaTrabajadorController for camelCase fields
- update controller tests for new field names

## Testing
- `go test ./controllers -run NominaTrabajadorPostInvalidJSON -count=1` *(fails: field: models.DetallePedido.PKIDProducto, one model must have one pk field only)*

------
https://chatgpt.com/codex/tasks/task_e_68b3966327048325bba2fc0c9c0d0026