### PR TITLE
docs: actualizar nombres de columnas

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -2119,7 +2119,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "integer",
-                        "description": "ID del cliente (PK_DOCUMENTO_CLIENTE)",
+                        "description": "ID del cliente (documento_cliente)",
                         "name": "cliente",
                         "in": "query"
                     },
@@ -2297,7 +2297,7 @@ const docTemplate = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "Asigna un domicilio existente a un pedido (sólo setea PK_ID_DOMICILIO).",
+                "description": "Asigna un domicilio existente a un pedido (sólo setea id_domicilio).",
                 "consumes": [
                     "application/json"
                 ],
@@ -3774,13 +3774,13 @@ const docTemplate = `{
                 "MONTO_INCIDENCIAS": {
                     "type": "integer"
                 },
-                "PK_DOCUMENTO_TRABAJADOR": {
+                "documento_trabajador": {
                     "type": "integer"
                 },
-                "PK_ID_NOMINA": {
+                "id_nomina": {
                     "type": "integer"
                 },
-                "PK_ID_NOMINA_TRABAJADOR": {
+                "id_nomina_trabajador": {
                     "type": "integer"
                 },
                 "SUELDO_BASE": {
@@ -3798,7 +3798,7 @@ const docTemplate = `{
                     "type": "string",
                     "example": "Pago correspondiente al mes de enero"
                 },
-                "PK_DOCUMENTO_TRABAJADOR": {
+                "documento_trabajador": {
                     "type": "integer",
                     "example": 1015466494
                 }
@@ -3815,7 +3815,7 @@ const docTemplate = `{
                     "type": "integer",
                     "example": 50000
                 },
-                "PK_ID_NOMINA_TRABAJADOR": {
+                "id_nomina_trabajador": {
                     "type": "integer",
                     "example": 1
                 },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -2112,7 +2112,7 @@
                     },
                     {
                         "type": "integer",
-                        "description": "ID del cliente (PK_DOCUMENTO_CLIENTE)",
+                        "description": "ID del cliente (documento_cliente)",
                         "name": "cliente",
                         "in": "query"
                     },
@@ -2290,7 +2290,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Asigna un domicilio existente a un pedido (sólo setea PK_ID_DOMICILIO).",
+                "description": "Asigna un domicilio existente a un pedido (sólo setea id_domicilio).",
                 "consumes": [
                     "application/json"
                 ],
@@ -3767,13 +3767,13 @@
                 "MONTO_INCIDENCIAS": {
                     "type": "integer"
                 },
-                "PK_DOCUMENTO_TRABAJADOR": {
+                "documento_trabajador": {
                     "type": "integer"
                 },
-                "PK_ID_NOMINA": {
+                "id_nomina": {
                     "type": "integer"
                 },
-                "PK_ID_NOMINA_TRABAJADOR": {
+                "id_nomina_trabajador": {
                     "type": "integer"
                 },
                 "SUELDO_BASE": {
@@ -3791,7 +3791,7 @@
                     "type": "string",
                     "example": "Pago correspondiente al mes de enero"
                 },
-                "PK_DOCUMENTO_TRABAJADOR": {
+                "documento_trabajador": {
                     "type": "integer",
                     "example": 1015466494
                 }
@@ -3808,7 +3808,7 @@
                     "type": "integer",
                     "example": 50000
                 },
-                "PK_ID_NOMINA_TRABAJADOR": {
+                "id_nomina_trabajador": {
                     "type": "integer",
                     "example": 1
                 },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -117,11 +117,11 @@ definitions:
         type: string
       MONTO_INCIDENCIAS:
         type: integer
-      PK_DOCUMENTO_TRABAJADOR:
+      documento_trabajador:
         type: integer
-      PK_ID_NOMINA:
+      id_nomina:
         type: integer
-      PK_ID_NOMINA_TRABAJADOR:
+      id_nomina_trabajador:
         type: integer
       SUELDO_BASE:
         type: integer
@@ -133,7 +133,7 @@ definitions:
       DETALLES:
         example: Pago correspondiente al mes de enero
         type: string
-      PK_DOCUMENTO_TRABAJADOR:
+      documento_trabajador:
         example: 1015466494
         type: integer
     type: object
@@ -145,7 +145,7 @@ definitions:
       MONTO_INCIDENCIAS:
         example: 50000
         type: integer
-      PK_ID_NOMINA_TRABAJADOR:
+      id_nomina_trabajador:
         example: 1
         type: integer
       SUELDO_BASE:
@@ -1672,7 +1672,7 @@ paths:
         in: query
         name: anio
         type: integer
-      - description: ID del cliente (PK_DOCUMENTO_CLIENTE)
+      - description: ID del cliente (documento_cliente)
         in: query
         name: cliente
         type: integer
@@ -1790,7 +1790,7 @@ paths:
     post:
       consumes:
       - application/json
-      description: Asigna un domicilio existente a un pedido (sólo setea PK_ID_DOMICILIO).
+      description: Asigna un domicilio existente a un pedido (sólo setea id_domicilio).
       parameters:
       - description: ID del pedido
         in: query


### PR DESCRIPTION
## Summary
- Reemplaza identificadores de columnas en Swagger por nombres en minúsculas

## Testing
- `go test ./...` *(falla: field: models.DetallePedido.PKIDProducto, one model must have one pk field only)*

------
https://chatgpt.com/codex/tasks/task_e_68b3a61e2d448325adaf9766e25d307b