### PR TITLE
Refactor Pago model to use int64 IDs and time for hora

### DIFF
--- a/controllers/PagoController.go
+++ b/controllers/PagoController.go
@@ -69,11 +69,7 @@ func (c *PagoController) GetAll() {
 	for i := range pagos {
 		pagos[i].UPDATED_AT = pagos[i].UPDATED_AT.UTC()
 		pagos[i].FECHA = pagos[i].FECHA.UTC()
-
-		// Formatear HORA si es necesario
-		if len(pagos[i].HORA) >= 19 {
-			pagos[i].HORA = pagos[i].HORA[11:19] // Solo toma HH:mm:ss
-		}
+		pagos[i].HORA = pagos[i].HORA.UTC()
 	}
 
 	// Leer parámetros de la URL
@@ -102,7 +98,7 @@ func (c *PagoController) GetAll() {
 		if estado != "" && pago.ESTADO_PAGO != estado {
 			continue
 		}
-		if metodo_pago > 0 && pago.PK_ID_METODO_PAGO != metodo_pago {
+		if metodo_pago > 0 && pago.PK_ID_METODO_PAGO != int64(metodo_pago) {
 			continue
 		}
 
@@ -156,7 +152,7 @@ func (c *PagoController) GetById() {
 		return
 	}
 
-	pago := models.Pago{PK_ID_PAGO: id}
+	pago := models.Pago{PK_ID_PAGO: int64(id)}
 	err = o.Read(&pago)
 	if err == orm.ErrNoRows {
 		c.Ctx.Output.SetStatus(http.StatusOK)
@@ -172,11 +168,7 @@ func (c *PagoController) GetById() {
 	// Ajustar fechas y hora
 	pago.FECHA = pago.FECHA.In(database.BogotaZone)
 	pago.UPDATED_AT = pago.UPDATED_AT.In(database.BogotaZone)
-
-	// Formatear HORA
-	if len(pago.HORA) >= 19 {
-		pago.HORA = pago.HORA[11:19] // Formato HH:mm:ss
-	}
+	pago.HORA = pago.HORA.In(database.BogotaZone)
 
 	c.Ctx.Output.SetStatus(http.StatusOK)
 	c.Data["json"] = models.ApiResponse{
@@ -206,7 +198,7 @@ func (c *PagoController) Post() {
 		EstadoPago   string `json:"estadoPago"`
 		FechaPago    string `json:"fechaPago"`    // YYYY-MM-DD
 		HoraPago     string `json:"horaPago"`     // HH:mm:ss
-		MetodoPagoId int    `json:"metodoPagoId"` // entero
+		MetodoPagoId int64  `json:"metodoPagoId"` // entero
 		Monto        int64  `json:"monto"`        // entero
 		UpdatedAt    string `json:"updatedAt"`    // ignorado al insertar
 		UpdatedBy    string `json:"updatedBy"`
@@ -245,7 +237,8 @@ func (c *PagoController) Post() {
 		c.ServeJSON()
 		return
 	}
-	if _, err := time.Parse("15:04:05", in.HoraPago); err != nil {
+	hora, err := time.Parse("15:04:05", in.HoraPago)
+	if err != nil {
 		c.Ctx.Output.SetStatus(http.StatusBadRequest)
 		c.Data["json"] = models.ApiResponse{Code: http.StatusBadRequest, Message: "Formato de hora inválido, debe ser HH:mm:ss", Cause: err.Error()}
 		c.ServeJSON()
@@ -287,7 +280,7 @@ func (c *PagoController) Post() {
 
 	pago := models.Pago{
 		FECHA:             fecha,
-		HORA:              in.HoraPago,
+		HORA:              hora,
 		MONTO:             in.Monto,
 		ESTADO_PAGO:       in.EstadoPago,   // e.g. "pagado"
 		PK_ID_METODO_PAGO: in.MetodoPagoId, // FK
@@ -342,7 +335,7 @@ func (c *PagoController) Put() {
 	}
 
 	// Buscar el pago por ID
-	pago := models.Pago{PK_ID_PAGO: id}
+	pago := models.Pago{PK_ID_PAGO: int64(id)}
 	if err := o.Read(&pago); err == orm.ErrNoRows {
 		c.Ctx.Output.SetStatus(http.StatusOK)
 		c.Data["json"] = models.ApiResponse{
@@ -385,7 +378,8 @@ func (c *PagoController) Put() {
 	// Procesar HORA
 	if horaStr, ok := input["HORA"].(string); ok && horaStr != "" {
 		// Validar el formato de HORA
-		if _, err := time.Parse("15:04:05", horaStr); err != nil {
+		parsedHora, err := time.Parse("15:04:05", horaStr)
+		if err != nil {
 			c.Ctx.Output.SetStatus(http.StatusBadRequest)
 			c.Data["json"] = models.ApiResponse{
 				Code:    http.StatusBadRequest,
@@ -395,7 +389,7 @@ func (c *PagoController) Put() {
 			c.ServeJSON()
 			return
 		}
-		pago.HORA = horaStr
+		pago.HORA = parsedHora
 	} else {
 		c.Ctx.Output.SetStatus(http.StatusBadRequest)
 		c.Data["json"] = models.ApiResponse{
@@ -431,8 +425,8 @@ func (c *PagoController) Put() {
 	pago.UPDATED_AT = time.Now().UTC()
 
 	if pkMetodoPago, ok := input["PK_ID_METODO_PAGO"].(float64); ok {
-		valorMetodoPago := int(pkMetodoPago)     // Convertir a int
-		pago.PK_ID_METODO_PAGO = valorMetodoPago // Asignar al puntero
+		valorMetodoPago := int64(pkMetodoPago)
+		pago.PK_ID_METODO_PAGO = valorMetodoPago
 	} else {
 		// Opcional: Manejo de errores o acciones si el campo es obligatorio
 		c.Ctx.Output.SetStatus(http.StatusBadRequest)
@@ -493,7 +487,7 @@ func (c *PagoController) Delete() {
 		return
 	}
 
-	pago := models.Pago{PK_ID_PAGO: id}
+	pago := models.Pago{PK_ID_PAGO: int64(id)}
 
 	if _, err := o.Delete(&pago); err == nil {
 		c.Ctx.Output.SetStatus(http.StatusOK)

--- a/controllers/PedidoController.go
+++ b/controllers/PedidoController.go
@@ -271,7 +271,7 @@ func (c *PedidoController) AssignPago() {
 	}
 
 	// También cambiamos el estado en la tabla PAGO
-	pago := models.Pago{PK_ID_PAGO: pagoID}
+	pago := models.Pago{PK_ID_PAGO: int64(pagoID)}
 	if err := o.Read(&pago); err == nil {
 		pago.ESTADO_PAGO = models.EstadoPagoPagado
 		o.Update(&pago, "ESTADO_PAGO")

--- a/controllers/pago_controller_test.go
+++ b/controllers/pago_controller_test.go
@@ -384,7 +384,7 @@ func TestPagoDeleteNotFound(t *testing.T) {
 func TestPagoGetAllSuccess(t *testing.T) {
 	orig := pagoNewOrm
 	pagoNewOrm = func() ormer {
-		pagos := []models.Pago{{PK_ID_PAGO: 1, FECHA: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC), HORA: "2024-01-01T10:00:00Z", ESTADO_PAGO: "pagado", PK_ID_METODO_PAGO: 1}}
+		pagos := []models.Pago{{PK_ID_PAGO: int64(1), FECHA: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC), HORA: time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC), ESTADO_PAGO: "pagado", PK_ID_METODO_PAGO: int64(1)}}
 		return fakeOrmer{queryAll: func(res interface{}, cols ...string) (int64, error) {
 			ptr := res.(*[]models.Pago)
 			*ptr = pagos
@@ -409,8 +409,8 @@ func TestPagoGetAllFilterFecha(t *testing.T) {
 	orig := pagoNewOrm
 	pagoNewOrm = func() ormer {
 		pagos := []models.Pago{
-			{PK_ID_PAGO: 1, FECHA: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC), HORA: "10:00:00"},
-			{PK_ID_PAGO: 2, FECHA: time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC), HORA: "11:00:00"},
+			{PK_ID_PAGO: int64(1), FECHA: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC), HORA: time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC)},
+			{PK_ID_PAGO: int64(2), FECHA: time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC), HORA: time.Date(2024, 1, 2, 11, 0, 0, 0, time.UTC)},
 		}
 		return fakeOrmer{queryAll: func(res interface{}, cols ...string) (int64, error) {
 			ptr := res.(*[]models.Pago)
@@ -436,12 +436,12 @@ func TestPagoGetAllFilterOthers(t *testing.T) {
 	orig := pagoNewOrm
 	pagoNewOrm = func() ormer {
 		pagos := []models.Pago{
-			{FECHA: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC), HORA: "10:00:00", ESTADO_PAGO: "pagado", PK_ID_METODO_PAGO: 1},
-			{FECHA: time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC), HORA: "10:00:00", ESTADO_PAGO: "pagado", PK_ID_METODO_PAGO: 1},
-			{FECHA: time.Date(2024, 2, 1, 0, 0, 0, 0, time.UTC), HORA: "10:00:00", ESTADO_PAGO: "pagado", PK_ID_METODO_PAGO: 1},
-			{FECHA: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC), HORA: "10:00:00", ESTADO_PAGO: "pagado", PK_ID_METODO_PAGO: 1},
-			{FECHA: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC), HORA: "10:00:00", ESTADO_PAGO: "no pago", PK_ID_METODO_PAGO: 1},
-			{FECHA: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC), HORA: "10:00:00", ESTADO_PAGO: "pagado", PK_ID_METODO_PAGO: 2},
+			{FECHA: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC), HORA: time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC), ESTADO_PAGO: "pagado", PK_ID_METODO_PAGO: int64(1)},
+			{FECHA: time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC), HORA: time.Date(2024, 1, 2, 10, 0, 0, 0, time.UTC), ESTADO_PAGO: "pagado", PK_ID_METODO_PAGO: int64(1)},
+			{FECHA: time.Date(2024, 2, 1, 0, 0, 0, 0, time.UTC), HORA: time.Date(2024, 2, 1, 10, 0, 0, 0, time.UTC), ESTADO_PAGO: "pagado", PK_ID_METODO_PAGO: int64(1)},
+			{FECHA: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC), HORA: time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC), ESTADO_PAGO: "pagado", PK_ID_METODO_PAGO: int64(1)},
+			{FECHA: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC), HORA: time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC), ESTADO_PAGO: "no pago", PK_ID_METODO_PAGO: int64(1)},
+			{FECHA: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC), HORA: time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC), ESTADO_PAGO: "pagado", PK_ID_METODO_PAGO: int64(2)},
 		}
 		return fakeOrmer{queryAll: func(res interface{}, cols ...string) (int64, error) {
 			ptr := res.(*[]models.Pago)
@@ -466,7 +466,7 @@ func TestPagoGetAllFilterOthers(t *testing.T) {
 func TestPagoGetAllNoResults(t *testing.T) {
 	orig := pagoNewOrm
 	pagoNewOrm = func() ormer {
-		pagos := []models.Pago{{FECHA: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC), HORA: "10:00:00", ESTADO_PAGO: "pagado", PK_ID_METODO_PAGO: 1}}
+		pagos := []models.Pago{{FECHA: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC), HORA: time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC), ESTADO_PAGO: "pagado", PK_ID_METODO_PAGO: int64(1)}}
 		return fakeOrmer{queryAll: func(res interface{}, cols ...string) (int64, error) {
 			ptr := res.(*[]models.Pago)
 			*ptr = pagos
@@ -511,7 +511,7 @@ func TestPagoGetByIdSuccess(t *testing.T) {
 	pagoNewOrm = func() ormer {
 		return fakeOrmer{read: func(m interface{}, cols ...string) error {
 			p := m.(*models.Pago)
-			*p = models.Pago{PK_ID_PAGO: 1, FECHA: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC), HORA: "2024-01-01T10:00:00Z", UPDATED_AT: time.Now()}
+			*p = models.Pago{PK_ID_PAGO: int64(1), FECHA: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC), HORA: time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC), UPDATED_AT: time.Now()}
 			return nil
 		}}
 	}

--- a/models/Pago.go
+++ b/models/Pago.go
@@ -8,15 +8,13 @@ import (
 )
 
 type Pago struct {
-	PK_ID_PAGO        int        `orm:"column(pk_id_pago);pk;auto" json:"pagoId"`
+	PK_ID_PAGO        int64      `orm:"column(pk_id_pago);pk;auto" json:"pagoId"`
 	FECHA             time.Time  `orm:"column(fecha);type(date)" json:"fechaPago"`
-	HORA              string     `orm:"column(hora);type(time)" json:"horaPago"`
+	HORA              time.Time  `orm:"column(hora);type(time)" json:"horaPago"`
 	MONTO             int64      `orm:"column(monto)" json:"monto"`
 	ESTADO_PAGO       EstadoPago `orm:"column(estado_pago);type(text)" json:"estadoPago"`
-	PK_ID_METODO_PAGO int        `orm:"column(pk_id_metodo_pago);null" json:"metodoPagoId"`
-	CREATED_AT        time.Time  `orm:"column(created_at);type(timestamp);auto_now_add" json:"createdAt"`
+	PK_ID_METODO_PAGO int64      `orm:"column(pk_id_metodo_pago);null" json:"metodoPagoId"`
 	UPDATED_AT        time.Time  `orm:"column(updated_at);type(timestamp);auto_now" json:"updatedAt"`
-	CREATED_BY        *string    `orm:"column(created_by);type(text)" json:"createdBy,omitempty"`
 	UPDATED_BY        *string    `orm:"column(updated_by);type(text);null" json:"updatedBy,omitempty"`
 }
 
@@ -32,10 +30,12 @@ func (d Pago) MarshalJSON() ([]byte, error) {
 	type Alias Pago
 	return json.Marshal(&struct {
 		FECHA      string `json:"fechaPago"`
+		HORA       string `json:"horaPago"`
 		UPDATED_AT string `json:"updatedAt"`
 		Alias
 	}{
 		FECHA:      d.FECHA.Format("02-01-2006"),
+		HORA:       d.HORA.Format("15:04:05"),
 		UPDATED_AT: d.UPDATED_AT.Format("02-01-2006 15:04:05"),
 		Alias:      (Alias)(d),
 	})


### PR DESCRIPTION
## Summary
- convert Pago model IDs to int64, drop creation fields, and store Hora as time.Time
- adjust Pago controller to handle new time and ID types
- update AssignPago and related tests for new Pago types

## Testing
- `go test ./...` *(fails: TestNominaPostMissingDatesForAutoGeneration, TestNominaPostMissingDatesForVerification, TestPedidoAssignDomicilioUpdateError, TestPedidoAssignDomicilioSuccess, TestPedidoAssignPagoUpdateError, TestPedidoAssignPagoSuccess, TestPedidoUpdateEstadoPedidoUpdateError, TestPedidoUpdateEstadoPedidoSuccess, TestProductoHandleImageUploadTooLarge, TestProductoHandleImageUploadSuccess, TestProductoPostMissingNombre, TestPostMissingFields, TestPutInvalidDates, TestPutHashError, TestPutValidateDatesError, TestPutTelefonoUpdated, TestInitDBSuccess, TestCambiosHorarioMarshalJSON, TestDomicilioMarshalJSON, TestIncidenciaMarshalJSON, TestNominaMarshalJSON, TestPedidoMarshalJSON, TestReservaMarshalJSON, TestTrabajadorMarshalJSON, TestTrabajadorMarshalJSONNil)*

------
https://chatgpt.com/codex/tasks/task_e_68b44d8dbdd88325915528846b912d26