### PR TITLE
Simplify product price history model

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ Go-based REST API for managing restaurant operations such as customers, orders, 
   - `EstadoNomina`: `pago`, `no pago`.
   - Additional enums exist for domicilios, pagos, pedidos, productos y días de la semana.
 - **Price history** for products is stored in the `precio_producto_hist` table. A new entry is
-  created when a product is registered or its price changes, closing the previous record.
+  created when a product is registered or its price changes, storing the effective date of the
+  change.
 - `POST /producto_pedido` and `PUT /producto_pedido` no longer accept `precio` in the payload; the
   database trigger assigns it automatically.
 - **Payroll (nómina)** operations:
@@ -66,7 +67,7 @@ Go-based REST API for managing restaurant operations such as customers, orders, 
 ## Database Tables
 - **nomina**: stores payroll records including amount, state, and audit timestamps.
 - **reserva**: manages restaurant reservations with date, time, party size, and status.
-- **precio_producto_hist**: tracks product price changes over time, closing previous entries when prices update.
+- **precio_producto_hist**: tracks product price changes over time with an effective date for each entry.
 - **cambios_horario**: logs schedule adjustments such as opening/closing hours and whether the restaurant opens.
 
 ## Testing

--- a/controllers/ProductoController.go
+++ b/controllers/ProductoController.go
@@ -185,9 +185,9 @@ func (c *ProductoController) Post() {
 
 	// Registrar historial de precios
 	hist := models.PrecioProductoHist{
-		PKIDProducto: producto.PK_ID_PRODUCTO,
-		Precio:       float64(producto.PRECIO),
-		FechaInicio:  time.Now(),
+		PKIDProducto:  producto.PK_ID_PRODUCTO,
+		Precio:        float64(producto.PRECIO),
+		FechaVigencia: time.Now(),
 	}
 	if _, err := o.Insert(&hist); err != nil {
 		c.Ctx.Output.SetStatus(http.StatusInternalServerError)
@@ -307,27 +307,12 @@ func (c *ProductoController) Put() {
 			return
 		}
 
-		// Si cambió el precio, actualizar historial
+		// Si cambió el precio, registrar nuevo historial
 		if producto.PRECIO != original.PRECIO {
-			now := time.Now()
-			if _, err := o.QueryTable(new(models.PrecioProductoHist)).
-				Filter("pk_id_producto", producto.PK_ID_PRODUCTO).
-				Filter("fecha_fin__isnull", true).
-				Update(orm.Params{"fecha_fin": now}); err != nil {
-				c.Ctx.Output.SetStatus(http.StatusInternalServerError)
-				c.Data["json"] = models.ApiResponse{
-					Code:    http.StatusInternalServerError,
-					Message: "Error al actualizar historial de precios",
-					Cause:   err.Error(),
-				}
-				c.ServeJSON()
-				return
-			}
-
 			hist := models.PrecioProductoHist{
-				PKIDProducto: producto.PK_ID_PRODUCTO,
-				Precio:       float64(producto.PRECIO),
-				FechaInicio:  now,
+				PKIDProducto:  producto.PK_ID_PRODUCTO,
+				Precio:        float64(producto.PRECIO),
+				FechaVigencia: time.Now(),
 			}
 			if _, err := o.Insert(&hist); err != nil {
 				c.Ctx.Output.SetStatus(http.StatusInternalServerError)

--- a/models/PrecioProductoHist.go
+++ b/models/PrecioProductoHist.go
@@ -6,16 +6,12 @@ import (
 	"github.com/beego/beego/v2/client/orm"
 )
 
+// PrecioProductoHist represents the price of a product at a given time.
+// It no longer maintains its own primary key or audit timestamps.
 type PrecioProductoHist struct {
-	PKIDPrecioProductoHist int64      `orm:"column(pk_id_precio_producto_hist);pk;auto" json:"precioProductoHistId"`
-	PKIDProducto           int64      `orm:"column(pk_id_producto)" json:"productoId"`
-	Precio                 float64    `orm:"column(precio)" json:"precio"`
-	FechaInicio            time.Time  `orm:"column(fecha_inicio);type(date)" json:"fechaInicio"`
-	FechaFin               *time.Time `orm:"column(fecha_fin);type(date);null" json:"fechaFin,omitempty"`
-	CreatedAt              time.Time  `orm:"column(created_at);type(timestamp);auto_now_add" json:"createdAt"`
-	UpdatedAt              time.Time  `orm:"column(updated_at);type(timestamp);auto_now" json:"updatedAt"`
-	CreatedBy              *string    `orm:"column(created_by);type(text)" json:"createdBy,omitempty"`
-	UpdatedBy              *string    `orm:"column(updated_by);type(text)" json:"updatedBy,omitempty"`
+	PKIDProducto  int64     `orm:"column(pk_id_producto)" json:"productoId"`
+	Precio        float64   `orm:"column(precio)" json:"precio"`
+	FechaVigencia time.Time `orm:"column(fecha_vigencia);type(date)" json:"fechaVigencia"`
 }
 
 func (p *PrecioProductoHist) TableName() string {

--- a/tests/producto_precio_hist_test.go
+++ b/tests/producto_precio_hist_test.go
@@ -46,7 +46,7 @@ func TestProductoPriceHistoryLifecycle(t *testing.T) {
 	if _, err := o.QueryTable(new(models.PrecioProductoHist)).Filter("PKIDProducto", p.PK_ID_PRODUCTO).All(&hist); err != nil {
 		t.Skipf("cannot query history: %v", err)
 	}
-	if len(hist) != 1 || hist[0].Precio != float64(p.PRECIO) || hist[0].FechaFin != nil {
+	if len(hist) != 1 || hist[0].Precio != float64(p.PRECIO) || hist[0].FechaVigencia.IsZero() {
 		t.Errorf("unexpected initial history: %+v", hist)
 	}
 
@@ -72,19 +72,14 @@ func TestProductoPriceHistoryLifecycle(t *testing.T) {
 	}
 	var oldOK, newOK bool
 	for _, h := range hist {
+		if h.FechaVigencia.IsZero() {
+			t.Errorf("missing FechaVigencia in history: %+v", h)
+		}
 		if h.Precio == 100 {
-			if h.FechaFin == nil {
-				t.Errorf("old history missing FechaFin")
-			} else {
-				oldOK = true
-			}
+			oldOK = true
 		}
 		if h.Precio == 200 {
-			if h.FechaFin != nil {
-				t.Errorf("new history should not have FechaFin")
-			} else {
-				newOK = true
-			}
+			newOK = true
 		}
 	}
 	if !oldOK || !newOK {


### PR DESCRIPTION
## Summary
- Drop standalone primary key and audit fields from `PrecioProductoHist` and track only product ID, price, and effective date
- Adjust product controller to insert new history entries on creation or price change without closing previous records
- Update price history lifecycle test and README to reflect new model

## Testing
- `go test ./...` *(fails: field: models.Producto.IMAGEN, unsupport field type , may be miss setting tag)*

------
https://chatgpt.com/codex/tasks/task_e_68b457f866088325bbfabed3f7813a79