### PR TITLE
Add test for entregado flag and audit fields in domicilio controller

### DIFF
--- a/controllers/domicilio_controller_test.go
+++ b/controllers/domicilio_controller_test.go
@@ -1,6 +1,8 @@
 package controllers
 
 import (
+	stdctx "context"
+	"database/sql/driver"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -60,5 +62,51 @@ func TestPostInvalidEstadoPago(t *testing.T) {
 	}
 	if !strings.Contains(resp.Message, "estadoPago") {
 		t.Fatalf("expected error message about estadoPago, got %s", resp.Message)
+	}
+}
+
+func TestPostEntregadoTrue(t *testing.T) {
+	MockExec = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Result, error) {
+		return mockResult{}, nil
+	}
+	MockQuery = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
+		cols := []string{"pk_id_domicilio"}
+		vals := [][]driver.Value{{int64(1)}}
+		return &mockRows{columns: cols, values: vals}, nil
+	}
+	defer func() { MockExec = nil; MockQuery = nil }()
+
+	body := `{"direccion":"Calle 1","fechaDomicilio":"2024-01-01","telefono":"123","entregado":true}`
+	r := httptest.NewRequest(http.MethodPost, "/domicilios", strings.NewReader(body))
+	r.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	ctx.Input.RequestBody = []byte(body)
+	c := DomicilioController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	c.Post()
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected status 201, got %d", w.Code)
+	}
+	var resp models.ApiResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+	data, ok := resp.Data.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected data object, got %T", resp.Data)
+	}
+	if entregado, ok := data["entregado"].(bool); !ok || !entregado {
+		t.Fatalf("expected entregado true, got %v", data["entregado"])
+	}
+	if _, ok := data["createdAt"]; !ok {
+		t.Fatalf("expected createdAt in response")
+	}
+	if _, ok := data["updatedAt"]; !ok {
+		t.Fatalf("expected updatedAt in response")
 	}
 }


### PR DESCRIPTION
## Summary
- add unit test for DomicilioController to verify `entregado=true` is returned in response
- ensure audit fields `createdAt` and `updatedAt` are present

## Testing
- `go test ./controllers -run TestPostEntregadoTrue -count=1`
- `go test ./controllers -count=1` *(fails: TestNominaPostMissingDatesForAutoGeneration, TestNominaPostMissingDatesForVerification, TestPedidoAssignDomicilioUpdateError, TestPedidoAssignDomicilioSuccess, TestPedidoAssignPagoUpdateError, TestPedidoAssignPagoSuccess, TestPedidoUpdateEstadoPedidoUpdateError, TestPedidoUpdateEstadoPedidoSuccess, TestProductoHandleImageUploadTooLarge, TestProductoHandleImageUploadSuccess, TestProductoPostMissingNombre, TestPostMissingFields, TestPutInvalidDates, TestPutHashError, TestPutValidateDatesError, TestPutTelefonoUpdated)*

------
https://chatgpt.com/codex/tasks/task_e_68b4446497b4832587373bf040a2d17d