### PR TITLE
test: validate payroll auto generation response

### DIFF
--- a/tests/nomina_functions_test.go
+++ b/tests/nomina_functions_test.go
@@ -1,10 +1,13 @@
 package test
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"restaurante/models"
 )
 
 func TestNominaGenerarYVerificar(t *testing.T) {
@@ -14,5 +17,29 @@ func TestNominaGenerarYVerificar(t *testing.T) {
 	w := sendRequest(req)
 	if w.Code != http.StatusCreated {
 		t.Skipf("nomina generation/verification failed or DB unavailable: %d %s", w.Code, w.Body.String())
+	}
+
+	var resp models.ApiResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+
+	if resp.Message != "Nómina creada correctamente" {
+		t.Errorf("unexpected response message: %s", resp.Message)
+	}
+
+	if resp.Data == nil {
+		t.Fatalf("expected response data")
+	}
+	dataBytes, err := json.Marshal(resp.Data)
+	if err != nil {
+		t.Fatalf("failed to marshal data: %v", err)
+	}
+	var nomina models.Nomina
+	if err := json.Unmarshal(dataBytes, &nomina); err != nil {
+		t.Fatalf("failed to unmarshal nomina: %v", err)
+	}
+	if nomina.PK_ID_NOMINA == 0 {
+		t.Errorf("expected valid nomina ID, got %d", nomina.PK_ID_NOMINA)
 	}
 }


### PR DESCRIPTION
## Summary
- deserialize payroll generation response and verify success message and generated ID

## Testing
- `go test ./...` *(fails: missing configuration and database connection)*

------
https://chatgpt.com/codex/tasks/task_e_68b445661cec8325ad8974d0964911e5