### PR TITLE
Refactor reservation contact model

### DIFF
--- a/controllers/ReservaController.go
+++ b/controllers/ReservaController.go
@@ -40,10 +40,10 @@ var updateReserva = func(o orm.Ormer, r *models.Reserva, cols ...string) (int64,
 	return o.Update(r, cols...)
 }
 
-var queryReservasByParam = func(o orm.Ormer, documentoCliente int64, fecha time.Time, useDoc, useFecha bool, reservas *[]models.Reserva) (int64, error) {
+var queryReservasByParam = func(o orm.Ormer, contactoID int64, fecha time.Time, useContacto, useFecha bool, reservas *[]models.Reserva) (int64, error) {
 	qs := o.QueryTable(new(models.Reserva))
-	if useDoc {
-		qs = qs.Filter("DOCUMENTO_CLIENTE", documentoCliente)
+	if useContacto {
+		qs = qs.Filter("PK_ID_CONTACTO", contactoID)
 	}
 	if useFecha {
 		qs = qs.Filter("FECHA", fecha)
@@ -268,20 +268,24 @@ func (c *ReservaController) Post() {
 		reserva.CREATED_BY = &createdBy
 	}
 
-	if nombreCompleto, ok := input["nombreCompleto"].(string); ok {
-		reserva.NOMBRE_COMPLETO = &nombreCompleto
-	}
-	if telefono, ok := input["telefono"].(string); ok {
-		reserva.TELEFONO = &telefono
-	}
-	if documentoCliente, ok := input["documentoCliente"].(float64); ok {
-		intDocumentoCliente := int64(documentoCliente) // Convertir a int64
-		reserva.DOCUMENTO_CLIENTE = &intDocumentoCliente
+	if contactoID, ok := input["contactoId"].(float64); ok {
+		reserva.PK_ID_CONTACTO = int64(contactoID)
 	} else {
 		c.Ctx.Output.SetStatus(http.StatusBadRequest)
 		c.Data["json"] = models.ApiResponse{
 			Code:    http.StatusBadRequest,
-			Message: "El campo DOCUMENTO_CLIENTE debe ser un número",
+			Message: "El campo PK_ID_CONTACTO debe ser un número",
+		}
+		c.ServeJSON()
+		return
+	}
+	if restauranteID, ok := input["restauranteId"].(float64); ok {
+		reserva.PK_ID_RESTAURANTE = int64(restauranteID)
+	} else {
+		c.Ctx.Output.SetStatus(http.StatusBadRequest)
+		c.Data["json"] = models.ApiResponse{
+			Code:    http.StatusBadRequest,
+			Message: "El campo PK_ID_RESTAURANTE debe ser un número",
 		}
 		c.ServeJSON()
 		return
@@ -417,20 +421,24 @@ func (c *ReservaController) Put() {
 		reserva.UPDATED_BY = &updatedBy
 	}
 
-	if nombreCompleto, ok := input["nombreCompleto"].(string); ok {
-		reserva.NOMBRE_COMPLETO = &nombreCompleto
-	}
-	if telefono, ok := input["telefono"].(string); ok {
-		reserva.TELEFONO = &telefono
-	}
-	if documentoCliente, ok := input["documentoCliente"].(float64); ok {
-		intDocumentoCliente := int64(documentoCliente) // Convertir a int64
-		reserva.DOCUMENTO_CLIENTE = &intDocumentoCliente
+	if contactoID, ok := input["contactoId"].(float64); ok {
+		reserva.PK_ID_CONTACTO = int64(contactoID)
 	} else {
 		c.Ctx.Output.SetStatus(http.StatusBadRequest)
 		c.Data["json"] = models.ApiResponse{
 			Code:    http.StatusBadRequest,
-			Message: "El campo DOCUMENTO_CLIENTE debe ser un número",
+			Message: "El campo PK_ID_CONTACTO debe ser un número",
+		}
+		c.ServeJSON()
+		return
+	}
+	if restauranteID, ok := input["restauranteId"].(float64); ok {
+		reserva.PK_ID_RESTAURANTE = int64(restauranteID)
+	} else {
+		c.Ctx.Output.SetStatus(http.StatusBadRequest)
+		c.Data["json"] = models.ApiResponse{
+			Code:    http.StatusBadRequest,
+			Message: "El campo PK_ID_RESTAURANTE debe ser un número",
 		}
 		c.ServeJSON()
 		return
@@ -462,12 +470,12 @@ func (c *ReservaController) Put() {
 }
 
 // @Title GetByCliente
-// @Summary Obtener reservas por documento de cliente y/o fecha
-// @Description Devuelve las reservas asociadas a un cliente en una fecha específica, todas sus reservas si no se especifica la fecha, o todas las reservas en una fecha específica si no se especifica el cliente.
+// @Summary Obtener reservas por contacto y/o fecha
+// @Description Devuelve las reservas asociadas a un contacto en una fecha específica, todas sus reservas si no se especifica la fecha, o todas las reservas en una fecha específica si no se especifica el contacto.
 // @Tags reservas
 // @Accept json
 // @Produce json
-// @Param documentoCliente query int false "Documento del Cliente (Opcional)"
+// @Param contactoId query int false "ID del Contacto (Opcional)"
 // @Param fecha query string false "Fecha de la reserva (YYYY-MM-DD) (Opcional)"
 // @Success 200 {array} models.Reserva "Lista de reservas encontradas"
 // @Failure 400 {object} models.ApiResponse "Error en los parámetros"
@@ -477,10 +485,10 @@ func (c *ReservaController) GetByParameter() {
 	o := ormNew()
 	var reservas []models.Reserva
 
-	documentoCliente, errDoc := c.GetInt64("documentoCliente")
+	contactoID, errContacto := c.GetInt64("contactoId")
 	fechaReserva := c.GetString("fecha")
 
-	useDoc := errDoc == nil && documentoCliente != 0
+	useContacto := errContacto == nil && contactoID != 0
 	var parsedDate time.Time
 	useFecha := false
 	if fechaReserva != "" {
@@ -498,7 +506,7 @@ func (c *ReservaController) GetByParameter() {
 		useFecha = true
 	}
 
-	_, err := queryReservasByParam(o, documentoCliente, parsedDate, useDoc, useFecha, &reservas)
+	_, err := queryReservasByParam(o, contactoID, parsedDate, useContacto, useFecha, &reservas)
 	if err != nil {
 		c.Ctx.Output.SetStatus(http.StatusInternalServerError)
 		c.Data["json"] = models.ApiResponse{

--- a/controllers/reserva_controller_test.go
+++ b/controllers/reserva_controller_test.go
@@ -24,10 +24,10 @@ func resetReservaMocks() {
 	readReserva = func(o orm.Ormer, r *models.Reserva) error { return o.Read(r) }
 	insertReserva = func(o orm.Ormer, r *models.Reserva) (int64, error) { return o.Insert(r) }
 	updateReserva = func(o orm.Ormer, r *models.Reserva, cols ...string) (int64, error) { return o.Update(r, cols...) }
-	queryReservasByParam = func(o orm.Ormer, doc int64, fecha time.Time, useDoc, useFecha bool, reservas *[]models.Reserva) (int64, error) {
+	queryReservasByParam = func(o orm.Ormer, contacto int64, fecha time.Time, useContacto, useFecha bool, reservas *[]models.Reserva) (int64, error) {
 		qs := o.QueryTable(new(models.Reserva))
-		if useDoc {
-			qs = qs.Filter("documento_cliente", doc)
+		if useContacto {
+			qs = qs.Filter("pk_id_contacto", contacto)
 		}
 		if useFecha {
 			qs = qs.Filter("fecha", fecha)
@@ -93,10 +93,11 @@ func TestReservaPostInvalidJSON(t *testing.T) {
 func TestReservaPostInvalidDate(t *testing.T) {
 	t.Cleanup(resetReservaMocks)
 	payload := map[string]interface{}{
-		"fechaReserva":     "2024-13-01",
-		"horaReserva":      "12:00:00",
-		"personas":         2,
-		"documentoCliente": 123,
+		"fechaReserva":  "2024-13-01",
+		"horaReserva":   "12:00:00",
+		"personas":      2,
+		"contactoId":    123,
+		"restauranteId": 1,
 	}
 	body, _ := json.Marshal(payload)
 	r := httptest.NewRequest(http.MethodPost, "/reservas", bytes.NewReader(body))
@@ -121,9 +122,10 @@ func TestReservaPostInvalidDate(t *testing.T) {
 func TestReservaPostMissingHora(t *testing.T) {
 	t.Cleanup(resetReservaMocks)
 	payload := map[string]interface{}{
-		"fechaReserva":     "2024-01-01",
-		"personas":         2,
-		"documentoCliente": 123,
+		"fechaReserva":  "2024-01-01",
+		"personas":      2,
+		"contactoId":    123,
+		"restauranteId": 1,
 	}
 	body, _ := json.Marshal(payload)
 	r := httptest.NewRequest(http.MethodPost, "/reservas", bytes.NewReader(body))
@@ -184,7 +186,7 @@ func TestReservaGetByParameterInvalidFecha(t *testing.T) {
 
 func TestReservaGetByParameterDBError(t *testing.T) {
 	t.Cleanup(resetReservaMocks)
-	r := httptest.NewRequest(http.MethodGet, "/reservas/parameter?documentoCliente=123&fecha=2024-10-10", nil)
+	r := httptest.NewRequest(http.MethodGet, "/reservas/parameter?contactoId=123&fecha=2024-10-10", nil)
 	w := httptest.NewRecorder()
 	ctx := context.NewContext()
 	ctx.Reset(w, r)
@@ -292,9 +294,10 @@ func TestReservaGetByIdScenarios(t *testing.T) {
 func TestReservaPostMissingFecha(t *testing.T) {
 	t.Cleanup(resetReservaMocks)
 	payload := map[string]interface{}{
-		"horaReserva":      "12:00:00",
-		"personas":         2,
-		"documentoCliente": 123,
+		"horaReserva":   "12:00:00",
+		"personas":      2,
+		"contactoId":    123,
+		"restauranteId": 1,
 	}
 	body, _ := json.Marshal(payload)
 	r := httptest.NewRequest(http.MethodPost, "/reservas", bytes.NewReader(body))
@@ -314,10 +317,11 @@ func TestReservaPostMissingFecha(t *testing.T) {
 func TestReservaPostInvalidHora(t *testing.T) {
 	t.Cleanup(resetReservaMocks)
 	payload := map[string]interface{}{
-		"fechaReserva":     "2024-01-01",
-		"horaReserva":      "99:99:99",
-		"personas":         2,
-		"documentoCliente": 123,
+		"fechaReserva":  "2024-01-01",
+		"horaReserva":   "99:99:99",
+		"personas":      2,
+		"contactoId":    123,
+		"restauranteId": 1,
 	}
 	body, _ := json.Marshal(payload)
 	r := httptest.NewRequest(http.MethodPost, "/reservas", bytes.NewReader(body))
@@ -338,9 +342,10 @@ func TestReservaPostInvalidHora(t *testing.T) {
 func TestReservaPostMissingPersonas(t *testing.T) {
 	t.Cleanup(resetReservaMocks)
 	payload := map[string]interface{}{
-		"fechaReserva":     "2024-01-01",
-		"horaReserva":      "12:00:00",
-		"documentoCliente": 123,
+		"fechaReserva":  "2024-01-01",
+		"horaReserva":   "12:00:00",
+		"contactoId":    123,
+		"restauranteId": 1,
 	}
 	body, _ := json.Marshal(payload)
 	r := httptest.NewRequest(http.MethodPost, "/reservas", bytes.NewReader(body))
@@ -361,11 +366,12 @@ func TestReservaPostMissingPersonas(t *testing.T) {
 func TestReservaPostInvalidEstado(t *testing.T) {
 	t.Cleanup(resetReservaMocks)
 	payload := map[string]interface{}{
-		"fechaReserva":     "2024-01-01",
-		"horaReserva":      "12:00:00",
-		"personas":         2,
-		"documentoCliente": 123,
-		"estadoReserva":    "DESCONOCIDO",
+		"fechaReserva":  "2024-01-01",
+		"horaReserva":   "12:00:00",
+		"personas":      2,
+		"contactoId":    123,
+		"restauranteId": 1,
+		"estadoReserva": "DESCONOCIDO",
 	}
 	body, _ := json.Marshal(payload)
 	r := httptest.NewRequest(http.MethodPost, "/reservas", bytes.NewReader(body))
@@ -383,13 +389,14 @@ func TestReservaPostInvalidEstado(t *testing.T) {
 	}
 }
 
-func TestReservaPostInvalidDocumento(t *testing.T) {
+func TestReservaPostInvalidContacto(t *testing.T) {
 	t.Cleanup(resetReservaMocks)
 	payload := map[string]interface{}{
-		"fechaReserva":     "2024-01-01",
-		"horaReserva":      "12:00:00",
-		"personas":         2,
-		"documentoCliente": "abc",
+		"fechaReserva":  "2024-01-01",
+		"horaReserva":   "12:00:00",
+		"personas":      2,
+		"contactoId":    "abc",
+		"restauranteId": 1,
 	}
 	body, _ := json.Marshal(payload)
 	r := httptest.NewRequest(http.MethodPost, "/reservas", bytes.NewReader(body))
@@ -412,10 +419,11 @@ func TestReservaPostInsertError(t *testing.T) {
 	insertReserva = func(o orm.Ormer, r *models.Reserva) (int64, error) { return 0, errors.New("db") }
 	t.Cleanup(resetReservaMocks)
 	payload := map[string]interface{}{
-		"fechaReserva":     "2024-01-01",
-		"horaReserva":      "12:00:00",
-		"personas":         2,
-		"documentoCliente": 123,
+		"fechaReserva":  "2024-01-01",
+		"horaReserva":   "12:00:00",
+		"personas":      2,
+		"contactoId":    123,
+		"restauranteId": 1,
 	}
 	body, _ := json.Marshal(payload)
 	r := httptest.NewRequest(http.MethodPost, "/reservas", bytes.NewReader(body))
@@ -442,15 +450,16 @@ func TestReservaPostSuccess(t *testing.T) {
 	}
 	t.Cleanup(resetReservaMocks)
 	payload := map[string]interface{}{
-		"fechaReserva":     "2024-01-01",
-		"horaReserva":      "12:00:00",
-		"personas":         2,
-		"documentoCliente": 123,
-		"estadoReserva":    models.EstadoReservaConfirmada,
-		"indicaciones":     "Ninguna",
-		"createdBy":        "admin",
-		"nombreCompleto":   "John Doe",
-		"telefono":         "123",
+		"fechaReserva":   "2024-01-01",
+		"horaReserva":    "12:00:00",
+		"personas":       2,
+		"contactoId":     123,
+		"restauranteId":  1,
+		"estadoReserva":  models.EstadoReservaConfirmada,
+		"indicaciones":   "Ninguna",
+		"createdBy":      "admin",
+		"nombreCompleto": "John Doe",
+		"telefono":       "123",
 	}
 	body, _ := json.Marshal(payload)
 	r := httptest.NewRequest(http.MethodPost, "/reservas", bytes.NewReader(body))
@@ -528,7 +537,7 @@ func TestReservaPutScenarios(t *testing.T) {
 	}
 
 	// invalid fecha
-	payload := map[string]interface{}{"fechaReserva": "2024-13-01", "horaReserva": "12:00:00", "personas": 2, "documentoCliente": 123}
+	payload := map[string]interface{}{"fechaReserva": "2024-13-01", "horaReserva": "12:00:00", "personas": 2, "contactoId": 123, "restauranteId": 1}
 	body, _ := json.Marshal(payload)
 	r = httptest.NewRequest(http.MethodPut, "/reservas?id=1", bytes.NewReader(body))
 	w = httptest.NewRecorder()
@@ -557,9 +566,9 @@ func TestReservaPutScenarios(t *testing.T) {
 		t.Fatalf("expected 400, got %d", w.Code)
 	}
 
-	// invalid documento
+	// invalid contacto
 	payload["horaReserva"] = "12:00:00"
-	payload["documentoCliente"] = "abc"
+	payload["contactoId"] = "abc"
 	body, _ = json.Marshal(payload)
 	r = httptest.NewRequest(http.MethodPut, "/reservas?id=1", bytes.NewReader(body))
 	w = httptest.NewRecorder()
@@ -573,7 +582,7 @@ func TestReservaPutScenarios(t *testing.T) {
 	}
 
 	// update error
-	payload["documentoCliente"] = 123
+	payload["contactoId"] = 123
 	body, _ = json.Marshal(payload)
 	updateReserva = func(o orm.Ormer, r *models.Reserva, cols ...string) (int64, error) { return 0, errors.New("db") }
 	r = httptest.NewRequest(http.MethodPut, "/reservas?id=1", bytes.NewReader(body))
@@ -593,15 +602,16 @@ func TestReservaPutScenarios(t *testing.T) {
 		return 1, nil
 	}
 	payload = map[string]interface{}{
-		"fechaReserva":     "2024-01-02",
-		"horaReserva":      "13:00:00",
-		"personas":         3,
-		"estadoReserva":    models.EstadoReservaConfirmada,
-		"indicaciones":     "OK",
-		"updatedBy":        "admin",
-		"nombreCompleto":   "John",
-		"telefono":         "123",
-		"documentoCliente": 123,
+		"fechaReserva":   "2024-01-02",
+		"horaReserva":    "13:00:00",
+		"personas":       3,
+		"estadoReserva":  models.EstadoReservaConfirmada,
+		"indicaciones":   "OK",
+		"updatedBy":      "admin",
+		"nombreCompleto": "John",
+		"telefono":       "123",
+		"contactoId":     123,
+		"restauranteId":  1,
 	}
 	body, _ = json.Marshal(payload)
 	r = httptest.NewRequest(http.MethodPut, "/reservas?id=1", bytes.NewReader(body))
@@ -628,20 +638,20 @@ func TestReservaPutScenarios(t *testing.T) {
 
 func TestReservaGetByParameterSuccess(t *testing.T) {
 	db := []models.Reserva{{
-		PK_ID_RESERVA:     1,
-		DOCUMENTO_CLIENTE: func() *int64 { v := int64(123); return &v }(),
-		FECHA:             time.Now(),
-		CREATED_AT:        time.Now(),
-		UPDATED_AT:        time.Now(),
-		HORA:              "2024-01-01T12:00:00Z",
+		PK_ID_RESERVA:  1,
+		PK_ID_CONTACTO: 123,
+		FECHA:          time.Now(),
+		CREATED_AT:     time.Now(),
+		UPDATED_AT:     time.Now(),
+		HORA:           "2024-01-01T12:00:00Z",
 	}}
 	ormNew = func() orm.Ormer { return nil }
-	queryReservasByParam = func(o orm.Ormer, doc int64, fecha time.Time, useDoc, useFecha bool, reservas *[]models.Reserva) (int64, error) {
+	queryReservasByParam = func(o orm.Ormer, contacto int64, fecha time.Time, useContacto, useFecha bool, reservas *[]models.Reserva) (int64, error) {
 		*reservas = append(*reservas, db...)
 		return int64(len(db)), nil
 	}
 	t.Cleanup(resetReservaMocks)
-	r := httptest.NewRequest(http.MethodGet, "/reservas/parameter?documentoCliente=123&fecha=2024-01-01", nil)
+	r := httptest.NewRequest(http.MethodGet, "/reservas/parameter?contactoId=123&fecha=2024-01-01", nil)
 	w := httptest.NewRecorder()
 	ctx := context.NewContext()
 	ctx.Reset(w, r)
@@ -734,11 +744,12 @@ func TestReservaPutInvalidEstadoIgnored(t *testing.T) {
 	t.Cleanup(resetReservaMocks)
 
 	payload := map[string]interface{}{
-		"estadoReserva":    "invalido",
-		"fechaReserva":     "2024-01-01",
-		"horaReserva":      "12:00:00",
-		"personas":         2,
-		"documentoCliente": 123,
+		"estadoReserva": "invalido",
+		"fechaReserva":  "2024-01-01",
+		"horaReserva":   "12:00:00",
+		"personas":      2,
+		"contactoId":    123,
+		"restauranteId": 1,
 	}
 	body, _ := json.Marshal(payload)
 	r := httptest.NewRequest(http.MethodPut, "/reservas?id=1", bytes.NewReader(body))

--- a/models/Reserva.go
+++ b/models/Reserva.go
@@ -12,15 +12,14 @@ type Reserva struct {
 	FECHA             time.Time      `orm:"column(fecha);type(date)" json:"fechaReserva"`
 	HORA              string         `orm:"column(hora);type(time);size(8)" json:"horaReserva"`
 	PERSONAS          int            `orm:"column(personas)" json:"personas"`
+	PK_ID_CONTACTO    int64          `orm:"column(pk_id_contacto)" json:"contactoId"`
+	PK_ID_RESTAURANTE int64          `orm:"column(pk_id_restaurante)" json:"restauranteId"`
 	ESTADO_RESERVA    *EstadoReserva `orm:"column(estado_reserva);null" json:"estadoReserva,omitempty"`
 	INDICACIONES      *string        `orm:"column(indicaciones);null" json:"indicaciones,omitempty"`
 	CREATED_AT        time.Time      `orm:"column(created_at);type(timestamp);auto_now_add" json:"createdAt"`
 	UPDATED_AT        time.Time      `orm:"column(updated_at);type(timestamp);auto_now" json:"updatedAt"`
 	CREATED_BY        *string        `orm:"column(created_by);type(text);null" json:"createdBy,omitempty"`
 	UPDATED_BY        *string        `orm:"column(updated_by);type(text);null" json:"updatedBy,omitempty"`
-	NOMBRE_COMPLETO   *string        `orm:"column(nombre_completo);type(text);null" json:"nombreCompleto,omitempty"`
-	TELEFONO          *string        `orm:"column(telefono);type(text);null" json:"telefono,omitempty"`
-	DOCUMENTO_CLIENTE *int64         `orm:"column(documento_cliente);null" json:"documentoCliente,omitempty"`
 }
 
 func (r *Reserva) TableName() string {

--- a/models/ReservaContacto.go
+++ b/models/ReservaContacto.go
@@ -3,11 +3,11 @@ package models
 import "github.com/beego/beego/v2/client/orm"
 
 type ReservaContacto struct {
-	PKIDReservaContacto int64   `orm:"column(pk_id_reserva_contacto);pk;auto" json:"reservaContactoId"`
-	PKIDReserva         int64   `orm:"column(pk_id_reserva)" json:"reservaId"`
-	Nombre              string  `orm:"column(nombre);type(text)" json:"nombre"`
-	Telefono            *string `orm:"column(telefono);type(text);null" json:"telefono,omitempty"`
-	Email               *string `orm:"column(email);type(text);null" json:"email,omitempty"`
+	PKIDContacto       int64   `orm:"column(pk_id_contacto);pk;auto" json:"contactoId"`
+	NombreCompleto     string  `orm:"column(nombre_completo);type(text)" json:"nombreCompleto"`
+	Telefono           *string `orm:"column(telefono);type(text);null" json:"telefono,omitempty"`
+	DocumentoContacto  *string `orm:"column(documento_contacto);type(text);null" json:"documentoContacto,omitempty"`
+	PKDocumentoCliente *int64  `orm:"column(pk_documento_cliente);null" json:"documentoCliente,omitempty"`
 }
 
 func (r *ReservaContacto) TableName() string {


### PR DESCRIPTION
## Summary
- redefine ReservaContacto schema
- use contacto and restaurante references in Reserva model
- adjust reservation controller and tests for new fields

## Testing
- `go test ./...` *(fails: field models.Producto.IMAGEN unsupported field type)*

------
https://chatgpt.com/codex/tasks/task_e_68b45b4df9f48325b4026e61ebccf124