### PR TITLE
feat: allow null UPDATED_BY for pagos

### DIFF
--- a/controllers/PagoController.go
+++ b/controllers/PagoController.go
@@ -280,13 +280,18 @@ func (c *PagoController) Post() {
 	}
 
 	// Mapear a tu entidad de BD
+	var updatedBy *string
+	if in.UpdatedBy != "" {
+		updatedBy = &in.UpdatedBy
+	}
+
 	pago := models.Pago{
 		FECHA:             fecha,
 		HORA:              in.HoraPago,
 		MONTO:             in.Monto,
 		ESTADO_PAGO:       in.EstadoPago,   // e.g. "pagado"
 		PK_ID_METODO_PAGO: in.MetodoPagoId, // FK
-		UPDATED_BY:        in.UpdatedBy,    // opcional
+		UPDATED_BY:        updatedBy,       // opcional
 		// UPDATED_AT se maneja con auto_now en el modelo
 	}
 
@@ -419,7 +424,7 @@ func (c *PagoController) Put() {
 	}
 
 	if updatedBy, ok := input["UPDATED_BY"].(string); ok {
-		pago.UPDATED_BY = updatedBy
+		pago.UPDATED_BY = &updatedBy
 	}
 
 	// Actualizar la fecha de modificación

--- a/models/Pago.go
+++ b/models/Pago.go
@@ -17,7 +17,7 @@ type Pago struct {
 	CREATED_AT        time.Time  `orm:"column(created_at);type(timestamp);auto_now_add" json:"createdAt"`
 	UPDATED_AT        time.Time  `orm:"column(updated_at);type(timestamp);auto_now" json:"updatedAt"`
 	CREATED_BY        *string    `orm:"column(created_by);type(text)" json:"createdBy,omitempty"`
-	UPDATED_BY        string     `orm:"column(updated_by)" json:"updatedBy"`
+	UPDATED_BY        *string    `orm:"column(updated_by);type(text);null" json:"updatedBy,omitempty"`
 }
 
 func (p *Pago) TableName() string {


### PR DESCRIPTION
## Summary
- allow null UPDATED_BY field in Pago model
- update PagoController to handle pointer UPDATED_BY

## Testing
- `go test ./models -run Pago -count=1` (fails: models.DetallePedido.PKIDProducto pk conflict)
- `go test ./controllers -run Pago -count=1` (fails: missing conf/app.conf & models.DetallePedido.PKIDProducto pk conflict)


------
https://chatgpt.com/codex/tasks/task_e_68b437b8b8d08325b6a1d69bb6087583