### PR TITLE
test: validate created and updated by on reserva

### DIFF
--- a/controllers/reserva_controller_test.go
+++ b/controllers/reserva_controller_test.go
@@ -466,6 +466,16 @@ func TestReservaPostSuccess(t *testing.T) {
 	if w.Code != http.StatusCreated {
 		t.Fatalf("expected 201, got %d", w.Code)
 	}
+
+	var resp struct {
+		Data map[string]interface{} `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+	if createdBy, ok := resp.Data["createdBy"].(string); !ok || createdBy != "admin" {
+		t.Fatalf("expected createdBy admin, got %v", resp.Data["createdBy"])
+	}
 }
 
 func TestReservaPutScenarios(t *testing.T) {
@@ -603,6 +613,16 @@ func TestReservaPutScenarios(t *testing.T) {
 	c.Put()
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var resp struct {
+		Data map[string]interface{} `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+	if updatedBy, ok := resp.Data["updatedBy"].(string); !ok || updatedBy != "admin" {
+		t.Fatalf("expected updatedBy admin, got %v", resp.Data["updatedBy"])
 	}
 }
 

--- a/models/reserva_test.go
+++ b/models/reserva_test.go
@@ -29,6 +29,48 @@ func TestReservaMarshalJSON(t *testing.T) {
 	}
 }
 
+func TestReservaMarshalJSONCreatedUpdatedBy(t *testing.T) {
+	r := Reserva{}
+
+	b, err := json.Marshal(r)
+	if err != nil {
+		t.Fatalf("json.Marshal returned error: %v", err)
+	}
+
+	var data map[string]interface{}
+	if err := json.Unmarshal(b, &data); err != nil {
+		t.Fatalf("json.Unmarshal returned error: %v", err)
+	}
+
+	if _, ok := data["createdBy"]; ok {
+		t.Errorf("createdBy should be omitted when nil")
+	}
+	if _, ok := data["updatedBy"]; ok {
+		t.Errorf("updatedBy should be omitted when nil")
+	}
+
+	cb, ub := "creator", "updater"
+	r.CREATED_BY = &cb
+	r.UPDATED_BY = &ub
+
+	b, err = json.Marshal(r)
+	if err != nil {
+		t.Fatalf("json.Marshal returned error: %v", err)
+	}
+
+	data = map[string]interface{}{}
+	if err := json.Unmarshal(b, &data); err != nil {
+		t.Fatalf("json.Unmarshal returned error: %v", err)
+	}
+
+	if data["createdBy"] != cb {
+		t.Errorf("expected createdBy %s, got %v", cb, data["createdBy"])
+	}
+	if data["updatedBy"] != ub {
+		t.Errorf("expected updatedBy %s, got %v", ub, data["updatedBy"])
+	}
+}
+
 func TestReservaTableName(t *testing.T) {
 	r := Reserva{}
 	if r.TableName() != "reserva" {


### PR DESCRIPTION
## Summary
- check createdBy field from Post responses
- check updatedBy field from Put responses
- ensure Reserva JSON omits createdBy/updatedBy when nil and includes them otherwise

## Testing
- `go test ./models -run ReservaMarshalJSONCreatedUpdatedBy -v`
- `go test ./controllers -run TestReservaPostSuccess -v`
- `go test ./controllers -run TestReservaPutScenarios -v`
- `go test ./...` *(fails: TestNominaPostMissingDatesForAutoGeneration, TestNominaPostMissingDatesForVerification, TestPagoPutSuccess, TestPagoPutUpdateError, TestPedidoAssignDomicilioUpdateError, TestPedidoAssignDomicilioSuccess, TestPedidoAssignPagoUpdateError, TestPedidoAssignPagoSuccess, TestPedidoUpdateEstadoPedidoUpdateError, TestPedidoUpdateEstadoPedidoSuccess, TestProductoHandleImageUploadTooLarge, TestProductoHandleImageUploadSuccess, TestProductoPostMissingNombre, TestPostMissingFields, TestPutInvalidDates, TestPutHashError, TestPutValidateDatesError, TestPutTelefonoUpdated, TestInitDBSuccess, TestCambiosHorarioMarshalJSON, TestDomicilioMarshalJSON, TestIncidenciaMarshalJSON, TestNominaMarshalJSON, TestPagoMarshalJSON, TestPedidoMarshalJSON, TestReservaMarshalJSON, TestTrabajadorMarshalJSON, TestTrabajadorMarshalJSONNil)*

------
https://chatgpt.com/codex/tasks/task_e_68b441320d9c83258cd4917ccfc21cb1