### PR TITLE
Remove Domicilio payment state field

### DIFF
--- a/controllers/DomicilioController.go
+++ b/controllers/DomicilioController.go
@@ -24,14 +24,6 @@ func isValidEstadoDomicilio(e string) bool {
 	return false
 }
 
-func isValidEstadoPago(e string) bool {
-	switch models.EstadoPago(e) {
-	case models.EstadoPagoPagado, models.EstadoPagoPendiente, models.EstadoPagoNoPago:
-		return true
-	}
-	return false
-}
-
 // @Title GetAll
 // @Summary Obtener todos los domicilios con posibilidad de filtrar
 // @Description Devuelve todos los domicilios registrados en la base de datos, filtrando según criterios específicos.
@@ -363,18 +355,6 @@ func (c *DomicilioController) Post() {
 		}
 		domicilio.ESTADO_DOMICILIO = estado
 	}
-	if estadoPago, ok := input["estadoPago"].(string); ok {
-		if !isValidEstadoPago(estadoPago) {
-			c.Ctx.Output.SetStatus(http.StatusBadRequest)
-			c.Data["json"] = models.ApiResponse{
-				Code:    http.StatusBadRequest,
-				Message: "El valor de 'estadoPago' no es válido",
-			}
-			c.ServeJSON()
-			return
-		}
-		domicilio.ESTADO_PAGO = estadoPago
-	}
 	if entregado, ok := input["entregado"].(bool); ok {
 		domicilio.ENTREGADO = entregado
 	}
@@ -485,18 +465,6 @@ func (c *DomicilioController) Put() {
 			return
 		}
 		domicilio.ESTADO_DOMICILIO = estado
-	}
-	if estadoPago, ok := input["estadoPago"].(string); ok {
-		if !isValidEstadoPago(estadoPago) {
-			c.Ctx.Output.SetStatus(http.StatusBadRequest)
-			c.Data["json"] = models.ApiResponse{
-				Code:    http.StatusBadRequest,
-				Message: "El valor de 'estadoPago' no es válido",
-			}
-			c.ServeJSON()
-			return
-		}
-		domicilio.ESTADO_PAGO = estadoPago
 	}
 	if entregado, ok := input["entregado"].(bool); ok {
 		domicilio.ENTREGADO = entregado

--- a/controllers/domicilio_controller_test.go
+++ b/controllers/domicilio_controller_test.go
@@ -39,32 +39,6 @@ func TestPostInvalidEstado(t *testing.T) {
 	}
 }
 
-func TestPostInvalidEstadoPago(t *testing.T) {
-	body := `{"direccion":"Calle 1","fechaDomicilio":"2024-01-01","telefono":"123","estadoPago":"otro"}`
-	r := httptest.NewRequest(http.MethodPost, "/domicilios", strings.NewReader(body))
-	r.Header.Set("Content-Type", "application/json")
-	w := httptest.NewRecorder()
-	ctx := context.NewContext()
-	ctx.Reset(w, r)
-	ctx.Input.RequestBody = []byte(body)
-	c := DomicilioController{}
-	c.Ctx = ctx
-	c.Data = make(map[interface{}]interface{})
-
-	c.Post()
-
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("expected status 400, got %d", w.Code)
-	}
-	var resp models.ApiResponse
-	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
-		t.Fatalf("failed to unmarshal response: %v", err)
-	}
-	if !strings.Contains(resp.Message, "estadoPago") {
-		t.Fatalf("expected error message about estadoPago, got %s", resp.Message)
-	}
-}
-
 func TestPostEntregadoTrue(t *testing.T) {
 	MockExec = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Result, error) {
 		return mockResult{}, nil

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -3677,9 +3677,6 @@ const docTemplate = `{
                 "entregado": {
                     "type": "boolean"
                 },
-                "estadoPago": {
-                    "type": "string"
-                },
                 "fechaDomicilio": {
                     "type": "string"
                 },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -3670,9 +3670,6 @@
                 "entregado": {
                     "type": "boolean"
                 },
-                "estadoPago": {
-                    "type": "string"
-                },
                 "fechaDomicilio": {
                     "type": "string"
                 },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -54,8 +54,6 @@ definitions:
         type: integer
       entregado:
         type: boolean
-      estadoPago:
-        type: string
       fechaDomicilio:
         type: string
       observaciones:

--- a/models/Domicilio.go
+++ b/models/Domicilio.go
@@ -11,8 +11,7 @@ type Domicilio struct {
 	PK_ID_DOMICILIO         int             `orm:"column(pk_id_domicilio);pk;auto" json:"domicilioId"`
 	DIRECCION               string          `orm:"column(direccion);type(text)" json:"direccion"`
 	TELEFONO                string          `orm:"column(telefono);type(text)" json:"telefono"`
-	ESTADO_DOMICILIO        EstadoDomicilio `orm:"column(estado);type(text)" json:"estado"`
-	ESTADO_PAGO             EstadoPago      `orm:"column(estado_pago);type(text)" json:"estadoPago"`
+	ESTADO_DOMICILIO        EstadoDomicilio `orm:"column(estado_domicilio);type(text)" json:"estado"`
 	ENTREGADO               bool            `orm:"column(entregado);type(boolean)" json:"entregado"`
 	FECHA                   time.Time       `orm:"column(fecha);type(date)" json:"fechaDomicilio"`
 	OBSERVACIONES           string          `orm:"column(observaciones);type(text)" json:"observaciones"`

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -118,9 +118,6 @@
                 "entregado": {
                     "type": "boolean"
                 },
-                "estadoPago": {
-                    "type": "string"
-                },
                 "fechaDomicilio": {
                     "type": "string",
                     "format": "datetime"

--- a/swagger/swagger.yml
+++ b/swagger/swagger.yml
@@ -83,8 +83,6 @@ definitions:
         format: int64
       entregado:
         type: boolean
-      estadoPago:
-        type: string
       fechaDomicilio:
         type: string
         format: datetime


### PR DESCRIPTION
## Summary
- rename Domicilio estado column to `estado_domicilio`
- drop `estado_pago` from Domicilio model, controller, and tests
- update Swagger docs to reflect the removal

## Testing
- `go test ./...` *(fails: TestNominaPostMissingDatesForAutoGeneration, TestNominaPostMissingDatesForVerification, TestPedidoAssignDomicilioUpdateError, TestPedidoAssignDomicilioSuccess, TestPedidoAssignPagoUpdateError, TestPedidoAssignPagoSuccess, TestPedidoUpdateEstadoPedidoUpdateError, TestPedidoUpdateEstadoPedidoSuccess, TestProductoHandleImageUploadTooLarge, TestProductoHandleImageUploadSuccess, TestProductoPostMissingNombre, TestPostMissingFields, TestPutInvalidDates, TestPutHashError, TestPutValidateDatesError, TestPutTelefonoUpdated, TestInitDBSuccess, TestCambiosHorarioMarshalJSON, TestDomicilioMarshalJSON, TestIncidenciaMarshalJSON, TestNominaMarshalJSON, TestPedidoMarshalJSON, TestReservaMarshalJSON, TestTrabajadorMarshalJSON, TestTrabajadorMarshalJSONNil)*

------
https://chatgpt.com/codex/tasks/task_e_68b448cfd8248325b83092b61aa32cd9