### PR TITLE
Use int64 for prices and note composite keys

### DIFF
--- a/controllers/ProductoController.go
+++ b/controllers/ProductoController.go
@@ -186,7 +186,7 @@ func (c *ProductoController) Post() {
 	// Registrar historial de precios
 	hist := models.PrecioProductoHist{
 		PKIDProducto:  producto.PK_ID_PRODUCTO,
-		Precio:        float64(producto.PRECIO),
+		Precio:        producto.PRECIO,
 		FechaVigencia: time.Now(),
 	}
 	if _, err := o.Insert(&hist); err != nil {
@@ -311,7 +311,7 @@ func (c *ProductoController) Put() {
 		if producto.PRECIO != original.PRECIO {
 			hist := models.PrecioProductoHist{
 				PKIDProducto:  producto.PK_ID_PRODUCTO,
-				Precio:        float64(producto.PRECIO),
+				Precio:        producto.PRECIO,
 				FechaVigencia: time.Now(),
 			}
 			if _, err := o.Insert(&hist); err != nil {

--- a/models/DetallePedido.go
+++ b/models/DetallePedido.go
@@ -3,10 +3,10 @@ package models
 import "github.com/beego/beego/v2/client/orm"
 
 type DetallePedido struct {
-	PKIDPedido   int64   `orm:"column(pk_id_pedido);pk" json:"pedidoId"`
-	PKIDProducto int64   `orm:"column(pk_id_producto)" json:"productoId"`
-	Precio       float64 `orm:"column(precio)" json:"precio"`
-	Cantidad     int     `orm:"column(cantidad)" json:"cantidad"`
+	PKIDPedido   int64 `orm:"column(pk_id_pedido);pk" json:"pedidoId"`
+	PKIDProducto int64 `orm:"column(pk_id_producto)" json:"productoId"` // part of composite PK
+	Precio       int64 `orm:"column(precio);type(bigint)" json:"precio"`
+	Cantidad     int   `orm:"column(cantidad)" json:"cantidad"`
 }
 
 func (d *DetallePedido) TableName() string {

--- a/models/PrecioProductoHist.go
+++ b/models/PrecioProductoHist.go
@@ -9,9 +9,9 @@ import (
 // PrecioProductoHist represents the price of a product at a given time.
 // It no longer maintains its own primary key or audit timestamps.
 type PrecioProductoHist struct {
-	PKIDProducto  int64     `orm:"column(pk_id_producto)" json:"productoId"`
-	Precio        float64   `orm:"column(precio)" json:"precio"`
-	FechaVigencia time.Time `orm:"column(fecha_vigencia);type(date)" json:"fechaVigencia"`
+	PKIDProducto  int64     `orm:"column(pk_id_producto);pk" json:"productoId"`
+	Precio        int64     `orm:"column(precio);type(bigint)" json:"precio"`
+	FechaVigencia time.Time `orm:"column(fecha_vigencia);type(date)" json:"fechaVigencia"` // part of composite PK
 }
 
 func (p *PrecioProductoHist) TableName() string {

--- a/tests/detalle_pedido_trigger_test.go
+++ b/tests/detalle_pedido_trigger_test.go
@@ -52,7 +52,7 @@ func TestDetallePedidoTriggerOnInsert(t *testing.T) {
 	if err := o.Read(&det); err != nil {
 		t.Skipf("read detalle_pedido failed: %v", err)
 	}
-	if det.Precio != float64(prod.PRECIO) {
-		t.Errorf("expected precio %.2f, got %.2f", float64(prod.PRECIO), det.Precio)
+	if det.Precio != prod.PRECIO {
+		t.Errorf("expected precio %d, got %d", prod.PRECIO, det.Precio)
 	}
 }

--- a/tests/producto_precio_hist_test.go
+++ b/tests/producto_precio_hist_test.go
@@ -46,7 +46,7 @@ func TestProductoPriceHistoryLifecycle(t *testing.T) {
 	if _, err := o.QueryTable(new(models.PrecioProductoHist)).Filter("PKIDProducto", p.PK_ID_PRODUCTO).All(&hist); err != nil {
 		t.Skipf("cannot query history: %v", err)
 	}
-	if len(hist) != 1 || hist[0].Precio != float64(p.PRECIO) || hist[0].FechaVigencia.IsZero() {
+	if len(hist) != 1 || hist[0].Precio != p.PRECIO || hist[0].FechaVigencia.IsZero() {
 		t.Errorf("unexpected initial history: %+v", hist)
 	}
 


### PR DESCRIPTION
## Summary
- use int64 for price fields
- document composite key handling in order models
- update price history logic and tests

## Testing
- `go test ./...` *(fails: field: models.Producto.IMAGEN, unsupport field type , may be miss setting tag)*

------
https://chatgpt.com/codex/tasks/task_e_68b4599ed9548325b0172f54f6123b18