### PR TITLE
refactor: lowercase Cliente model column names

### DIFF
--- a/models/Cliente.go
+++ b/models/Cliente.go
@@ -5,18 +5,18 @@ import (
 )
 
 type Cliente struct {
-	PK_DOCUMENTO_CLIENTE int     `orm:"column(PK_DOCUMENTO_CLIENTE);pk" json:"documentoCliente"`
-	NOMBRE               string  `orm:"column(NOMBRE);type(text)"        json:"nombre"`
-	APELLIDO             string  `orm:"column(APELLIDO);type(text)"      json:"apellido"`
-	CORREO               *string `orm:"column(CORREO);type(text)"        json:"correo"`
-	DIRECCION            string  `orm:"column(DIRECCION);type(text)"     json:"direccion"`
-	TELEFONO             string  `orm:"column(TELEFONO);type(text)"      json:"telefono"`
-	OBSERVACIONES        *string `orm:"column(OBSERVACIONES);type(text)" json:"observaciones"`
-	PASSWORD             string  `orm:"column(PASSWORD);type(text)"      json:"password"`
+	PK_DOCUMENTO_CLIENTE int     `orm:"column(pk_documento_cliente);pk" json:"documentoCliente"`
+	NOMBRE               string  `orm:"column(nombre);type(text)"        json:"nombre"`
+	APELLIDO             string  `orm:"column(apellido);type(text)"      json:"apellido"`
+	CORREO               *string `orm:"column(correo);type(text)"        json:"correo"`
+	DIRECCION            string  `orm:"column(direccion);type(text)"     json:"direccion"`
+	TELEFONO             string  `orm:"column(telefono);type(text)"      json:"telefono"`
+	OBSERVACIONES        *string `orm:"column(observaciones);type(text)" json:"observaciones"`
+	PASSWORD             string  `orm:"column(password);type(text)"      json:"password"`
 }
 
 func (c *Cliente) TableName() string {
-	return "CLIENTE"
+	return "cliente"
 }
 
 func init() {


### PR DESCRIPTION
## Summary
- use lowercase ORM column names in Cliente model
- set Cliente TableName to `cliente`

## Testing
- `go test ./...` *(fails: field: models.DetallePedido.PKIDProducto, one model must have one pk field only)*

------
https://chatgpt.com/codex/tasks/task_e_68b39b9d76e08325be77a6c4017de57f