### PR TITLE
Añadir prueba de PUT sin updatedBy para Pago

### DIFF
--- a/controllers/pago_controller_test.go
+++ b/controllers/pago_controller_test.go
@@ -560,7 +560,7 @@ func TestPagoPutSuccess(t *testing.T) {
 		}
 	}
 	t.Cleanup(func() { pagoNewOrm = orig })
-	body := `{"fechaPago":"2024-02-02","horaPago":"11:00:00","monto":2000,"estadoPago":"pendiente","updatedBy":"me","metodoPagoId":1}`
+	body := `{"FECHA":"2024-02-02","HORA":"11:00:00","MONTO":2000,"ESTADO_PAGO":"pendiente","UPDATED_BY":"me","PK_ID_METODO_PAGO":1}`
 	r := httptest.NewRequest(http.MethodPut, "/pagos?id=1", strings.NewReader(body))
 	w := httptest.NewRecorder()
 	ctx := context.NewContext()
@@ -572,6 +572,33 @@ func TestPagoPutSuccess(t *testing.T) {
 	c.Put()
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d body %s", w.Code, w.Body.String())
+	}
+}
+
+func TestPagoPutSuccessWithoutUpdatedBy(t *testing.T) {
+	orig := pagoNewOrm
+	pagoNewOrm = func() ormer {
+		return fakeOrmer{
+			read:   func(m interface{}, cols ...string) error { return nil },
+			update: func(m interface{}, cols ...string) (int64, error) { return 1, nil },
+		}
+	}
+	t.Cleanup(func() { pagoNewOrm = orig })
+	body := `{"FECHA":"2024-02-02","HORA":"11:00:00","MONTO":2000,"ESTADO_PAGO":"pendiente","PK_ID_METODO_PAGO":1}`
+	r := httptest.NewRequest(http.MethodPut, "/pagos?id=1", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	c := PagoController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+	c.Ctx.Input.RequestBody = []byte(body)
+	c.Put()
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body %s", w.Code, w.Body.String())
+	}
+	if strings.Contains(w.Body.String(), "updatedBy") {
+		t.Fatalf("response should not include updatedBy: %s", w.Body.String())
 	}
 }
 
@@ -623,7 +650,7 @@ func TestPagoPutNotFound(t *testing.T) {
 		return fakeOrmer{read: func(m interface{}, cols ...string) error { return orm.ErrNoRows }}
 	}
 	t.Cleanup(func() { pagoNewOrm = orig })
-	body := `{"fechaPago":"2024-01-01","horaPago":"10:00:00","metodoPagoId":1}`
+	body := `{"FECHA":"2024-01-01","HORA":"10:00:00","PK_ID_METODO_PAGO":1}`
 	r := httptest.NewRequest(http.MethodPut, "/pagos?id=1", strings.NewReader(body))
 	w := httptest.NewRecorder()
 	ctx := context.NewContext()
@@ -647,7 +674,7 @@ func TestPagoPutUpdateError(t *testing.T) {
 		}
 	}
 	t.Cleanup(func() { pagoNewOrm = orig })
-	body := `{"fechaPago":"2024-01-01","horaPago":"10:00:00","metodoPagoId":1}`
+	body := `{"FECHA":"2024-01-01","HORA":"10:00:00","PK_ID_METODO_PAGO":1}`
 	r := httptest.NewRequest(http.MethodPut, "/pagos?id=1", strings.NewReader(body))
 	w := httptest.NewRecorder()
 	ctx := context.NewContext()

--- a/models/pago_test.go
+++ b/models/pago_test.go
@@ -24,10 +24,34 @@ func TestPagoMarshalJSON(t *testing.T) {
 		t.Fatalf("json.Unmarshal returned error: %v", err)
 	}
 
-	if data["fechapago"] != "16-08-2024" {
-		t.Errorf("expected fechapago 16-08-2024, got %v", data["fechapago"])
+	if data["fechaPago"] != "16-08-2024" {
+		t.Errorf("expected fechaPago 16-08-2024, got %v", data["fechaPago"])
 	}
-	if data["updatedat"] != "17-08-2024 12:30:45" {
-		t.Errorf("expected updatedat 17-08-2024 12:30:45, got %v", data["updatedat"])
+	if data["updatedAt"] != "17-08-2024 12:30:45" {
+		t.Errorf("expected updatedAt 17-08-2024 12:30:45, got %v", data["updatedAt"])
+	}
+}
+
+func TestPagoMarshalJSONNilUpdatedBy(t *testing.T) {
+	fecha := time.Date(2024, time.August, 16, 0, 0, 0, 0, time.UTC)
+	updated := time.Date(2024, time.August, 17, 12, 30, 45, 0, time.UTC)
+	p := Pago{
+		FECHA:      fecha,
+		UPDATED_AT: updated,
+		UPDATED_BY: nil,
+	}
+
+	b, err := json.Marshal(p)
+	if err != nil {
+		t.Fatalf("json.Marshal returned error: %v", err)
+	}
+
+	var data map[string]interface{}
+	if err := json.Unmarshal(b, &data); err != nil {
+		t.Fatalf("json.Unmarshal returned error: %v", err)
+	}
+
+	if _, ok := data["updatedBy"]; ok {
+		t.Errorf("expected updatedBy to be omitted, got %v", data["updatedBy"])
 	}
 }


### PR DESCRIPTION
## Summary
- Corrige las claves en la prueba de serialización de Pago y agrega caso cuando updatedBy es nil
- Ajusta pruebas de controlador de Pago y agrega escenario PUT sin updatedBy

## Testing
- `go test ./models -run Pago`
- `go test ./controllers -run 'TestPagoPutSuccess$|TestPagoPutSuccessWithoutUpdatedBy|TestPagoPutUpdateError'`


------
https://chatgpt.com/codex/tasks/task_e_68b442f531fc8325a13b0fb1a3f9ca4b