### PR TITLE
Validate day for HorarioTrabajador endpoints

### DIFF
--- a/controllers/HorarioTrabajadorController.go
+++ b/controllers/HorarioTrabajadorController.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"restaurante/models"
+	"strings"
 	"time"
 
 	"github.com/beego/beego/v2/client/orm"
@@ -12,6 +13,16 @@ import (
 
 type HorarioTrabajadorController struct {
 	web.Controller
+}
+
+func isValidDia(dia string) bool {
+	switch models.DiaSemana(strings.ToLower(dia)) {
+	case models.DiaLunes, models.DiaMartes, models.DiaMiercoles,
+		models.DiaJueves, models.DiaViernes, models.DiaSabado, models.DiaDomingo:
+		return true
+	default:
+		return false
+	}
 }
 
 // @Title GetAll
@@ -89,6 +100,13 @@ func (c *HorarioTrabajadorController) Post() {
 		return
 	}
 
+	if !isValidDia(input.DIA) {
+		c.Ctx.Output.SetStatus(http.StatusBadRequest)
+		c.Data["json"] = models.ApiResponse{Code: http.StatusBadRequest, Message: "Día inválido"}
+		c.ServeJSON()
+		return
+	}
+
 	horaInicio, err1 := time.Parse("15:04:05", input.HORA_INICIO)
 	horaFin, err2 := time.Parse("15:04:05", input.HORA_FIN)
 	if err1 != nil || err2 != nil {
@@ -153,7 +171,7 @@ func (c *HorarioTrabajadorController) Put() {
 		return
 	}
 	dia := c.GetString("dia")
-	if dia == "" {
+	if dia == "" || !isValidDia(dia) {
 		c.Ctx.Output.SetStatus(http.StatusBadRequest)
 		c.Data["json"] = models.ApiResponse{Code: http.StatusBadRequest, Message: "Parámetro 'dia' inválido"}
 		c.ServeJSON()

--- a/controllers/horario_trabajador_controller_test.go
+++ b/controllers/horario_trabajador_controller_test.go
@@ -1,0 +1,95 @@
+package controllers
+
+import (
+	stdctx "context"
+	"database/sql/driver"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/beego/beego/v2/server/web/context"
+)
+
+func setupHTCtx(method, url, body string) (*HorarioTrabajadorController, *httptest.ResponseRecorder) {
+	r := httptest.NewRequest(method, url, strings.NewReader(body))
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	if body != "" {
+		ctx.Input.RequestBody = []byte(body)
+	}
+	c := &HorarioTrabajadorController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+	return c, w
+}
+
+func TestHorarioTrabajadorPostInvalidDia(t *testing.T) {
+	body := `{"documentoTrabajador":1,"dia":"noday","horaInicio":"08:00:00","horaFin":"17:00:00"}`
+	c, w := setupHTCtx(http.MethodPost, "/horario_trabajador", body)
+	c.Post()
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "Día inválido") {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
+}
+
+func TestHorarioTrabajadorPostSuccess(t *testing.T) {
+	MockExec = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Result, error) {
+		return mockResult{}, nil
+	}
+	MockQuery = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
+		cols := []string{"pk_documento_trabajador"}
+		vals := [][]driver.Value{{int64(1)}}
+		return &mockRows{columns: cols, values: vals}, nil
+	}
+	defer func() { MockExec = nil; MockQuery = nil }()
+
+	body := `{"documentoTrabajador":1,"dia":"lunes","horaInicio":"08:00:00","horaFin":"17:00:00"}`
+	c, w := setupHTCtx(http.MethodPost, "/horario_trabajador", body)
+	c.Post()
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "Horario creado correctamente") {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
+}
+
+func TestHorarioTrabajadorPutInvalidDia(t *testing.T) {
+	body := `{"horaInicio":"09:00:00"}`
+	c, w := setupHTCtx(http.MethodPut, "/horario_trabajador?documento=1&dia=foo", body)
+	c.Put()
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "Parámetro 'dia' inválido") {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
+}
+
+func TestHorarioTrabajadorPutSuccess(t *testing.T) {
+	MockQuery = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
+		cols := []string{"pk_documento_trabajador", "dia", "hora_inicio", "hora_fin"}
+		vals := [][]driver.Value{{int64(1), "lunes", time.Date(2024, 1, 1, 8, 0, 0, 0, time.UTC), time.Date(2024, 1, 1, 17, 0, 0, 0, time.UTC)}}
+		return &mockRows{columns: cols, values: vals}, nil
+	}
+	MockExec = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Result, error) {
+		return mockResult{}, nil
+	}
+	defer func() { MockExec = nil; MockQuery = nil }()
+
+	body := `{"horaFin":"18:00:00"}`
+	c, w := setupHTCtx(http.MethodPut, "/horario_trabajador?documento=1&dia=lunes", body)
+	c.Put()
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "Horario actualizado correctamente") {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
+}


### PR DESCRIPTION
## Summary
- validate day field against models.DiaSemana in HorarioTrabajadorController
- add Post and Put tests for valid and invalid days

## Testing
- `GOPROXY=off go test ./controllers -run HorarioTrabajador -v` *(fails: field: models.DetallePedido.PKIDProducto, one model must have one pk field only)*

------
https://chatgpt.com/codex/tasks/task_e_68b43a7394508325a2588f3c70001d44