### PR TITLE
test: add validation for remaining enums

### DIFF
--- a/tests/enums_test.go
+++ b/tests/enums_test.go
@@ -28,4 +28,61 @@ func TestEstadoEnums(t *testing.T) {
 			t.Errorf("EstadoNomina %s mismatched", expect)
 		}
 	}
+
+	domicilios := map[string]models.EstadoDomicilio{
+		"pendiente": models.EstadoDomicilioPendiente,
+		"en camino": models.EstadoDomicilioEnCamino,
+		"entregado": models.EstadoDomicilioEntregado,
+	}
+	for expect, val := range domicilios {
+		if string(val) != expect {
+			t.Errorf("EstadoDomicilio %s mismatched", expect)
+		}
+	}
+
+	pagos := map[string]models.EstadoPago{
+		"pagado":    models.EstadoPagoPagado,
+		"pendiente": models.EstadoPagoPendiente,
+		"no pago":   models.EstadoPagoNoPago,
+	}
+	for expect, val := range pagos {
+		if string(val) != expect {
+			t.Errorf("EstadoPago %s mismatched", expect)
+		}
+	}
+
+	pedidos := map[string]models.EstadoPedido{
+		"iniciado":  models.EstadoPedidoIniciado,
+		"terminado": models.EstadoPedidoTerminado,
+	}
+	for expect, val := range pedidos {
+		if string(val) != expect {
+			t.Errorf("EstadoPedido %s mismatched", expect)
+		}
+	}
+
+	productos := map[string]models.EstadoProducto{
+		"disponible":    models.EstadoProductoDisponible,
+		"no disponible": models.EstadoProductoNoDisponible,
+	}
+	for expect, val := range productos {
+		if string(val) != expect {
+			t.Errorf("EstadoProducto %s mismatched", expect)
+		}
+	}
+
+	dias := map[string]models.DiaSemana{
+		"lunes":     models.DiaLunes,
+		"martes":    models.DiaMartes,
+		"miercoles": models.DiaMiercoles,
+		"jueves":    models.DiaJueves,
+		"viernes":   models.DiaViernes,
+		"sabado":    models.DiaSabado,
+		"domingo":   models.DiaDomingo,
+	}
+	for expect, val := range dias {
+		if string(val) != expect {
+			t.Errorf("DiaSemana %s mismatched", expect)
+		}
+	}
 }


### PR DESCRIPTION
## Summary
- extend enum tests to cover domicilios, pagos, pedidos, productos, and días de la semana

## Testing
- `go test ./tests -run Enums`


------
https://chatgpt.com/codex/tasks/task_e_68b44076cb2c8325a857ef3f1b659878