### PR TITLE
feat: capture client id on pedidos

### DIFF
--- a/controllers/PedidoController.go
+++ b/controllers/PedidoController.go
@@ -37,13 +37,12 @@ func (c *PedidoController) GetAll() {
 
 	// Construcción de la consulta SQL
 	query := `
-        SELECT p.*
-        FROM pedido p
-        LEFT JOIN pedido_cliente pc ON p.pk_id_pedido = pc.pk_id_pedido
-        LEFT JOIN pago pa ON p.pk_id_pago = pa.pk_id_pago
-        LEFT JOIN metodo_pago mp ON pa.pk_id_metodo_pago = mp.pk_id_metodo_pago
-        WHERE 1 = 1
-    `
+       SELECT p.*
+       FROM pedido p
+       LEFT JOIN pago pa ON p.pk_id_pago = pa.pk_id_pago
+       LEFT JOIN metodo_pago mp ON pa.pk_id_metodo_pago = mp.pk_id_metodo_pago
+       WHERE 1 = 1
+   `
 
 	// Parámetros de filtro
 	params := []interface{}{}
@@ -77,7 +76,7 @@ func (c *PedidoController) GetAll() {
 	}
 
 	if cliente > 0 {
-		query += ` AND pc.pk_documento_cliente = ?`
+		query += ` AND p.pk_documento_cliente = ?`
 		params = append(params, cliente)
 	}
 
@@ -386,11 +385,10 @@ SELECT
     COALESCE(p.pk_id_pago, 0)                        AS pago_id,
     COALESCE(pa.pk_id_metodo_pago, 0)                AS metodo_pago_id,
     COALESCE(p.pk_id_domicilio, 0)                   AS domicilio_id,
-    COALESCE(pc.pk_documento_cliente, 0)             AS documento_cliente
+    COALESCE(p.pk_documento_cliente, 0)             AS pk_documento_cliente
 FROM pedido p
 LEFT JOIN pago pa        ON p.pk_id_pago = pa.pk_id_pago
 LEFT JOIN metodo_pago mp ON pa.pk_id_metodo_pago = mp.pk_id_metodo_pago
-LEFT JOIN pedido_cliente pc ON p.pk_id_pedido = pc.pk_id_pedido
 WHERE p.pk_id_pedido = ?;
     `
 

--- a/controllers/pedido_controller_test.go
+++ b/controllers/pedido_controller_test.go
@@ -469,7 +469,7 @@ func TestPedidoUpdateEstadoPedidoSuccess(t *testing.T) {
 
 func TestPedidoGetPedidoDetailsSuccess(t *testing.T) {
 	MockQuery = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
-		cols := []string{"pk_id_pedido", "fecha", "hora", "delivery", "estado_pedido", "metodo_pago", "productos", "pago_id", "metodo_pago_id", "domicilio_id", "documento_cliente"}
+		cols := []string{"pk_id_pedido", "fecha", "hora", "delivery", "estado_pedido", "metodo_pago", "productos", "pago_id", "metodo_pago_id", "domicilio_id", "pk_documento_cliente"}
 		vals := [][]driver.Value{{int64(1), "2024-01-01", "12:00:00", false, "terminado", "NEQUI", "[]", int64(2), int64(3), int64(4), int64(5)}}
 		return &mockRows{columns: cols, values: vals}, nil
 	}

--- a/models/Pedido.go
+++ b/models/Pedido.go
@@ -8,18 +8,17 @@ import (
 )
 
 type Pedido struct {
-	PK_ID_PEDIDO      int          `orm:"column(pk_id_pedido);pk;auto" json:"pedidoId"`
-	FECHA             time.Time    `orm:"column(fecha);type(date)" json:"fechaPedido"`
-	HORA              string       `orm:"column(hora);type(time)" json:"horaPedido"`
-	DELIVERY          bool         `orm:"column(delivery);type(boolean)" json:"delivery"`
-	ESTADO_PEDIDO     EstadoPedido `orm:"column(estado_pedido)" json:"estadoPedido"`
-	PK_ID_DOMICILIO   *int         `orm:"column(pk_id_domicilio);null" json:"domicilioId,omitempty"`
-	PK_ID_PAGO        *int         `orm:"column(pk_id_pago);null" json:"pagoId"`
-	PK_ID_RESTAURANTE *int         `orm:"column(pk_id_restaurante);null" json:"restauranteId"`
-	CREATED_AT        time.Time    `orm:"column(created_at);type(timestamp);auto_now_add" json:"createdAt"`
-	UPDATED_AT        time.Time    `orm:"column(updated_at);type(timestamp);auto_now" json:"updatedAt"`
-	CREATED_BY        *string      `orm:"column(created_by);type(text)" json:"createdBy,omitempty"`
-	UPDATED_BY        string       `orm:"column(updated_by)" json:"updatedBy"`
+	PK_ID_PEDIDO         int          `orm:"column(pk_id_pedido);pk;auto" json:"pedidoId"`
+	FECHA                time.Time    `orm:"column(fecha);type(date)" json:"fechaPedido"`
+	HORA                 string       `orm:"column(hora);type(time)" json:"horaPedido"`
+	DELIVERY             bool         `orm:"column(delivery);type(boolean)" json:"delivery"`
+	ESTADO_PEDIDO        EstadoPedido `orm:"column(estado_pedido)" json:"estadoPedido"`
+	PK_ID_DOMICILIO      *int         `orm:"column(pk_id_domicilio);null" json:"domicilioId,omitempty"`
+	PK_ID_PAGO           *int         `orm:"column(pk_id_pago);null" json:"pagoId"`
+	PK_ID_RESTAURANTE    *int         `orm:"column(pk_id_restaurante);null" json:"restauranteId"`
+	PK_DOCUMENTO_CLIENTE int64        `orm:"column(pk_documento_cliente)" json:"documentoCliente"`
+	UPDATED_AT           time.Time    `orm:"column(updated_at);type(timestamp);auto_now" json:"updatedAt"`
+	UPDATED_BY           string       `orm:"column(updated_by)" json:"updatedBy"`
 }
 
 type PedidoDetails struct {
@@ -33,7 +32,7 @@ type PedidoDetails struct {
 	PagoID           int64  `json:"pagoId" orm:"column(pago_id)"`
 	MetodoPagoID     int64  `json:"metodoPagoId" orm:"column(metodo_pago_id)"`
 	DomicilioID      int64  `json:"domicilioId" orm:"column(domicilio_id)"`
-	DocumentoCliente int64  `json:"documentoCliente" orm:"column(documento_cliente)"`
+	DocumentoCliente int64  `json:"documentoCliente" orm:"column(pk_documento_cliente)"`
 }
 
 func (p *Pedido) TableName() string {
@@ -48,12 +47,10 @@ func (d Pedido) MarshalJSON() ([]byte, error) {
 	type Alias Pedido
 	return json.Marshal(&struct {
 		FECHA      string `json:"fechaPedido"`
-		CREATED_AT string `json:"createdAt"`
 		UPDATED_AT string `json:"updatedAt"`
 		Alias
 	}{
 		FECHA:      d.FECHA.Format("02-01-2006"),
-		CREATED_AT: d.CREATED_AT.Format("02-01-2006 15:04:05"),
 		UPDATED_AT: d.UPDATED_AT.Format("02-01-2006 15:04:05"),
 		Alias:      (Alias)(d),
 	})

--- a/models/pedido_test.go
+++ b/models/pedido_test.go
@@ -21,11 +21,11 @@ func TestPedidoMarshalJSON(t *testing.T) {
 		t.Fatalf("json.Unmarshal returned error: %v", err)
 	}
 
-	if data["fechapedido"] != "01-05-2024" {
-		t.Errorf("expected fechapedido 01-05-2024, got %v", data["fechapedido"])
+	if data["fechaPedido"] != "01-05-2024" {
+		t.Errorf("expected fechaPedido 01-05-2024, got %v", data["fechaPedido"])
 	}
-	if data["updatedat"] != "02-05-2024 12:00:00" {
-		t.Errorf("expected updatedat 02-05-2024 12:00:00, got %v", data["updatedat"])
+	if data["updatedAt"] != "02-05-2024 12:00:00" {
+		t.Errorf("expected updatedAt 02-05-2024 12:00:00, got %v", data["updatedAt"])
 	}
 }
 


### PR DESCRIPTION
## Summary
- add `PK_DOCUMENTO_CLIENTE` to `Pedido` model and drop unused creation fields
- update `PedidoController` queries and filters to use embedded client id
- adapt unit tests for new column

## Testing
- `go test ./...` (fails: TestPedidoAssignDomicilioUpdateError, TestNominaMarshalJSON, TestTrabajadorMarshalJSON, ...)
- `go test ./controllers` (fails: TestPostMissingFields, TestPutInvalidDates, TestPutTelefonoUpdated, ...)


------
https://chatgpt.com/codex/tasks/task_e_68b45042816883259f3ecbac57dbbd7d