### PR TITLE
Use int64 for MetodoPago ID and align field types

### DIFF
--- a/controllers/MetodoPagoController.go
+++ b/controllers/MetodoPagoController.go
@@ -105,7 +105,7 @@ func (c *MetodoPagoController) GetById() {
 		return
 	}
 
-	metodo := models.MetodoPago{PK_ID_METODO_PAGO: id}
+        metodo := models.MetodoPago{PK_ID_METODO_PAGO: int64(id)}
 
 	err = o.Read(&metodo)
 	if err == orm.ErrNoRows {
@@ -204,7 +204,7 @@ func (c *MetodoPagoController) Put() {
 		return
 	}
 
-	metodo := models.MetodoPago{PK_ID_METODO_PAGO: id}
+        metodo := models.MetodoPago{PK_ID_METODO_PAGO: int64(id)}
 
 	if o.Read(&metodo) == nil {
 		var updatedMetodo models.MetodoPago
@@ -219,7 +219,7 @@ func (c *MetodoPagoController) Put() {
 			return
 		}
 
-		updatedMetodo.PK_ID_METODO_PAGO = id
+                updatedMetodo.PK_ID_METODO_PAGO = int64(id)
 		_, err := o.Update(&updatedMetodo)
 		if err != nil {
 			c.Ctx.Output.SetStatus(http.StatusInternalServerError)
@@ -277,7 +277,7 @@ func (c *MetodoPagoController) Delete() {
 		return
 	}
 
-	metodo := models.MetodoPago{PK_ID_METODO_PAGO: id}
+        metodo := models.MetodoPago{PK_ID_METODO_PAGO: int64(id)}
 
 	if _, err := o.Delete(&metodo); err == nil {
 		c.Ctx.Output.SetStatus(http.StatusOK)

--- a/controllers/metodo_pago_controller_test.go
+++ b/controllers/metodo_pago_controller_test.go
@@ -129,12 +129,12 @@ func TestMetodoPagoDeleteNotFound(t *testing.T) {
 // mockMetodoPagoOrmer provides an in-memory implementation of metodoPagoOrmer
 // used to test the controller without touching a real database.
 type mockMetodoPagoOrmer struct {
-        data   map[int]models.MetodoPago
-        nextID int
+        data   map[int64]models.MetodoPago
+        nextID int64
 }
 
 func newMockMetodoPagoOrmer() *mockMetodoPagoOrmer {
-        return &mockMetodoPagoOrmer{data: make(map[int]models.MetodoPago), nextID: 1}
+        return &mockMetodoPagoOrmer{data: make(map[int64]models.MetodoPago), nextID: 1}
 }
 
 func (m *mockMetodoPagoOrmer) QueryTable(_ interface{}) metodoPagoQuerySeter {
@@ -142,19 +142,19 @@ func (m *mockMetodoPagoOrmer) QueryTable(_ interface{}) metodoPagoQuerySeter {
 }
 
 func (m *mockMetodoPagoOrmer) All(res interface{}, _ ...string) (int64, error) {
-	slice, ok := res.(*[]models.MetodoPago)
-	if !ok {
-		return 0, errors.New("invalid result type")
-	}
-	for _, v := range m.data {
-		*slice = append(*slice, v)
-	}
-	return int64(len(m.data)), nil
+        slice, ok := res.(*[]models.MetodoPago)
+        if !ok {
+                return 0, errors.New("invalid result type")
+        }
+        for _, v := range m.data {
+                *slice = append(*slice, v)
+        }
+        return int64(len(m.data)), nil
 }
 
 func (m *mockMetodoPagoOrmer) Read(v interface{}, _ ...string) error {
 	mp := v.(*models.MetodoPago)
-	item, ok := m.data[mp.PK_ID_METODO_PAGO]
+        item, ok := m.data[mp.PK_ID_METODO_PAGO]
 	if !ok {
 		return orm.ErrNoRows
 	}
@@ -164,10 +164,10 @@ func (m *mockMetodoPagoOrmer) Read(v interface{}, _ ...string) error {
 
 func (m *mockMetodoPagoOrmer) Insert(v interface{}) (int64, error) {
 	mp := v.(*models.MetodoPago)
-	mp.PK_ID_METODO_PAGO = m.nextID
-	m.nextID++
-	m.data[mp.PK_ID_METODO_PAGO] = *mp
-	return 1, nil
+        mp.PK_ID_METODO_PAGO = m.nextID
+        m.nextID++
+        m.data[mp.PK_ID_METODO_PAGO] = *mp
+        return 1, nil
 }
 
 func (m *mockMetodoPagoOrmer) Update(v interface{}, _ ...string) (int64, error) {

--- a/models/MetodoPago.go
+++ b/models/MetodoPago.go
@@ -3,9 +3,9 @@ package models
 import "github.com/beego/beego/v2/client/orm"
 
 type MetodoPago struct {
-	PK_ID_METODO_PAGO int    `orm:"column(pk_id_metodo_pago);pk;auto" json:"metodoPagoId"`
-	TIPO              string `orm:"column(tipo);size(50)" json:"tipo"`
-	DETALLE           string `orm:"column(detalle);type(text);null" json:"detalle"`
+        PK_ID_METODO_PAGO int64  `orm:"column(pk_id_metodo_pago);pk;auto" json:"metodoPagoId"`
+        TIPO              string `orm:"column(tipo);type(text)" json:"tipo"`
+        DETALLE           string `orm:"column(detalle);type(text);null" json:"detalle"`
 }
 
 func (m *MetodoPago) TableName() string {


### PR DESCRIPTION
## Summary
- use int64 for MetodoPago primary key
- drop size limit from MetodoPago type column and mark as text
- adjust controller and tests to handle int64 IDs

## Testing
- `go test ./...` *(fails: command not found: go)*

------
https://chatgpt.com/codex/tasks/task_e_68b44a44d1d483258eab24c41814fba9