### PR TITLE
Use int64 for Cliente IDs

### DIFF
--- a/controllers/ClienteController.go
+++ b/controllers/ClienteController.go
@@ -1,37 +1,36 @@
 package controllers
 
 import (
-        "encoding/json"
-        "net/http"
-        "restaurante/models"
-        "strconv"
-        "strings"
+	"encoding/json"
+	"net/http"
+	"restaurante/models"
+	"strings"
 
-        "github.com/beego/beego/v2/client/orm"
-        "github.com/beego/beego/v2/server/web"
-        "golang.org/x/crypto/bcrypt"
+	"github.com/beego/beego/v2/client/orm"
+	"github.com/beego/beego/v2/server/web"
+	"golang.org/x/crypto/bcrypt"
 )
 
 var ormNew = orm.NewOrm
 
 var queryAllClientes = func(o orm.Ormer, clientes *[]models.Cliente) (int64, error) {
-        return o.QueryTable(new(models.Cliente)).All(clientes)
+	return o.QueryTable(new(models.Cliente)).All(clientes)
 }
 
 var readCliente = func(o orm.Ormer, c *models.Cliente) error {
-        return o.Read(c)
+	return o.Read(c)
 }
 
 var insertCliente = func(o orm.Ormer, c *models.Cliente) (int64, error) {
-        return o.Insert(c)
+	return o.Insert(c)
 }
 
 var updateCliente = func(o orm.Ormer, c *models.Cliente) (int64, error) {
-        return o.Update(c)
+	return o.Update(c)
 }
 
 var deleteCliente = func(o orm.Ormer, c *models.Cliente) (int64, error) {
-        return o.Delete(c)
+	return o.Delete(c)
 }
 
 var bcryptGenerate = bcrypt.GenerateFromPassword
@@ -68,13 +67,13 @@ func isUniqueEmailErr(err error) bool {
 // @Security BearerAuth
 // @Router /clientes [get]
 func (c *ClienteController) GetAll() {
-        o := ormNew()
+	o := ormNew()
 	var clientes []models.Cliente
 
 	// Obtener el valor del parámetro fields
 	fields := c.GetString("fields")
 
-       _, err := queryAllClientes(o, &clientes)
+	_, err := queryAllClientes(o, &clientes)
 	if err != nil {
 		c.Ctx.Output.SetStatus(http.StatusInternalServerError)
 		c.Data["json"] = models.ApiResponse{
@@ -132,8 +131,8 @@ func (c *ClienteController) GetAll() {
 // @Security BearerAuth
 // @Router /clientes/search [get]
 func (c *ClienteController) GetById() {
-        o := ormNew()
-	id, err := c.GetInt("id")
+	o := ormNew()
+	id, err := c.GetInt64("id")
 
 	if err != nil || id == 0 {
 		c.Ctx.Output.SetStatus(http.StatusBadRequest)
@@ -148,7 +147,7 @@ func (c *ClienteController) GetById() {
 
 	cliente := models.Cliente{PK_DOCUMENTO_CLIENTE: id}
 
-       err = readCliente(o, &cliente)
+	err = readCliente(o, &cliente)
 	if err == orm.ErrNoRows {
 		c.Ctx.Output.SetStatus(http.StatusOK)
 		c.Data["json"] = models.ApiResponse{
@@ -192,7 +191,7 @@ func (c *ClienteController) GetById() {
 // @Failure 409 {object} models.ApiResponse "Correo ya registrado"
 // @Router /clientes [post]
 func (c *ClienteController) Post() {
-        o := ormNew()
+	o := ormNew()
 	var cliente models.Cliente
 
 	if err := json.Unmarshal(c.Ctx.Input.RequestBody, &cliente); err != nil {
@@ -213,7 +212,7 @@ func (c *ClienteController) Post() {
 	}
 
 	// Hash de la contraseña antes de insertar
-       hashedPassword, err := bcryptGenerate([]byte(cliente.PASSWORD), bcrypt.DefaultCost)
+	hashedPassword, err := bcryptGenerate([]byte(cliente.PASSWORD), bcrypt.DefaultCost)
 	if err != nil {
 		c.Ctx.Output.SetStatus(http.StatusInternalServerError)
 		c.Data["json"] = models.ApiResponse{
@@ -227,7 +226,7 @@ func (c *ClienteController) Post() {
 	cliente.PASSWORD = string(hashedPassword)
 
 	// Inserción en la base de datos
-       if _, err = insertCliente(o, &cliente); err != nil {
+	if _, err = insertCliente(o, &cliente); err != nil {
 		if isUniqueEmailErr(err) {
 			c.Ctx.Output.SetStatus(http.StatusConflict)
 			c.Data["json"] = models.ApiResponse{
@@ -274,11 +273,10 @@ func (c *ClienteController) Post() {
 // @Security BearerAuth
 // @Router /clientes [put]
 func (c *ClienteController) Put() {
-        o := ormNew()
+	o := ormNew()
 
 	// Obtener el ID del query parameter
-	idStr := c.GetString("id")
-	id, err := strconv.Atoi(idStr)
+	id, err := c.GetInt64("id")
 	if err != nil || id == 0 {
 		c.Ctx.Output.SetStatus(http.StatusBadRequest)
 		c.Data["json"] = models.ApiResponse{
@@ -292,7 +290,7 @@ func (c *ClienteController) Put() {
 
 	// Verificar si el cliente existe
 	cliente := models.Cliente{PK_DOCUMENTO_CLIENTE: id}
-       if err := readCliente(o, &cliente); err != nil {
+	if err := readCliente(o, &cliente); err != nil {
 		if err == orm.ErrNoRows {
 			c.Ctx.Output.SetStatus(http.StatusOK)
 			c.Data["json"] = models.ApiResponse{
@@ -342,7 +340,7 @@ func (c *ClienteController) Put() {
 
 	// Si se proporciona una nueva contraseña, hashéala; de lo contrario conserva la actual
 	if updatedCliente.PASSWORD != "" {
-               hashedPassword, err := bcryptGenerate([]byte(updatedCliente.PASSWORD), bcrypt.DefaultCost)
+		hashedPassword, err := bcryptGenerate([]byte(updatedCliente.PASSWORD), bcrypt.DefaultCost)
 		if err != nil {
 			c.Ctx.Output.SetStatus(http.StatusInternalServerError)
 			c.Data["json"] = models.ApiResponse{
@@ -360,7 +358,7 @@ func (c *ClienteController) Put() {
 	}
 
 	// Actualizar en la base de datos
-       if _, err = updateCliente(o, &updatedCliente); err != nil {
+	if _, err = updateCliente(o, &updatedCliente); err != nil {
 		if isUniqueEmailErr(err) {
 			c.Ctx.Output.SetStatus(http.StatusConflict)
 			c.Data["json"] = models.ApiResponse{
@@ -405,11 +403,10 @@ func (c *ClienteController) Put() {
 // @Security BearerAuth
 // @Router /clientes [delete]
 func (c *ClienteController) Delete() {
-        o := ormNew()
+	o := ormNew()
 
 	// Obtener el ID del query parameter
-	idStr := c.GetString("id")
-	id, err := strconv.Atoi(idStr)
+	id, err := c.GetInt64("id")
 	if err != nil || id == 0 {
 		c.Ctx.Output.SetStatus(http.StatusBadRequest)
 		c.Data["json"] = models.ApiResponse{
@@ -422,7 +419,7 @@ func (c *ClienteController) Delete() {
 
 	cliente := models.Cliente{PK_DOCUMENTO_CLIENTE: id}
 
-       if _, err := deleteCliente(o, &cliente); err == nil {
+	if _, err := deleteCliente(o, &cliente); err == nil {
 		c.Ctx.Output.SetStatus(http.StatusOK)
 		c.Data["json"] = models.ApiResponse{
 			Code:    http.StatusOK,

--- a/controllers/LoginController.go
+++ b/controllers/LoginController.go
@@ -28,7 +28,7 @@ type LoginController struct {
 
 // Estructura para los claims del JWT
 type Claims struct {
-	Documento int    `json:"documento"`
+	Documento int64  `json:"documento"`
 	Rol       string `json:"rol"`
 	Nombre    string `json:"nombre"`
 	jwt.StandardClaims
@@ -64,7 +64,7 @@ func (c *LoginController) Login() {
 	o := newOrm()
 
 	// Primero, intenta encontrar al usuario como trabajador
-	trabajador := models.Trabajador{PK_DOCUMENTO_TRABAJADOR: int64(loginRequest.Documento)}
+	trabajador := models.Trabajador{PK_DOCUMENTO_TRABAJADOR: loginRequest.Documento}
 	err := o.Read(&trabajador)
 
 	if err == nil {
@@ -80,7 +80,7 @@ func (c *LoginController) Login() {
 		}
 		nombre := trabajador.NOMBRE + " " + trabajador.APELLIDO
 		// Generar JWT con el rol específico del trabajador (admin, mesero, mensajero, etc.)
-		generateJWT(c, int(trabajador.PK_DOCUMENTO_TRABAJADOR), trabajador.ROL, nombre)
+		generateJWT(c, trabajador.PK_DOCUMENTO_TRABAJADOR, trabajador.ROL, nombre)
 		return
 	}
 
@@ -115,7 +115,7 @@ func (c *LoginController) Login() {
 }
 
 // Función para generar y devolver un token JWT
-func generateJWT(c *LoginController, documento int, rol string, nombre string) {
+func generateJWT(c *LoginController, documento int64, rol string, nombre string) {
 	now := time.Now()
 	expirationTime := now.Add(24 * time.Hour)
 

--- a/controllers/PedidoClienteController.go
+++ b/controllers/PedidoClienteController.go
@@ -133,7 +133,7 @@ func (c *PedidoClienteController) Post() {
 	// Ejecutar transacción
 	err := pcDoTx(o, func(ctx context.Context, txOrm orm.TxOrmer) error {
 		// Validar que el cliente existe
-		cliente := models.Cliente{PK_DOCUMENTO_CLIENTE: int(relacion.PK_DOCUMENTO_CLIENTE)}
+		cliente := models.Cliente{PK_DOCUMENTO_CLIENTE: relacion.PK_DOCUMENTO_CLIENTE}
 		if err := pcReadCliente(txOrm, &cliente); err != nil {
 			c.Ctx.Output.SetStatus(http.StatusOK)
 			c.Data["json"] = models.ApiResponse{

--- a/controllers/cliente_controller_test.go
+++ b/controllers/cliente_controller_test.go
@@ -1,483 +1,482 @@
 package controllers
 
 import (
-        "encoding/json"
-        "errors"
-        "net/http"
-        "net/http/httptest"
-        "strings"
-        "testing"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
 
-        "github.com/beego/beego/v2/client/orm"
-        "github.com/beego/beego/v2/server/web/context"
-       "golang.org/x/crypto/bcrypt"
-        "restaurante/models"
+	"github.com/beego/beego/v2/client/orm"
+	"github.com/beego/beego/v2/server/web/context"
+	"golang.org/x/crypto/bcrypt"
+	"restaurante/models"
 )
 
 func resetMocks() {
-        ormNew = orm.NewOrm
-        queryAllClientes = func(o orm.Ormer, clientes *[]models.Cliente) (int64, error) {
-                return o.QueryTable(new(models.Cliente)).All(clientes)
-        }
-        readCliente = func(o orm.Ormer, c *models.Cliente) error { return o.Read(c) }
-        insertCliente = func(o orm.Ormer, c *models.Cliente) (int64, error) { return o.Insert(c) }
-        updateCliente = func(o orm.Ormer, c *models.Cliente) (int64, error) { return o.Update(c) }
-        deleteCliente = func(o orm.Ormer, c *models.Cliente) (int64, error) { return o.Delete(c) }
-       bcryptGenerate = bcrypt.GenerateFromPassword
+	ormNew = orm.NewOrm
+	queryAllClientes = func(o orm.Ormer, clientes *[]models.Cliente) (int64, error) {
+		return o.QueryTable(new(models.Cliente)).All(clientes)
+	}
+	readCliente = func(o orm.Ormer, c *models.Cliente) error { return o.Read(c) }
+	insertCliente = func(o orm.Ormer, c *models.Cliente) (int64, error) { return o.Insert(c) }
+	updateCliente = func(o orm.Ormer, c *models.Cliente) (int64, error) { return o.Update(c) }
+	deleteCliente = func(o orm.Ormer, c *models.Cliente) (int64, error) { return o.Delete(c) }
+	bcryptGenerate = bcrypt.GenerateFromPassword
 }
 
 func TestNormalizeEmail(t *testing.T) {
-        got := normalizeEmail("  Foo@Example.COM  ")
-        if got != "foo@example.com" {
-                t.Errorf("expected foo@example.com, got %s", got)
-        }
+	got := normalizeEmail("  Foo@Example.COM  ")
+	if got != "foo@example.com" {
+		t.Errorf("expected foo@example.com, got %s", got)
+	}
 }
 
 func TestIsUniqueEmailErr(t *testing.T) {
-        uniqueErr := errors.New("uq_cliente_correo")
-        if !isUniqueEmailErr(uniqueErr) {
-                t.Errorf("expected true for unique email error")
-        }
-        otherErr := errors.New("other")
-        if isUniqueEmailErr(otherErr) {
-                t.Errorf("expected false for non unique email error")
-        }
-        if isUniqueEmailErr(nil) {
-                t.Errorf("expected false for nil error")
-        }
+	uniqueErr := errors.New("uq_cliente_correo")
+	if !isUniqueEmailErr(uniqueErr) {
+		t.Errorf("expected true for unique email error")
+	}
+	otherErr := errors.New("other")
+	if isUniqueEmailErr(otherErr) {
+		t.Errorf("expected false for non unique email error")
+	}
+	if isUniqueEmailErr(nil) {
+		t.Errorf("expected false for nil error")
+	}
 }
 
 func TestClienteGetAllSuccess(t *testing.T) {
-        db := map[int]models.Cliente{1: {PK_DOCUMENTO_CLIENTE: 1, NOMBRE: "Foo", APELLIDO: "Bar", TELEFONO: "123", PASSWORD: "pwd"}}
-        ormNew = func() orm.Ormer { return nil }
-        queryAllClientes = func(o orm.Ormer, clientes *[]models.Cliente) (int64, error) {
-                for _, c := range db {
-                        *clientes = append(*clientes, c)
-                }
-                return int64(len(db)), nil
-        }
-        t.Cleanup(resetMocks)
-        r := httptest.NewRequest(http.MethodGet, "/clientes", nil)
-        w := httptest.NewRecorder()
-        ctx := context.NewContext()
-        ctx.Reset(w, r)
-       c := ClienteController{}
-       c.Ctx = ctx
-       c.Data = map[interface{}]interface{}{}
-        c.GetAll()
-        if w.Code != http.StatusOK {
-                t.Fatalf("expected 200, got %d", w.Code)
-        }
-        if strings.Contains(w.Body.String(), "pwd") {
-                t.Fatalf("password should be removed")
-        }
+	db := map[int64]models.Cliente{1: {PK_DOCUMENTO_CLIENTE: 1, NOMBRE: "Foo", APELLIDO: "Bar", TELEFONO: "123", PASSWORD: "pwd"}}
+	ormNew = func() orm.Ormer { return nil }
+	queryAllClientes = func(o orm.Ormer, clientes *[]models.Cliente) (int64, error) {
+		for _, c := range db {
+			*clientes = append(*clientes, c)
+		}
+		return int64(len(db)), nil
+	}
+	t.Cleanup(resetMocks)
+	r := httptest.NewRequest(http.MethodGet, "/clientes", nil)
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	c := ClienteController{}
+	c.Ctx = ctx
+	c.Data = map[interface{}]interface{}{}
+	c.GetAll()
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if strings.Contains(w.Body.String(), "pwd") {
+		t.Fatalf("password should be removed")
+	}
 }
 
 func TestClienteGetAllFiltered(t *testing.T) {
-        db := map[int]models.Cliente{1: {PK_DOCUMENTO_CLIENTE: 1, NOMBRE: "Foo", APELLIDO: "Bar", TELEFONO: "123", PASSWORD: "pwd"}}
-        ormNew = func() orm.Ormer { return nil }
-        queryAllClientes = func(o orm.Ormer, clientes *[]models.Cliente) (int64, error) {
-                for _, c := range db {
-                        *clientes = append(*clientes, c)
-                }
-                return 1, nil
-        }
-        t.Cleanup(resetMocks)
-        r := httptest.NewRequest(http.MethodGet, "/clientes?fields=nombre_completo_telefono", nil)
-        w := httptest.NewRecorder()
-        ctx := context.NewContext()
-        ctx.Reset(w, r)
-        c := ClienteController{}
-        c.Ctx = ctx
-        c.Data = map[interface{}]interface{}{}
-        c.GetAll()
-        if w.Code != http.StatusOK {
-                t.Fatalf("expected 200, got %d", w.Code)
-        }
-        if !strings.Contains(w.Body.String(), "nombre_completo") {
-                t.Fatalf("expected filtered response")
-        }
+	db := map[int64]models.Cliente{1: {PK_DOCUMENTO_CLIENTE: 1, NOMBRE: "Foo", APELLIDO: "Bar", TELEFONO: "123", PASSWORD: "pwd"}}
+	ormNew = func() orm.Ormer { return nil }
+	queryAllClientes = func(o orm.Ormer, clientes *[]models.Cliente) (int64, error) {
+		for _, c := range db {
+			*clientes = append(*clientes, c)
+		}
+		return 1, nil
+	}
+	t.Cleanup(resetMocks)
+	r := httptest.NewRequest(http.MethodGet, "/clientes?fields=nombre_completo_telefono", nil)
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	c := ClienteController{}
+	c.Ctx = ctx
+	c.Data = map[interface{}]interface{}{}
+	c.GetAll()
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "nombre_completo") {
+		t.Fatalf("expected filtered response")
+	}
 }
 
 func TestClienteGetAllDBError(t *testing.T) {
-        ormNew = func() orm.Ormer { return nil }
-        queryAllClientes = func(o orm.Ormer, clientes *[]models.Cliente) (int64, error) {
-                return 0, errors.New("db error")
-        }
-        t.Cleanup(resetMocks)
-        r := httptest.NewRequest(http.MethodGet, "/clientes", nil)
-        w := httptest.NewRecorder()
-        ctx := context.NewContext()
-        ctx.Reset(w, r)
-        c := ClienteController{}
-        c.Ctx = ctx
-        c.Data = map[interface{}]interface{}{}
-        c.GetAll()
-        if w.Code != http.StatusInternalServerError {
-                t.Fatalf("expected 500, got %d", w.Code)
-        }
+	ormNew = func() orm.Ormer { return nil }
+	queryAllClientes = func(o orm.Ormer, clientes *[]models.Cliente) (int64, error) {
+		return 0, errors.New("db error")
+	}
+	t.Cleanup(resetMocks)
+	r := httptest.NewRequest(http.MethodGet, "/clientes", nil)
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	c := ClienteController{}
+	c.Ctx = ctx
+	c.Data = map[interface{}]interface{}{}
+	c.GetAll()
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", w.Code)
+	}
 }
 
 func TestClienteGetByIdScenarios(t *testing.T) {
-       db := map[int]models.Cliente{1: {PK_DOCUMENTO_CLIENTE: 1, NOMBRE: "Foo", PASSWORD: "pwd"}}
-       ormNew = func() orm.Ormer { return nil }
-       var readErr error
-       readCliente = func(o orm.Ormer, c *models.Cliente) error {
-               if readErr != nil {
-                       return readErr
-               }
-               cli, ok := db[c.PK_DOCUMENTO_CLIENTE]
-               if !ok {
-                       return orm.ErrNoRows
-               }
-               *c = cli
-               return nil
-       }
-        t.Cleanup(resetMocks)
-        // invalid id
-        r := httptest.NewRequest(http.MethodGet, "/clientes/search", nil)
-        w := httptest.NewRecorder()
-        ctx := context.NewContext()
-        ctx.Reset(w, r)
-        c := ClienteController{}
-        c.Ctx = ctx
-        c.Data = map[interface{}]interface{}{}
-        c.GetById()
-        if w.Code != http.StatusBadRequest {
-                t.Fatalf("expected 400, got %d", w.Code)
-        }
-        // not found
-        r = httptest.NewRequest(http.MethodGet, "/clientes/search?id=2", nil)
-        w = httptest.NewRecorder()
-        ctx = context.NewContext()
-        ctx.Reset(w, r)
-        c.Ctx = ctx
-        c.Data = map[interface{}]interface{}{}
-        c.GetById()
-        if w.Code != http.StatusOK || !strings.Contains(w.Body.String(), "Cliente no encontrado") {
-                t.Fatalf("not found case failed")
-        }
-       // db error
-       readErr = errors.New("db error")
-       r = httptest.NewRequest(http.MethodGet, "/clientes/search?id=1", nil)
-       w = httptest.NewRecorder()
-       ctx = context.NewContext()
-       ctx.Reset(w, r)
-       c.Ctx = ctx
-       c.Data = map[interface{}]interface{}{}
-       c.GetById()
-       if w.Code != http.StatusInternalServerError {
-               t.Fatalf("expected 500, got %d", w.Code)
-       }
-       // success
-       readErr = nil
-       r = httptest.NewRequest(http.MethodGet, "/clientes/search?id=1", nil)
-        w = httptest.NewRecorder()
-        ctx = context.NewContext()
-        ctx.Reset(w, r)
-        c.Ctx = ctx
-        c.Data = map[interface{}]interface{}{}
-        c.GetById()
-        if w.Code != http.StatusOK {
-                t.Fatalf("expected 200, got %d", w.Code)
-        }
-        if strings.Contains(w.Body.String(), "pwd") {
-                t.Fatalf("password should be removed")
-        }
+	db := map[int64]models.Cliente{1: {PK_DOCUMENTO_CLIENTE: 1, NOMBRE: "Foo", PASSWORD: "pwd"}}
+	ormNew = func() orm.Ormer { return nil }
+	var readErr error
+	readCliente = func(o orm.Ormer, c *models.Cliente) error {
+		if readErr != nil {
+			return readErr
+		}
+		cli, ok := db[c.PK_DOCUMENTO_CLIENTE]
+		if !ok {
+			return orm.ErrNoRows
+		}
+		*c = cli
+		return nil
+	}
+	t.Cleanup(resetMocks)
+	// invalid id
+	r := httptest.NewRequest(http.MethodGet, "/clientes/search", nil)
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	c := ClienteController{}
+	c.Ctx = ctx
+	c.Data = map[interface{}]interface{}{}
+	c.GetById()
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+	// not found
+	r = httptest.NewRequest(http.MethodGet, "/clientes/search?id=2", nil)
+	w = httptest.NewRecorder()
+	ctx = context.NewContext()
+	ctx.Reset(w, r)
+	c.Ctx = ctx
+	c.Data = map[interface{}]interface{}{}
+	c.GetById()
+	if w.Code != http.StatusOK || !strings.Contains(w.Body.String(), "Cliente no encontrado") {
+		t.Fatalf("not found case failed")
+	}
+	// db error
+	readErr = errors.New("db error")
+	r = httptest.NewRequest(http.MethodGet, "/clientes/search?id=1", nil)
+	w = httptest.NewRecorder()
+	ctx = context.NewContext()
+	ctx.Reset(w, r)
+	c.Ctx = ctx
+	c.Data = map[interface{}]interface{}{}
+	c.GetById()
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", w.Code)
+	}
+	// success
+	readErr = nil
+	r = httptest.NewRequest(http.MethodGet, "/clientes/search?id=1", nil)
+	w = httptest.NewRecorder()
+	ctx = context.NewContext()
+	ctx.Reset(w, r)
+	c.Ctx = ctx
+	c.Data = map[interface{}]interface{}{}
+	c.GetById()
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if strings.Contains(w.Body.String(), "pwd") {
+		t.Fatalf("password should be removed")
+	}
 }
 
 func TestClientePostScenarios(t *testing.T) {
-        db := make(map[int]models.Cliente)
-        ormNew = func() orm.Ormer { return nil }
-        insertCliente = func(o orm.Ormer, c *models.Cliente) (int64, error) {
-                if _, ok := db[c.PK_DOCUMENTO_CLIENTE]; ok {
-                        return 0, errors.New("unique correo")
-                }
-                db[c.PK_DOCUMENTO_CLIENTE] = *c
-                return 1, nil
-        }
-        t.Cleanup(resetMocks)
-        // invalid json
-        r := httptest.NewRequest(http.MethodPost, "/clientes", strings.NewReader("notjson"))
-        w := httptest.NewRecorder()
-        ctx := context.NewContext()
-        ctx.Reset(w, r)
-        ctx.Input.CopyBody(1 << 20)
-        c := ClienteController{}
-        c.Ctx = ctx
-        c.Data = map[interface{}]interface{}{}
-        c.Post()
-        if w.Code != http.StatusBadRequest {
-                t.Fatalf("expected 400, got %d", w.Code)
-        }
-        // db error
-        insertCliente = func(o orm.Ormer, c *models.Cliente) (int64, error) { return 0, errors.New("db error") }
-        body := `{"documentoCliente":1,"nombre":"Foo","apellido":"B","direccion":"C","telefono":"1","password":"pass","correo":" TeSt@Email.com "}`
-        r = httptest.NewRequest(http.MethodPost, "/clientes", strings.NewReader(body))
-        w = httptest.NewRecorder()
-        ctx = context.NewContext()
-        ctx.Reset(w, r)
-        ctx.Input.CopyBody(1 << 20)
-        c.Ctx = ctx
-        c.Data = map[interface{}]interface{}{}
-        c.Post()
-        if w.Code != http.StatusInternalServerError {
-                t.Fatalf("expected 500, got %d", w.Code)
-        }
-        // unique error
-        insertCliente = func(o orm.Ormer, c *models.Cliente) (int64, error) { return 0, errors.New("unique correo") }
-        r = httptest.NewRequest(http.MethodPost, "/clientes", strings.NewReader(body))
-        w = httptest.NewRecorder()
-        ctx = context.NewContext()
-        ctx.Reset(w, r)
-        ctx.Input.CopyBody(1 << 20)
-        c.Ctx = ctx
-        c.Data = map[interface{}]interface{}{}
-        c.Post()
-        if w.Code != http.StatusConflict {
-                t.Fatalf("expected 409, got %d", w.Code)
-        }
-       // hash error
-       bcryptGenerate = func([]byte, int) ([]byte, error) { return nil, errors.New("hash") }
-       r = httptest.NewRequest(http.MethodPost, "/clientes", strings.NewReader(body))
-       w = httptest.NewRecorder()
-       ctx = context.NewContext()
-       ctx.Reset(w, r)
-       ctx.Input.CopyBody(1 << 20)
-       c.Ctx = ctx
-       c.Data = map[interface{}]interface{}{}
-       c.Post()
-       if w.Code != http.StatusInternalServerError {
-               t.Fatalf("expected 500, got %d", w.Code)
-       }
-       bcryptGenerate = bcrypt.GenerateFromPassword
-        // success
-        insertCliente = func(o orm.Ormer, c *models.Cliente) (int64, error) {
-                db[c.PK_DOCUMENTO_CLIENTE] = *c
-                return 1, nil
-        }
-        r = httptest.NewRequest(http.MethodPost, "/clientes", strings.NewReader(body))
-        w = httptest.NewRecorder()
-        ctx = context.NewContext()
-        ctx.Reset(w, r)
-        ctx.Input.CopyBody(1 << 20)
-        c.Ctx = ctx
-        c.Data = map[interface{}]interface{}{}
-        c.Post()
-       if w.Code != http.StatusCreated {
-               t.Fatalf("expected 201, got %d", w.Code)
-       }
-       var resp struct {
-               Data models.Cliente `json:"data"`
-       }
-       if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
-               t.Fatalf("invalid json: %v", err)
-       }
-       if resp.Data.PASSWORD != "" {
-               t.Fatalf("password should be empty")
-       }
+	db := make(map[int64]models.Cliente)
+	ormNew = func() orm.Ormer { return nil }
+	insertCliente = func(o orm.Ormer, c *models.Cliente) (int64, error) {
+		if _, ok := db[c.PK_DOCUMENTO_CLIENTE]; ok {
+			return 0, errors.New("unique correo")
+		}
+		db[c.PK_DOCUMENTO_CLIENTE] = *c
+		return 1, nil
+	}
+	t.Cleanup(resetMocks)
+	// invalid json
+	r := httptest.NewRequest(http.MethodPost, "/clientes", strings.NewReader("notjson"))
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	ctx.Input.CopyBody(1 << 20)
+	c := ClienteController{}
+	c.Ctx = ctx
+	c.Data = map[interface{}]interface{}{}
+	c.Post()
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+	// db error
+	insertCliente = func(o orm.Ormer, c *models.Cliente) (int64, error) { return 0, errors.New("db error") }
+	body := `{"documentoCliente":1,"nombre":"Foo","apellido":"B","direccion":"C","telefono":"1","password":"pass","correo":" TeSt@Email.com "}`
+	r = httptest.NewRequest(http.MethodPost, "/clientes", strings.NewReader(body))
+	w = httptest.NewRecorder()
+	ctx = context.NewContext()
+	ctx.Reset(w, r)
+	ctx.Input.CopyBody(1 << 20)
+	c.Ctx = ctx
+	c.Data = map[interface{}]interface{}{}
+	c.Post()
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", w.Code)
+	}
+	// unique error
+	insertCliente = func(o orm.Ormer, c *models.Cliente) (int64, error) { return 0, errors.New("unique correo") }
+	r = httptest.NewRequest(http.MethodPost, "/clientes", strings.NewReader(body))
+	w = httptest.NewRecorder()
+	ctx = context.NewContext()
+	ctx.Reset(w, r)
+	ctx.Input.CopyBody(1 << 20)
+	c.Ctx = ctx
+	c.Data = map[interface{}]interface{}{}
+	c.Post()
+	if w.Code != http.StatusConflict {
+		t.Fatalf("expected 409, got %d", w.Code)
+	}
+	// hash error
+	bcryptGenerate = func([]byte, int) ([]byte, error) { return nil, errors.New("hash") }
+	r = httptest.NewRequest(http.MethodPost, "/clientes", strings.NewReader(body))
+	w = httptest.NewRecorder()
+	ctx = context.NewContext()
+	ctx.Reset(w, r)
+	ctx.Input.CopyBody(1 << 20)
+	c.Ctx = ctx
+	c.Data = map[interface{}]interface{}{}
+	c.Post()
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", w.Code)
+	}
+	bcryptGenerate = bcrypt.GenerateFromPassword
+	// success
+	insertCliente = func(o orm.Ormer, c *models.Cliente) (int64, error) {
+		db[c.PK_DOCUMENTO_CLIENTE] = *c
+		return 1, nil
+	}
+	r = httptest.NewRequest(http.MethodPost, "/clientes", strings.NewReader(body))
+	w = httptest.NewRecorder()
+	ctx = context.NewContext()
+	ctx.Reset(w, r)
+	ctx.Input.CopyBody(1 << 20)
+	c.Ctx = ctx
+	c.Data = map[interface{}]interface{}{}
+	c.Post()
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d", w.Code)
+	}
+	var resp struct {
+		Data models.Cliente `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("invalid json: %v", err)
+	}
+	if resp.Data.PASSWORD != "" {
+		t.Fatalf("password should be empty")
+	}
 }
 
 func TestClientePutScenarios(t *testing.T) {
-        db := map[int]models.Cliente{1: {PK_DOCUMENTO_CLIENTE: 1, NOMBRE: "Foo", PASSWORD: "old"}, 2: {PK_DOCUMENTO_CLIENTE: 2, NOMBRE: "Bar", CORREO: ptr("a@a.com"), PASSWORD: "x"}}
-        ormNew = func() orm.Ormer { return nil }
-       readCliente = func(o orm.Ormer, c *models.Cliente) error {
-               cli, ok := db[c.PK_DOCUMENTO_CLIENTE]
-               if !ok {
-                       return orm.ErrNoRows
-               }
-               *c = cli
-               return nil
-       }
-       updateCliente = func(o orm.Ormer, c *models.Cliente) (int64, error) {
-                if c.NOMBRE == "fail" {
-                        return 0, errors.New("db error")
-                }
-                for id, cli := range db {
-                        if id != c.PK_DOCUMENTO_CLIENTE && cli.CORREO != nil && c.CORREO != nil && *cli.CORREO == *c.CORREO {
-                                return 0, errors.New("unique correo")
-                        }
-                }
-                db[c.PK_DOCUMENTO_CLIENTE] = *c
-                return 1, nil
-        }
-        t.Cleanup(resetMocks)
-       // invalid id
-       r := httptest.NewRequest(http.MethodPut, "/clientes", nil)
-        w := httptest.NewRecorder()
-        ctx := context.NewContext()
-        ctx.Reset(w, r)
-        c := ClienteController{}
-        c.Ctx = ctx
-        c.Data = map[interface{}]interface{}{}
-        c.Put()
-       if w.Code != http.StatusBadRequest {
-               t.Fatalf("expected 400, got %d", w.Code)
-       }
-       // read error
-       readCliente = func(o orm.Ormer, c *models.Cliente) error { return errors.New("db") }
-       r = httptest.NewRequest(http.MethodPut, "/clientes?id=1", strings.NewReader(`{"nombre":"Foo"}`))
-       w = httptest.NewRecorder()
-       ctx = context.NewContext()
-       ctx.Reset(w, r)
-       ctx.Input.CopyBody(1 << 20)
-       c.Ctx = ctx
-       c.Data = map[interface{}]interface{}{}
-       c.Put()
-       if w.Code != http.StatusInternalServerError {
-               t.Fatalf("expected 500, got %d", w.Code)
-       }
-       readCliente = func(o orm.Ormer, c *models.Cliente) error {
-               cli, ok := db[c.PK_DOCUMENTO_CLIENTE]
-               if !ok {
-                       return orm.ErrNoRows
-               }
-               *c = cli
-               return nil
-       }
-       // not found
-        r = httptest.NewRequest(http.MethodPut, "/clientes?id=3", strings.NewReader(`{"nombre":"Foo"}`))
-        w = httptest.NewRecorder()
-        ctx = context.NewContext()
-        ctx.Reset(w, r)
-        ctx.Input.CopyBody(1 << 20)
-        c.Ctx = ctx
-        c.Data = map[interface{}]interface{}{}
-        c.Put()
-        if w.Code != http.StatusOK || !strings.Contains(w.Body.String(), "Cliente no encontrado") {
-                t.Fatalf("not found failed")
-        }
-        // decode error
-        r = httptest.NewRequest(http.MethodPut, "/clientes?id=1", strings.NewReader("notjson"))
-        w = httptest.NewRecorder()
-        ctx = context.NewContext()
-        ctx.Reset(w, r)
-        ctx.Input.CopyBody(1 << 20)
-        c.Ctx = ctx
-        c.Data = map[interface{}]interface{}{}
-        c.Put()
-        if w.Code != http.StatusBadRequest {
-                t.Fatalf("expected 400, got %d", w.Code)
-        }
-        // unique error
-        r = httptest.NewRequest(http.MethodPut, "/clientes?id=1", strings.NewReader(`{"correo":"a@a.com"}`))
-        w = httptest.NewRecorder()
-        ctx = context.NewContext()
-        ctx.Reset(w, r)
-        ctx.Input.CopyBody(1 << 20)
-        c.Ctx = ctx
-        c.Data = map[interface{}]interface{}{}
-        c.Put()
-        if w.Code != http.StatusConflict {
-                t.Fatalf("expected 409, got %d", w.Code)
-        }
-       // update error
-       r = httptest.NewRequest(http.MethodPut, "/clientes?id=1", strings.NewReader(`{"nombre":"fail"}`))
-       w = httptest.NewRecorder()
-       ctx = context.NewContext()
-       ctx.Reset(w, r)
-       ctx.Input.CopyBody(1 << 20)
-       c.Ctx = ctx
-       c.Data = map[interface{}]interface{}{}
-       c.Put()
-       if w.Code != http.StatusInternalServerError {
-               t.Fatalf("expected 500, got %d", w.Code)
-       }
-       // hash error
-       bcryptGenerate = func([]byte, int) ([]byte, error) { return nil, errors.New("hash") }
-       r = httptest.NewRequest(http.MethodPut, "/clientes?id=1", strings.NewReader(`{"password":"n"}`))
-       w = httptest.NewRecorder()
-       ctx = context.NewContext()
-       ctx.Reset(w, r)
-       ctx.Input.CopyBody(1 << 20)
-       c.Ctx = ctx
-       c.Data = map[interface{}]interface{}{}
-       c.Put()
-       if w.Code != http.StatusInternalServerError {
-               t.Fatalf("expected 500, got %d", w.Code)
-       }
-       bcryptGenerate = bcrypt.GenerateFromPassword
-       // success with password
-       r = httptest.NewRequest(http.MethodPut, "/clientes?id=1", strings.NewReader(`{"nombre":"New","password":"newpass"}`))
-        w = httptest.NewRecorder()
-        ctx = context.NewContext()
-        ctx.Reset(w, r)
-        ctx.Input.CopyBody(1 << 20)
-        c.Ctx = ctx
-        c.Data = map[interface{}]interface{}{}
-        c.Put()
-        if w.Code != http.StatusOK {
-                t.Fatalf("expected 200, got %d", w.Code)
-        }
-        if strings.Contains(w.Body.String(), "newpass") {
-                t.Fatalf("password should be hidden")
-        }
-        if db[1].PASSWORD == "newpass" {
-                t.Fatalf("password should be hashed")
-        }
-        // success without password
-        r = httptest.NewRequest(http.MethodPut, "/clientes?id=1", strings.NewReader(`{"nombre":"Other"}`))
-        w = httptest.NewRecorder()
-        ctx = context.NewContext()
-        ctx.Reset(w, r)
-        ctx.Input.CopyBody(1 << 20)
-        c.Ctx = ctx
-        c.Data = map[interface{}]interface{}{}
-        c.Put()
-        if w.Code != http.StatusOK {
-                t.Fatalf("expected 200, got %d", w.Code)
-        }
-        if db[1].PASSWORD == "" {
-                t.Fatalf("password should remain")
-        }
+	db := map[int64]models.Cliente{1: {PK_DOCUMENTO_CLIENTE: 1, NOMBRE: "Foo", PASSWORD: "old"}, 2: {PK_DOCUMENTO_CLIENTE: 2, NOMBRE: "Bar", CORREO: ptr("a@a.com"), PASSWORD: "x"}}
+	ormNew = func() orm.Ormer { return nil }
+	readCliente = func(o orm.Ormer, c *models.Cliente) error {
+		cli, ok := db[c.PK_DOCUMENTO_CLIENTE]
+		if !ok {
+			return orm.ErrNoRows
+		}
+		*c = cli
+		return nil
+	}
+	updateCliente = func(o orm.Ormer, c *models.Cliente) (int64, error) {
+		if c.NOMBRE == "fail" {
+			return 0, errors.New("db error")
+		}
+		for id, cli := range db {
+			if id != c.PK_DOCUMENTO_CLIENTE && cli.CORREO != nil && c.CORREO != nil && *cli.CORREO == *c.CORREO {
+				return 0, errors.New("unique correo")
+			}
+		}
+		db[c.PK_DOCUMENTO_CLIENTE] = *c
+		return 1, nil
+	}
+	t.Cleanup(resetMocks)
+	// invalid id
+	r := httptest.NewRequest(http.MethodPut, "/clientes", nil)
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	c := ClienteController{}
+	c.Ctx = ctx
+	c.Data = map[interface{}]interface{}{}
+	c.Put()
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+	// read error
+	readCliente = func(o orm.Ormer, c *models.Cliente) error { return errors.New("db") }
+	r = httptest.NewRequest(http.MethodPut, "/clientes?id=1", strings.NewReader(`{"nombre":"Foo"}`))
+	w = httptest.NewRecorder()
+	ctx = context.NewContext()
+	ctx.Reset(w, r)
+	ctx.Input.CopyBody(1 << 20)
+	c.Ctx = ctx
+	c.Data = map[interface{}]interface{}{}
+	c.Put()
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", w.Code)
+	}
+	readCliente = func(o orm.Ormer, c *models.Cliente) error {
+		cli, ok := db[c.PK_DOCUMENTO_CLIENTE]
+		if !ok {
+			return orm.ErrNoRows
+		}
+		*c = cli
+		return nil
+	}
+	// not found
+	r = httptest.NewRequest(http.MethodPut, "/clientes?id=3", strings.NewReader(`{"nombre":"Foo"}`))
+	w = httptest.NewRecorder()
+	ctx = context.NewContext()
+	ctx.Reset(w, r)
+	ctx.Input.CopyBody(1 << 20)
+	c.Ctx = ctx
+	c.Data = map[interface{}]interface{}{}
+	c.Put()
+	if w.Code != http.StatusOK || !strings.Contains(w.Body.String(), "Cliente no encontrado") {
+		t.Fatalf("not found failed")
+	}
+	// decode error
+	r = httptest.NewRequest(http.MethodPut, "/clientes?id=1", strings.NewReader("notjson"))
+	w = httptest.NewRecorder()
+	ctx = context.NewContext()
+	ctx.Reset(w, r)
+	ctx.Input.CopyBody(1 << 20)
+	c.Ctx = ctx
+	c.Data = map[interface{}]interface{}{}
+	c.Put()
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+	// unique error
+	r = httptest.NewRequest(http.MethodPut, "/clientes?id=1", strings.NewReader(`{"correo":"a@a.com"}`))
+	w = httptest.NewRecorder()
+	ctx = context.NewContext()
+	ctx.Reset(w, r)
+	ctx.Input.CopyBody(1 << 20)
+	c.Ctx = ctx
+	c.Data = map[interface{}]interface{}{}
+	c.Put()
+	if w.Code != http.StatusConflict {
+		t.Fatalf("expected 409, got %d", w.Code)
+	}
+	// update error
+	r = httptest.NewRequest(http.MethodPut, "/clientes?id=1", strings.NewReader(`{"nombre":"fail"}`))
+	w = httptest.NewRecorder()
+	ctx = context.NewContext()
+	ctx.Reset(w, r)
+	ctx.Input.CopyBody(1 << 20)
+	c.Ctx = ctx
+	c.Data = map[interface{}]interface{}{}
+	c.Put()
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", w.Code)
+	}
+	// hash error
+	bcryptGenerate = func([]byte, int) ([]byte, error) { return nil, errors.New("hash") }
+	r = httptest.NewRequest(http.MethodPut, "/clientes?id=1", strings.NewReader(`{"password":"n"}`))
+	w = httptest.NewRecorder()
+	ctx = context.NewContext()
+	ctx.Reset(w, r)
+	ctx.Input.CopyBody(1 << 20)
+	c.Ctx = ctx
+	c.Data = map[interface{}]interface{}{}
+	c.Put()
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", w.Code)
+	}
+	bcryptGenerate = bcrypt.GenerateFromPassword
+	// success with password
+	r = httptest.NewRequest(http.MethodPut, "/clientes?id=1", strings.NewReader(`{"nombre":"New","password":"newpass"}`))
+	w = httptest.NewRecorder()
+	ctx = context.NewContext()
+	ctx.Reset(w, r)
+	ctx.Input.CopyBody(1 << 20)
+	c.Ctx = ctx
+	c.Data = map[interface{}]interface{}{}
+	c.Put()
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if strings.Contains(w.Body.String(), "newpass") {
+		t.Fatalf("password should be hidden")
+	}
+	if db[1].PASSWORD == "newpass" {
+		t.Fatalf("password should be hashed")
+	}
+	// success without password
+	r = httptest.NewRequest(http.MethodPut, "/clientes?id=1", strings.NewReader(`{"nombre":"Other"}`))
+	w = httptest.NewRecorder()
+	ctx = context.NewContext()
+	ctx.Reset(w, r)
+	ctx.Input.CopyBody(1 << 20)
+	c.Ctx = ctx
+	c.Data = map[interface{}]interface{}{}
+	c.Put()
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if db[1].PASSWORD == "" {
+		t.Fatalf("password should remain")
+	}
 }
 
 func ptr(s string) *string { return &s }
 
 func TestClienteDeleteScenarios(t *testing.T) {
-        db := map[int]models.Cliente{1: {PK_DOCUMENTO_CLIENTE: 1}}
-        ormNew = func() orm.Ormer { return nil }
-        deleteCliente = func(o orm.Ormer, c *models.Cliente) (int64, error) {
-                if _, ok := db[c.PK_DOCUMENTO_CLIENTE]; ok {
-                        delete(db, c.PK_DOCUMENTO_CLIENTE)
-                        return 1, nil
-                }
-                return 0, errors.New("not found")
-        }
-        t.Cleanup(resetMocks)
-        // invalid id
-        r := httptest.NewRequest(http.MethodDelete, "/clientes", nil)
-        w := httptest.NewRecorder()
-        ctx := context.NewContext()
-        ctx.Reset(w, r)
-        c := ClienteController{}
-        c.Ctx = ctx
-        c.Data = map[interface{}]interface{}{}
-        c.Delete()
-        if w.Code != http.StatusBadRequest {
-                t.Fatalf("expected 400, got %d", w.Code)
-        }
-        // not found
-        r = httptest.NewRequest(http.MethodDelete, "/clientes?id=2", nil)
-        w = httptest.NewRecorder()
-        ctx = context.NewContext()
-        ctx.Reset(w, r)
-        c.Ctx = ctx
-        c.Data = map[interface{}]interface{}{}
-        c.Delete()
-        if w.Code != http.StatusOK || !strings.Contains(w.Body.String(), "Cliente no encontrado") {
-                t.Fatalf("expected not found response")
-        }
-        // success
-        r = httptest.NewRequest(http.MethodDelete, "/clientes?id=1", nil)
-        w = httptest.NewRecorder()
-        ctx = context.NewContext()
-        ctx.Reset(w, r)
-        c.Ctx = ctx
-        c.Data = map[interface{}]interface{}{}
-        c.Delete()
-        if w.Code != http.StatusOK || !strings.Contains(w.Body.String(), "Cliente eliminado") {
-                t.Fatalf("expected success")
-        }
+	db := map[int64]models.Cliente{1: {PK_DOCUMENTO_CLIENTE: 1}}
+	ormNew = func() orm.Ormer { return nil }
+	deleteCliente = func(o orm.Ormer, c *models.Cliente) (int64, error) {
+		if _, ok := db[c.PK_DOCUMENTO_CLIENTE]; ok {
+			delete(db, c.PK_DOCUMENTO_CLIENTE)
+			return 1, nil
+		}
+		return 0, errors.New("not found")
+	}
+	t.Cleanup(resetMocks)
+	// invalid id
+	r := httptest.NewRequest(http.MethodDelete, "/clientes", nil)
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	c := ClienteController{}
+	c.Ctx = ctx
+	c.Data = map[interface{}]interface{}{}
+	c.Delete()
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+	// not found
+	r = httptest.NewRequest(http.MethodDelete, "/clientes?id=2", nil)
+	w = httptest.NewRecorder()
+	ctx = context.NewContext()
+	ctx.Reset(w, r)
+	c.Ctx = ctx
+	c.Data = map[interface{}]interface{}{}
+	c.Delete()
+	if w.Code != http.StatusOK || !strings.Contains(w.Body.String(), "Cliente no encontrado") {
+		t.Fatalf("expected not found response")
+	}
+	// success
+	r = httptest.NewRequest(http.MethodDelete, "/clientes?id=1", nil)
+	w = httptest.NewRecorder()
+	ctx = context.NewContext()
+	ctx.Reset(w, r)
+	c.Ctx = ctx
+	c.Data = map[interface{}]interface{}{}
+	c.Delete()
+	if w.Code != http.StatusOK || !strings.Contains(w.Body.String(), "Cliente eliminado") {
+		t.Fatalf("expected success")
+	}
 }
-

--- a/models/Cliente.go
+++ b/models/Cliente.go
@@ -5,7 +5,7 @@ import (
 )
 
 type Cliente struct {
-	PK_DOCUMENTO_CLIENTE int     `orm:"column(pk_documento_cliente);pk" json:"documentoCliente"`
+	PK_DOCUMENTO_CLIENTE int64   `orm:"column(pk_documento_cliente);pk" json:"documentoCliente"`
 	NOMBRE               string  `orm:"column(nombre);type(text)"        json:"nombre"`
 	APELLIDO             string  `orm:"column(apellido);type(text)"      json:"apellido"`
 	CORREO               *string `orm:"column(correo);type(text)"        json:"correo"`

--- a/models/LoginRequest.go
+++ b/models/LoginRequest.go
@@ -1,6 +1,6 @@
 package models
 
 type LoginRequest struct {
-	Documento int    `json:"documento"`
+	Documento int64  `json:"documento"`
 	Password  string `json:"password"`
 }


### PR DESCRIPTION
## Summary
- use `int64` for `Cliente.PK_DOCUMENTO_CLIENTE`
- update controller logic and login request to handle `int64`
- adjust tests for new identifier type

## Testing
- `go test ./controllers -run Cliente -count=1` *(fails: command hangs)*


------
https://chatgpt.com/codex/tasks/task_e_68b447846c248325be0ecfb17b6fc0d3