### PR TITLE
chore: normalize test column references to lowercase

### DIFF
--- a/controllers/pago_controller_test.go
+++ b/controllers/pago_controller_test.go
@@ -111,7 +111,7 @@ func TestPagoGetAllWithoutDB(t *testing.T) {
 	}
 }
 func TestPagoPostMissingFecha(t *testing.T) {
-	body := `{"HORA":"10:00:00","MONTO":1000,"ESTADO_PAGO":"pagado","PK_ID_METODO_PAGO":1}`
+	body := `{"horaPago":"10:00:00","monto":1000,"estadoPago":"pagado","metodoPagoId":1}`
 	r := httptest.NewRequest(http.MethodPost, "/pagos", strings.NewReader(body))
 	w := httptest.NewRecorder()
 	ctx := context.NewContext()
@@ -129,7 +129,7 @@ func TestPagoPostMissingFecha(t *testing.T) {
 }
 
 func TestPagoPostInvalidHora(t *testing.T) {
-	body := `{"FECHA":"2024-01-01","HORA":"25:00","MONTO":1000,"ESTADO_PAGO":"pagado","PK_ID_METODO_PAGO":1}`
+	body := `{"fechaPago":"2024-01-01","horaPago":"25:00","monto":1000,"estadoPago":"pagado","metodoPagoId":1}`
 	r := httptest.NewRequest(http.MethodPost, "/pagos", strings.NewReader(body))
 	w := httptest.NewRecorder()
 	ctx := context.NewContext()
@@ -147,7 +147,7 @@ func TestPagoPostInvalidHora(t *testing.T) {
 }
 
 func TestPagoPostInvalidEstado(t *testing.T) {
-	body := `{"FECHA":"2024-01-01","HORA":"10:00:00","MONTO":1000,"ESTADO_PAGO":"INVALIDO","PK_ID_METODO_PAGO":1}`
+	body := `{"fechaPago":"2024-01-01","horaPago":"10:00:00","monto":1000,"estadoPago":"INVALIDO","metodoPagoId":1}`
 	r := httptest.NewRequest(http.MethodPost, "/pagos", strings.NewReader(body))
 	w := httptest.NewRecorder()
 	ctx := context.NewContext()
@@ -165,7 +165,7 @@ func TestPagoPostInvalidEstado(t *testing.T) {
 }
 
 func TestPagoPostMissingMetodoPago(t *testing.T) {
-	body := `{"FECHA":"2024-01-01","HORA":"10:00:00","MONTO":1000,"ESTADO_PAGO":"pagado"}`
+	body := `{"fechaPago":"2024-01-01","horaPago":"10:00:00","monto":1000,"estadoPago":"pagado"}`
 	r := httptest.NewRequest(http.MethodPost, "/pagos", strings.NewReader(body))
 	w := httptest.NewRecorder()
 	ctx := context.NewContext()
@@ -183,7 +183,7 @@ func TestPagoPostMissingMetodoPago(t *testing.T) {
 }
 
 func TestPagoPostMissingHora(t *testing.T) {
-	body := `{"FECHA":"2024-01-01","MONTO":1000,"ESTADO_PAGO":"pagado","PK_ID_METODO_PAGO":1}`
+	body := `{"fechaPago":"2024-01-01","monto":1000,"estadoPago":"pagado","metodoPagoId":1}`
 	r := httptest.NewRequest(http.MethodPost, "/pagos", strings.NewReader(body))
 	w := httptest.NewRecorder()
 	ctx := context.NewContext()
@@ -225,7 +225,7 @@ func TestPagoPostSuccess(t *testing.T) {
 }
 
 func TestPagoPostMissingMonto(t *testing.T) {
-	body := `{"FECHA":"2024-01-01","HORA":"10:00:00","ESTADO_PAGO":"pagado","PK_ID_METODO_PAGO":1}`
+	body := `{"fechaPago":"2024-01-01","horaPago":"10:00:00","estadoPago":"pagado","metodoPagoId":1}`
 	r := httptest.NewRequest(http.MethodPost, "/pagos", strings.NewReader(body))
 	w := httptest.NewRecorder()
 	ctx := context.NewContext()
@@ -241,7 +241,7 @@ func TestPagoPostMissingMonto(t *testing.T) {
 }
 
 func TestPagoPostInvalidFecha(t *testing.T) {
-	body := `{"FECHA":"2024-13-01","HORA":"10:00:00","MONTO":1000,"ESTADO_PAGO":"pagado","PK_ID_METODO_PAGO":1}`
+	body := `{"fechaPago":"2024-13-01","horaPago":"10:00:00","monto":1000,"estadoPago":"pagado","metodoPagoId":1}`
 	r := httptest.NewRequest(http.MethodPost, "/pagos", strings.NewReader(body))
 	w := httptest.NewRecorder()
 	ctx := context.NewContext()
@@ -291,7 +291,7 @@ func TestPagoPutInvalidJSON(t *testing.T) {
 }
 
 func TestPagoPutMissingHora(t *testing.T) {
-	body := `{"FECHA":"2024-01-01"}`
+	body := `{"fechaPago":"2024-01-01"}`
 	r := httptest.NewRequest(http.MethodPut, "/pagos?id=1", strings.NewReader(body))
 	w := httptest.NewRecorder()
 	ctx := context.NewContext()
@@ -312,7 +312,7 @@ func TestPagoPutMissingMetodoPago(t *testing.T) {
 	orig := pagoNewOrm
 	pagoNewOrm = func() ormer { return fakeOrmer{read: func(m interface{}, cols ...string) error { return nil }} }
 	t.Cleanup(func() { pagoNewOrm = orig })
-	body := `{"FECHA":"2024-01-01","HORA":"10:00:00"}`
+	body := `{"fechaPago":"2024-01-01","horaPago":"10:00:00"}`
 	r := httptest.NewRequest(http.MethodPut, "/pagos?id=1", strings.NewReader(body))
 	w := httptest.NewRecorder()
 	ctx := context.NewContext()
@@ -334,7 +334,7 @@ func TestPagoPutInvalidFecha(t *testing.T) {
 		return fakeOrmer{read: func(m interface{}, cols ...string) error { return nil }}
 	}
 	t.Cleanup(func() { pagoNewOrm = orig })
-	body := `{"FECHA":"2024-13-01","HORA":"10:00:00","PK_ID_METODO_PAGO":1}`
+	body := `{"fechaPago":"2024-13-01","horaPago":"10:00:00","metodoPagoId":1}`
 	r := httptest.NewRequest(http.MethodPut, "/pagos?id=1", strings.NewReader(body))
 	w := httptest.NewRecorder()
 	ctx := context.NewContext()
@@ -560,7 +560,7 @@ func TestPagoPutSuccess(t *testing.T) {
 		}
 	}
 	t.Cleanup(func() { pagoNewOrm = orig })
-	body := `{"FECHA":"2024-02-02","HORA":"11:00:00","MONTO":2000,"ESTADO_PAGO":"pendiente","UPDATED_BY":"me","PK_ID_METODO_PAGO":1}`
+	body := `{"fechaPago":"2024-02-02","horaPago":"11:00:00","monto":2000,"estadoPago":"pendiente","updatedBy":"me","metodoPagoId":1}`
 	r := httptest.NewRequest(http.MethodPut, "/pagos?id=1", strings.NewReader(body))
 	w := httptest.NewRecorder()
 	ctx := context.NewContext()
@@ -581,7 +581,7 @@ func TestPagoPutInvalidHora(t *testing.T) {
 		return fakeOrmer{read: func(m interface{}, cols ...string) error { return nil }}
 	}
 	t.Cleanup(func() { pagoNewOrm = orig })
-	body := `{"FECHA":"2024-02-02","HORA":"25:00:00","PK_ID_METODO_PAGO":1}`
+	body := `{"fechaPago":"2024-02-02","horaPago":"25:00:00","metodoPagoId":1}`
 	r := httptest.NewRequest(http.MethodPut, "/pagos?id=1", strings.NewReader(body))
 	w := httptest.NewRecorder()
 	ctx := context.NewContext()
@@ -602,7 +602,7 @@ func TestPagoPutInvalidEstado(t *testing.T) {
 		return fakeOrmer{read: func(m interface{}, cols ...string) error { return nil }}
 	}
 	t.Cleanup(func() { pagoNewOrm = orig })
-	body := `{"FECHA":"2024-02-02","HORA":"11:00:00","ESTADO_PAGO":"MALO","PK_ID_METODO_PAGO":1}`
+	body := `{"fechaPago":"2024-02-02","horaPago":"11:00:00","estadoPago":"MALO","metodoPagoId":1}`
 	r := httptest.NewRequest(http.MethodPut, "/pagos?id=1", strings.NewReader(body))
 	w := httptest.NewRecorder()
 	ctx := context.NewContext()
@@ -623,7 +623,7 @@ func TestPagoPutNotFound(t *testing.T) {
 		return fakeOrmer{read: func(m interface{}, cols ...string) error { return orm.ErrNoRows }}
 	}
 	t.Cleanup(func() { pagoNewOrm = orig })
-	body := `{"FECHA":"2024-01-01","HORA":"10:00:00","PK_ID_METODO_PAGO":1}`
+	body := `{"fechaPago":"2024-01-01","horaPago":"10:00:00","metodoPagoId":1}`
 	r := httptest.NewRequest(http.MethodPut, "/pagos?id=1", strings.NewReader(body))
 	w := httptest.NewRecorder()
 	ctx := context.NewContext()
@@ -647,7 +647,7 @@ func TestPagoPutUpdateError(t *testing.T) {
 		}
 	}
 	t.Cleanup(func() { pagoNewOrm = orig })
-	body := `{"FECHA":"2024-01-01","HORA":"10:00:00","PK_ID_METODO_PAGO":1}`
+	body := `{"fechaPago":"2024-01-01","horaPago":"10:00:00","metodoPagoId":1}`
 	r := httptest.NewRequest(http.MethodPut, "/pagos?id=1", strings.NewReader(body))
 	w := httptest.NewRecorder()
 	ctx := context.NewContext()

--- a/controllers/producto_controller_test.go
+++ b/controllers/producto_controller_test.go
@@ -17,7 +17,7 @@ func setupProductoController(t *testing.T, data []byte) *web.Controller {
 	body := &bytes.Buffer{}
 	writer := multipart.NewWriter(body)
 	if data != nil {
-		part, err := writer.CreateFormFile("IMAGEN", "test.png")
+		part, err := writer.CreateFormFile("imagen", "test.png")
 		if err != nil {
 			t.Fatalf("CreateFormFile: %v", err)
 		}
@@ -150,10 +150,10 @@ func TestProductoGetByIdNotFound(t *testing.T) {
 func TestProductoPostMissingNombre(t *testing.T) {
 	body := &bytes.Buffer{}
 	writer := multipart.NewWriter(body)
-	writer.WriteField("NOMBRE", "")
-	writer.WriteField("CATEGORIA", "cat")
-	writer.WriteField("ESTADO_PRODUCTO", "disponible")
-	writer.WriteField("PRECIO", "10")
+	writer.WriteField("nombre", "")
+	writer.WriteField("categoria", "cat")
+	writer.WriteField("estadoProducto", "disponible")
+	writer.WriteField("precio", "10")
 	writer.Close()
 
 	r := httptest.NewRequest(http.MethodPost, "/productos", body)
@@ -170,7 +170,7 @@ func TestProductoPostMissingNombre(t *testing.T) {
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("expected status 400, got %d", w.Code)
 	}
-	if !strings.Contains(w.Body.String(), "NOMBRE") {
+	if !strings.Contains(w.Body.String(), "nombre") {
 		t.Errorf("unexpected body: %s", w.Body.String())
 	}
 }

--- a/controllers/reserva_controller_test.go
+++ b/controllers/reserva_controller_test.go
@@ -27,10 +27,10 @@ func resetReservaMocks() {
 	queryReservasByParam = func(o orm.Ormer, doc int64, fecha time.Time, useDoc, useFecha bool, reservas *[]models.Reserva) (int64, error) {
 		qs := o.QueryTable(new(models.Reserva))
 		if useDoc {
-			qs = qs.Filter("DOCUMENTO_CLIENTE", doc)
+			qs = qs.Filter("documento_cliente", doc)
 		}
 		if useFecha {
-			qs = qs.Filter("FECHA", fecha)
+			qs = qs.Filter("fecha", fecha)
 		}
 		return qs.All(reservas)
 	}

--- a/controllers/trabajador_controller_test.go
+++ b/controllers/trabajador_controller_test.go
@@ -201,12 +201,12 @@ func TestPostInvalidJSON(t *testing.T) {
 func TestPostMissingFields(t *testing.T) {
 	cases := []struct{ body, substr string }{
 		{`{"nombre":"a"}`, "documentoTrabajador"},
-		{`{"documentoTrabajador":1}`, "NOMBRE"},
-		{`{"documentoTrabajador":1,"nombre":"a"}`, "APELLIDO"},
-		{`{"documentoTrabajador":1,"nombre":"a","apellido":"b"}`, "ROL"},
-		{`{"documentoTrabajador":1,"nombre":"a","apellido":"b","rol":"c"}`, "FECHA_INGRESO"},
-		{`{"documentoTrabajador":1,"nombre":"a","apellido":"b","rol":"c","fechaIngreso":"2023-01-01"}`, "SUELDO"},
-		{`{"documentoTrabajador":1,"nombre":"a","apellido":"b","rol":"c","fechaIngreso":"2023-01-01","sueldo":1}`, "PASSWORD"},
+		{`{"documentoTrabajador":1}`, "nombre"},
+		{`{"documentoTrabajador":1,"nombre":"a"}`, "apellido"},
+		{`{"documentoTrabajador":1,"nombre":"a","apellido":"b"}`, "rol"},
+		{`{"documentoTrabajador":1,"nombre":"a","apellido":"b","rol":"c"}`, "fechaIngreso"},
+		{`{"documentoTrabajador":1,"nombre":"a","apellido":"b","rol":"c","fechaIngreso":"2023-01-01"}`, "sueldo"},
+		{`{"documentoTrabajador":1,"nombre":"a","apellido":"b","rol":"c","fechaIngreso":"2023-01-01","sueldo":1}`, "password"},
 	}
 	for _, tc := range cases {
 		c, w := buildContext(http.MethodPost, "/trabajadores", tc.body)
@@ -307,21 +307,21 @@ func TestPutInvalidDates(t *testing.T) {
 	original := newTrabajadorOrm
 	newTrabajadorOrm = func() orm.Ormer { return &mockOrm{} }
 	defer func() { newTrabajadorOrm = original }()
-	body := `{"FECHA_INGRESO":"bad"}`
+	body := `{"fechaIngreso":"bad"}`
 	c, w := buildContext(http.MethodPut, "/trabajadores?id=1", body)
 	c.Put()
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("%d", w.Code)
 	}
 
-	body2 := `{"FECHA_RETIRO":"bad"}`
+	body2 := `{"fechaRetiro":"bad"}`
 	c2, w2 := buildContext(http.MethodPut, "/trabajadores?id=1", body2)
 	c2.Put()
 	if w2.Code != http.StatusBadRequest {
 		t.Fatalf("%d", w2.Code)
 	}
 
-	body3 := `{"FECHA_NACIMIENTO":"bad"}`
+	body3 := `{"fechaNacimiento":"bad"}`
 	c3, w3 := buildContext(http.MethodPut, "/trabajadores?id=1", body3)
 	c3.Put()
 	if w3.Code != http.StatusBadRequest {
@@ -336,7 +336,7 @@ func TestPutHashError(t *testing.T) {
 	originalHash := hashPassword
 	hashPassword = func(string) (string, error) { return "", errors.New("hash") }
 	defer func() { hashPassword = originalHash }()
-	body := `{"PASSWORD":"p"}`
+	body := `{"password":"p"}`
 	c, w := buildContext(http.MethodPut, "/trabajadores?id=1", body)
 	c.Put()
 	if w.Code != http.StatusInternalServerError {
@@ -348,7 +348,7 @@ func TestPutValidateDatesError(t *testing.T) {
 	original := newTrabajadorOrm
 	newTrabajadorOrm = func() orm.Ormer { return &mockOrm{} }
 	defer func() { newTrabajadorOrm = original }()
-	body := `{"FECHA_INGRESO":"2023-01-02","FECHA_RETIRO":"2023-01-01"}`
+	body := `{"fechaIngreso":"2023-01-02","fechaRetiro":"2023-01-01"}`
 	c, w := buildContext(http.MethodPut, "/trabajadores?id=1", body)
 	c.Put()
 	if w.Code != http.StatusBadRequest {
@@ -360,7 +360,7 @@ func TestPutUpdateError(t *testing.T) {
 	original := newTrabajadorOrm
 	newTrabajadorOrm = func() orm.Ormer { return &mockOrm{updateErr: errors.New("db")} }
 	defer func() { newTrabajadorOrm = original }()
-	body := `{"NOMBRE":"a"}`
+	body := `{"nombre":"a"}`
 	c, w := buildContext(http.MethodPut, "/trabajadores?id=1", body)
 	c.Put()
 	if w.Code != http.StatusInternalServerError {
@@ -372,7 +372,7 @@ func TestPutSuccess(t *testing.T) {
 	original := newTrabajadorOrm
 	newTrabajadorOrm = func() orm.Ormer { return &mockOrm{} }
 	defer func() { newTrabajadorOrm = original }()
-	body := `{"NOMBRE":"a","APELLIDO":"b","ROL":"c","SUELDO":1,"NUEVO":true,"TELEFONO":"1","FECHA_INGRESO":"2023-01-01","FECHA_RETIRO":"2023-01-02","FECHA_NACIMIENTO":"2023-01-03","PASSWORD":"p"}`
+	body := `{"nombre":"a","apellido":"b","rol":"c","sueldo":1,"nuevo":true,"telefono":"1","fechaIngreso":"2023-01-01","fechaRetiro":"2023-01-02","fechaNacimiento":"2023-01-03","password":"p"}`
 	c, w := buildContext(http.MethodPut, "/trabajadores?id=1", body)
 	c.Put()
 	if w.Code != http.StatusOK {
@@ -385,7 +385,7 @@ func TestPutTelefonoUpdated(t *testing.T) {
 	original := newTrabajadorOrm
 	newTrabajadorOrm = func() orm.Ormer { return m }
 	defer func() { newTrabajadorOrm = original }()
-	body := `{"TELEFONO":"123"}`
+	body := `{"telefono":"123"}`
 	c, w := buildContext(http.MethodPut, "/trabajadores?id=1", body)
 	c.Put()
 	if w.Code != http.StatusOK {

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -2719,7 +2719,7 @@ const docTemplate = `{
                     {
                         "type": "string",
                         "description": "Estado del producto",
-                        "name": "ESTADO_PRODUCTO",
+                        "name": "estadoProducto",
                         "in": "formData",
                         "required": true
                     },
@@ -2793,7 +2793,7 @@ const docTemplate = `{
                     {
                         "type": "string",
                         "description": "Estado del producto",
-                        "name": "ESTADO_PRODUCTO",
+                        "name": "estadoProducto",
                         "in": "formData",
                         "required": true
                     },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -2712,7 +2712,7 @@
                     {
                         "type": "string",
                         "description": "Estado del producto",
-                        "name": "ESTADO_PRODUCTO",
+                        "name": "estadoProducto",
                         "in": "formData",
                         "required": true
                     },
@@ -2786,7 +2786,7 @@
                     {
                         "type": "string",
                         "description": "Estado del producto",
-                        "name": "ESTADO_PRODUCTO",
+                        "name": "estadoProducto",
                         "in": "formData",
                         "required": true
                     },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -2092,7 +2092,7 @@ paths:
         type: string
       - description: Estado del producto
         in: formData
-        name: ESTADO_PRODUCTO
+      name: estadoProducto
         required: true
         type: string
       - description: Precio del producto
@@ -2157,7 +2157,7 @@ paths:
         type: string
       - description: Estado del producto
         in: formData
-        name: ESTADO_PRODUCTO
+      name: estadoProducto
         required: true
         type: string
       - description: Precio del producto

--- a/tests/seed_data.go
+++ b/tests/seed_data.go
@@ -13,7 +13,7 @@ func SeedTestData() {
 	o := orm.NewOrm()
 
 	if _, err := o.Insert(&models.MetodoPago{PK_ID_METODO_PAGO: 1, TIPO: "Efectivo"}); err != nil {
-		log.Println("seed METODO_PAGO:", err)
+		log.Println("seed metodo_pago:", err)
 	}
 
 	if _, err := o.Insert(&models.DetallePedido{
@@ -21,7 +21,7 @@ func SeedTestData() {
 		PKIDProducto: 1,
 		Cantidad:     1,
 	}); err != nil {
-		log.Println("seed DETALLE_PEDIDO:", err)
+		log.Println("seed detalle_pedido:", err)
 	}
 
 	inicio, _ := time.Parse("15:04:05", "08:00:00")
@@ -32,6 +32,6 @@ func SeedTestData() {
 		HORA_INICIO:             inicio,
 		HORA_FIN:                fin,
 	}); err != nil {
-		log.Println("seed HORARIO_TRABAJADOR:", err)
+		log.Println("seed horario_trabajador:", err)
 	}
 }


### PR DESCRIPTION
## Summary
- use lowercase column names in controller tests
- adjust seed data logs to lowercase table names
- sync docs for `estadoProducto`

## Testing
- `go test ./...` *(fails: field: models.DetallePedido.PKIDProducto, one model must have one pk field only)*

------
https://chatgpt.com/codex/tasks/task_e_68b3a7a0ecb88325aea5a0112458e3da