### PR TITLE
test: expect lowercase identifiers

### DIFF
--- a/controllers/pedido_controller_test.go
+++ b/controllers/pedido_controller_test.go
@@ -174,7 +174,7 @@ func TestPedidoPostSuccess(t *testing.T) {
 		return mockResult{}, nil
 	}
 	MockQuery = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
-		cols := []string{"PK_ID_PEDIDO"}
+		cols := []string{"pk_id_pedido"}
 		vals := [][]driver.Value{{int64(1)}}
 		return &mockRows{columns: cols, values: vals}, nil
 	}
@@ -203,7 +203,7 @@ func TestPedidoPostSuccess(t *testing.T) {
 
 func TestPedidoGetAllWithFiltersNoResults(t *testing.T) {
 	MockQuery = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
-		cols := []string{"PK_ID_PEDIDO", "FECHA", "HORA", "DELIVERY", "ESTADO_PEDIDO", "PK_ID_DOMICILIO", "PK_ID_PAGO", "PK_ID_RESTAURANTE", "UPDATED_AT", "UPDATED_BY"}
+		cols := []string{"pk_id_pedido", "fecha", "hora", "delivery", "estado_pedido", "pk_id_domicilio", "pk_id_pago", "pk_id_restaurante", "updated_at", "updated_by"}
 		return &mockRows{columns: cols, values: [][]driver.Value{}}, nil
 	}
 	defer func() { MockQuery = nil }()
@@ -229,7 +229,7 @@ func TestPedidoGetAllWithFiltersNoResults(t *testing.T) {
 
 func TestPedidoGetAllWithResults(t *testing.T) {
 	MockQuery = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
-		cols := []string{"PK_ID_PEDIDO", "FECHA", "HORA", "DELIVERY", "ESTADO_PEDIDO", "PK_ID_DOMICILIO", "PK_ID_PAGO", "PK_ID_RESTAURANTE", "UPDATED_AT", "UPDATED_BY"}
+		cols := []string{"pk_id_pedido", "fecha", "hora", "delivery", "estado_pedido", "pk_id_domicilio", "pk_id_pago", "pk_id_restaurante", "updated_at", "updated_by"}
 		now := time.Now()
 		vals := [][]driver.Value{{int64(1), now, "12:00:00", false, "iniciado", nil, nil, nil, now, "tester"}}
 		return &mockRows{columns: cols, values: vals}, nil
@@ -256,7 +256,7 @@ func TestPedidoGetAllWithResults(t *testing.T) {
 
 func TestPedidoGetAllDomicilioFalse(t *testing.T) {
 	MockQuery = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
-		cols := []string{"PK_ID_PEDIDO", "FECHA", "HORA", "DELIVERY", "ESTADO_PEDIDO", "PK_ID_DOMICILIO", "PK_ID_PAGO", "PK_ID_RESTAURANTE", "UPDATED_AT", "UPDATED_BY"}
+		cols := []string{"pk_id_pedido", "fecha", "hora", "delivery", "estado_pedido", "pk_id_domicilio", "pk_id_pago", "pk_id_restaurante", "updated_at", "updated_by"}
 		return &mockRows{columns: cols, values: [][]driver.Value{}}, nil
 	}
 	defer func() { MockQuery = nil }()
@@ -281,7 +281,7 @@ func TestPedidoGetAllDomicilioFalse(t *testing.T) {
 
 func TestPedidoAssignDomicilioUpdateError(t *testing.T) {
 	MockQuery = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
-		cols := []string{"PK_ID_PEDIDO", "FECHA", "HORA", "DELIVERY", "ESTADO_PEDIDO", "PK_ID_DOMICILIO", "PK_ID_PAGO", "PK_ID_RESTAURANTE", "UPDATED_AT", "UPDATED_BY"}
+		cols := []string{"pk_id_pedido", "fecha", "hora", "delivery", "estado_pedido", "pk_id_domicilio", "pk_id_pago", "pk_id_restaurante", "updated_at", "updated_by"}
 		now := time.Now()
 		vals := [][]driver.Value{{int64(1), now, "12:00:00", false, "iniciado", nil, nil, nil, now, "tester"}}
 		return &mockRows{columns: cols, values: vals}, nil
@@ -311,7 +311,7 @@ func TestPedidoAssignDomicilioUpdateError(t *testing.T) {
 
 func TestPedidoAssignDomicilioSuccess(t *testing.T) {
 	MockQuery = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
-		cols := []string{"PK_ID_PEDIDO", "FECHA", "HORA", "DELIVERY", "ESTADO_PEDIDO", "PK_ID_DOMICILIO", "PK_ID_PAGO", "PK_ID_RESTAURANTE", "UPDATED_AT", "UPDATED_BY"}
+		cols := []string{"pk_id_pedido", "fecha", "hora", "delivery", "estado_pedido", "pk_id_domicilio", "pk_id_pago", "pk_id_restaurante", "updated_at", "updated_by"}
 		now := time.Now()
 		vals := [][]driver.Value{{int64(1), now, "12:00:00", false, "iniciado", nil, nil, nil, now, "tester"}}
 		return &mockRows{columns: cols, values: vals}, nil
@@ -341,7 +341,7 @@ func TestPedidoAssignDomicilioSuccess(t *testing.T) {
 
 func TestPedidoAssignPagoUpdateError(t *testing.T) {
 	MockQuery = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
-		cols := []string{"PK_ID_PEDIDO", "FECHA", "HORA", "DELIVERY", "ESTADO_PEDIDO", "PK_ID_DOMICILIO", "PK_ID_PAGO", "PK_ID_RESTAURANTE", "UPDATED_AT", "UPDATED_BY"}
+		cols := []string{"pk_id_pedido", "fecha", "hora", "delivery", "estado_pedido", "pk_id_domicilio", "pk_id_pago", "pk_id_restaurante", "updated_at", "updated_by"}
 		now := time.Now()
 		vals := [][]driver.Value{{int64(1), now, "12:00:00", false, "iniciado", nil, nil, nil, now, "tester"}}
 		return &mockRows{columns: cols, values: vals}, nil
@@ -374,12 +374,12 @@ func TestPedidoAssignPagoSuccess(t *testing.T) {
 	MockQuery = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
 		if qCount == 0 {
 			qCount++
-			cols := []string{"PK_ID_PEDIDO", "FECHA", "HORA", "DELIVERY", "ESTADO_PEDIDO", "PK_ID_DOMICILIO", "PK_ID_PAGO", "PK_ID_RESTAURANTE", "UPDATED_AT", "UPDATED_BY"}
+			cols := []string{"pk_id_pedido", "fecha", "hora", "delivery", "estado_pedido", "pk_id_domicilio", "pk_id_pago", "pk_id_restaurante", "updated_at", "updated_by"}
 			now := time.Now()
 			vals := [][]driver.Value{{int64(1), now, "12:00:00", false, "iniciado", nil, nil, nil, now, "tester"}}
 			return &mockRows{columns: cols, values: vals}, nil
 		}
-		cols := []string{"PK_ID_PAGO", "FECHA", "HORA", "MONTO", "ESTADO_PAGO", "PK_ID_METODO_PAGO", "UPDATED_AT", "UPDATED_BY"}
+		cols := []string{"pk_id_pago", "fecha", "hora", "monto", "estado_pago", "pk_id_metodo_pago", "updated_at", "updated_by"}
 		now := time.Now()
 		vals := [][]driver.Value{{int64(1), now, "12:00:00", int64(100), "pendiente", int64(1), now, "tester"}}
 		return &mockRows{columns: cols, values: vals}, nil
@@ -409,7 +409,7 @@ func TestPedidoAssignPagoSuccess(t *testing.T) {
 
 func TestPedidoUpdateEstadoPedidoUpdateError(t *testing.T) {
 	MockQuery = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
-		cols := []string{"PK_ID_PEDIDO", "FECHA", "HORA", "DELIVERY", "ESTADO_PEDIDO", "PK_ID_DOMICILIO", "PK_ID_PAGO", "PK_ID_RESTAURANTE", "UPDATED_AT", "UPDATED_BY"}
+		cols := []string{"pk_id_pedido", "fecha", "hora", "delivery", "estado_pedido", "pk_id_domicilio", "pk_id_pago", "pk_id_restaurante", "updated_at", "updated_by"}
 		now := time.Now()
 		vals := [][]driver.Value{{int64(1), now, "12:00:00", false, "iniciado", nil, nil, nil, now, "tester"}}
 		return &mockRows{columns: cols, values: vals}, nil
@@ -439,7 +439,7 @@ func TestPedidoUpdateEstadoPedidoUpdateError(t *testing.T) {
 
 func TestPedidoUpdateEstadoPedidoSuccess(t *testing.T) {
 	MockQuery = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
-		cols := []string{"PK_ID_PEDIDO", "FECHA", "HORA", "DELIVERY", "ESTADO_PEDIDO", "PK_ID_DOMICILIO", "PK_ID_PAGO", "PK_ID_RESTAURANTE", "UPDATED_AT", "UPDATED_BY"}
+		cols := []string{"pk_id_pedido", "fecha", "hora", "delivery", "estado_pedido", "pk_id_domicilio", "pk_id_pago", "pk_id_restaurante", "updated_at", "updated_by"}
 		now := time.Now()
 		vals := [][]driver.Value{{int64(1), now, "12:00:00", false, "iniciado", nil, nil, nil, now, "tester"}}
 		return &mockRows{columns: cols, values: vals}, nil

--- a/models/cambioshorario_test.go
+++ b/models/cambioshorario_test.go
@@ -20,8 +20,8 @@ func TestCambiosHorarioMarshalJSON(t *testing.T) {
 		t.Fatalf("json.Unmarshal returned error: %v", err)
 	}
 
-	if data["fechaCambioHorario"] != "02-01-2024" {
-		t.Errorf("expected fechaCambioHorario 02-01-2024, got %v", data["fechaCambioHorario"])
+	if data["fechacambiohorario"] != "02-01-2024" {
+		t.Errorf("expected fechacambiohorario 02-01-2024, got %v", data["fechacambiohorario"])
 	}
 }
 

--- a/models/domicilio_test.go
+++ b/models/domicilio_test.go
@@ -27,17 +27,17 @@ func TestDomicilioMarshalJSON(t *testing.T) {
 		t.Fatalf("json.Unmarshal returned error: %v", err)
 	}
 
-	if data["fechaDomicilio"] != "10-08-2024" {
-		t.Errorf("expected fechaDomicilio 10-08-2024, got %v", data["fechaDomicilio"])
+	if data["fechadomicilio"] != "10-08-2024" {
+		t.Errorf("expected fechadomicilio 10-08-2024, got %v", data["fechadomicilio"])
 	}
 	if data["estado"] != EstadoDomicilioEnCamino {
 		t.Errorf("expected estado %s, got %v", EstadoDomicilioEnCamino, data["estado"])
 	}
-	if data["createdAt"] != "09-08-2024 14:30:00" {
-		t.Errorf("expected createdAt 09-08-2024 14:30:00, got %v", data["createdAt"])
+	if data["createdat"] != "09-08-2024 14:30:00" {
+		t.Errorf("expected createdat 09-08-2024 14:30:00, got %v", data["createdat"])
 	}
-	if data["updatedAt"] != "11-08-2024 15:45:00" {
-		t.Errorf("expected updatedAt 11-08-2024 15:45:00, got %v", data["updatedAt"])
+	if data["updatedat"] != "11-08-2024 15:45:00" {
+		t.Errorf("expected updatedat 11-08-2024 15:45:00, got %v", data["updatedat"])
 	}
 }
 

--- a/models/incidencia_test.go
+++ b/models/incidencia_test.go
@@ -20,8 +20,8 @@ func TestIncidenciaMarshalJSON(t *testing.T) {
 		t.Fatalf("json.Unmarshal returned error: %v", err)
 	}
 
-	if data["fechaIncidencia"] != "03-06-2024" {
-		t.Errorf("expected fechaIncidencia 03-06-2024, got %v", data["fechaIncidencia"])
+	if data["fechaincidencia"] != "03-06-2024" {
+		t.Errorf("expected fechaincidencia 03-06-2024, got %v", data["fechaincidencia"])
 	}
 }
 

--- a/models/nomina_test.go
+++ b/models/nomina_test.go
@@ -20,8 +20,8 @@ func TestNominaMarshalJSON(t *testing.T) {
 		t.Fatalf("json.Unmarshal returned error: %v", err)
 	}
 
-	if data["fechaNomina"] != "05-07-2024" {
-		t.Errorf("expected fechaNomina 05-07-2024, got %v", data["fechaNomina"])
+	if data["fechanomina"] != "05-07-2024" {
+		t.Errorf("expected fechanomina 05-07-2024, got %v", data["fechanomina"])
 	}
 }
 

--- a/models/pago_test.go
+++ b/models/pago_test.go
@@ -24,10 +24,10 @@ func TestPagoMarshalJSON(t *testing.T) {
 		t.Fatalf("json.Unmarshal returned error: %v", err)
 	}
 
-	if data["fechaPago"] != "16-08-2024" {
-		t.Errorf("expected fechaPago 16-08-2024, got %v", data["fechaPago"])
+	if data["fechapago"] != "16-08-2024" {
+		t.Errorf("expected fechapago 16-08-2024, got %v", data["fechapago"])
 	}
-	if data["updatedAt"] != "17-08-2024 12:30:45" {
-		t.Errorf("expected updatedAt 17-08-2024 12:30:45, got %v", data["updatedAt"])
+	if data["updatedat"] != "17-08-2024 12:30:45" {
+		t.Errorf("expected updatedat 17-08-2024 12:30:45, got %v", data["updatedat"])
 	}
 }

--- a/models/pedido_test.go
+++ b/models/pedido_test.go
@@ -21,11 +21,11 @@ func TestPedidoMarshalJSON(t *testing.T) {
 		t.Fatalf("json.Unmarshal returned error: %v", err)
 	}
 
-	if data["fechaPedido"] != "01-05-2024" {
-		t.Errorf("expected fechaPedido 01-05-2024, got %v", data["fechaPedido"])
+	if data["fechapedido"] != "01-05-2024" {
+		t.Errorf("expected fechapedido 01-05-2024, got %v", data["fechapedido"])
 	}
-	if data["updatedAt"] != "02-05-2024 12:00:00" {
-		t.Errorf("expected updatedAt 02-05-2024 12:00:00, got %v", data["updatedAt"])
+	if data["updatedat"] != "02-05-2024 12:00:00" {
+		t.Errorf("expected updatedat 02-05-2024 12:00:00, got %v", data["updatedat"])
 	}
 }
 

--- a/models/reserva_test.go
+++ b/models/reserva_test.go
@@ -21,11 +21,11 @@ func TestReservaMarshalJSON(t *testing.T) {
 		t.Fatalf("json.Unmarshal returned error: %v", err)
 	}
 
-	if data["fechaReserva"] != "12-09-2024" {
-		t.Errorf("expected fechaReserva 12-09-2024, got %v", data["fechaReserva"])
+	if data["fechareserva"] != "12-09-2024" {
+		t.Errorf("expected fechareserva 12-09-2024, got %v", data["fechareserva"])
 	}
-	if data["estadoReserva"] != string(EstadoReservaConfirmada) {
-		t.Errorf("expected estadoReserva %s, got %v", EstadoReservaConfirmada, data["estadoReserva"])
+	if data["estadoreserva"] != string(EstadoReservaConfirmada) {
+		t.Errorf("expected estadoreserva %s, got %v", EstadoReservaConfirmada, data["estadoreserva"])
 	}
 }
 

--- a/models/trabajador_test.go
+++ b/models/trabajador_test.go
@@ -26,14 +26,14 @@ func TestTrabajadorMarshalJSON(t *testing.T) {
 		t.Fatalf("json.Unmarshal returned error: %v", err)
 	}
 
-	if data["fechaNacimiento"] != "01-03-1990" {
-		t.Errorf("expected fechaNacimiento 01-03-1990, got %v", data["fechaNacimiento"])
+	if data["fechanacimiento"] != "01-03-1990" {
+		t.Errorf("expected fechanacimiento 01-03-1990, got %v", data["fechanacimiento"])
 	}
-	if data["fechaIngreso"] != "10-02-2023 09:15:30" {
-		t.Errorf("expected fechaIngreso 10-02-2023 09:15:30, got %v", data["fechaIngreso"])
+	if data["fechaingreso"] != "10-02-2023 09:15:30" {
+		t.Errorf("expected fechaingreso 10-02-2023 09:15:30, got %v", data["fechaingreso"])
 	}
-	if data["fechaRetiro"] != "05-04-2024 18:00:00" {
-		t.Errorf("expected fechaRetiro 05-04-2024 18:00:00, got %v", data["fechaRetiro"])
+	if data["fecharetiro"] != "05-04-2024 18:00:00" {
+		t.Errorf("expected fecharetiro 05-04-2024 18:00:00, got %v", data["fecharetiro"])
 	}
 }
 
@@ -58,13 +58,13 @@ func TestTrabajadorMarshalJSONNil(t *testing.T) {
 		t.Fatalf("json.Unmarshal returned error: %v", err)
 	}
 
-	if _, ok := data["fechaNacimiento"]; ok {
-		t.Errorf("expected fechaNacimiento to be omitted")
+	if _, ok := data["fechanacimiento"]; ok {
+		t.Errorf("expected fechanacimiento to be omitted")
 	}
-	if data["fechaIngreso"] != "10-02-2023 09:15:30" {
-		t.Errorf("expected fechaIngreso 10-02-2023 09:15:30, got %v", data["fechaIngreso"])
+	if data["fechaingreso"] != "10-02-2023 09:15:30" {
+		t.Errorf("expected fechaingreso 10-02-2023 09:15:30, got %v", data["fechaingreso"])
 	}
-	if _, ok := data["fechaRetiro"]; ok {
-		t.Errorf("expected fechaRetiro to be omitted")
+	if _, ok := data["fecharetiro"]; ok {
+		t.Errorf("expected fecharetiro to be omitted")
 	}
 }


### PR DESCRIPTION
## Summary
- expect lowercase JSON keys in model tests
- use lowercase column names in pedido controller tests

## Testing
- `go test ./...` *(fails: models.DetallePedido.PKIDProducto composite primary key not supported)*

------
https://chatgpt.com/codex/tasks/task_e_68b39910d46c8325a1801b489a3e3264