### PR TITLE
Use composite key for schedule

### DIFF
--- a/controllers/HorarioTrabajadorController.go
+++ b/controllers/HorarioTrabajadorController.go
@@ -39,17 +39,24 @@ func isValidDia(dia string) bool {
 // @Router /horario_trabajador [get]
 func (c *HorarioTrabajadorController) GetAll() {
 	o := orm.NewOrm()
-	qs := o.QueryTable(new(models.HorarioTrabajador))
+	query := "SELECT pk_documento_trabajador, dia, hora_inicio, hora_fin FROM horario_trabajador"
+	var args []interface{}
+	var conds []string
 
 	if doc, err := c.GetInt64("documento"); err == nil && doc != 0 {
-		qs = qs.Filter("PK_DOCUMENTO_TRABAJADOR", doc)
+		conds = append(conds, "pk_documento_trabajador = ?")
+		args = append(args, doc)
 	}
 	if dia := c.GetString("dia"); dia != "" {
-		qs = qs.Filter("DIA", dia)
+		conds = append(conds, "dia = ?")
+		args = append(args, dia)
+	}
+	if len(conds) > 0 {
+		query += " WHERE " + strings.Join(conds, " AND ")
 	}
 
 	var horarios []models.HorarioTrabajador
-	if _, err := qs.All(&horarios); err != nil {
+	if _, err := o.Raw(query, args...).QueryRows(&horarios); err != nil {
 		c.Ctx.Output.SetStatus(http.StatusInternalServerError)
 		c.Data["json"] = models.ApiResponse{
 			Code:    http.StatusInternalServerError,
@@ -127,7 +134,10 @@ func (c *HorarioTrabajadorController) Post() {
 	}
 
 	o := orm.NewOrm()
-	if _, err := o.Insert(&horario); err != nil {
+	if _, err := o.Raw(
+		"INSERT INTO horario_trabajador (pk_documento_trabajador, dia, hora_inicio, hora_fin) VALUES (?, ?, ?, ?)",
+		horario.PK_DOCUMENTO_TRABAJADOR, horario.DIA, horario.HORA_INICIO, horario.HORA_FIN,
+	).Exec(); err != nil {
 		c.Ctx.Output.SetStatus(http.StatusInternalServerError)
 		c.Data["json"] = models.ApiResponse{
 			Code:    http.StatusInternalServerError,
@@ -178,9 +188,12 @@ func (c *HorarioTrabajadorController) Put() {
 		return
 	}
 
-	horario := models.HorarioTrabajador{PK_DOCUMENTO_TRABAJADOR: doc, DIA: dia}
+	var horario models.HorarioTrabajador
 	o := orm.NewOrm()
-	if err := o.Read(&horario); err == orm.ErrNoRows {
+	if err := o.Raw(
+		"SELECT pk_documento_trabajador, dia, hora_inicio, hora_fin FROM horario_trabajador WHERE pk_documento_trabajador = ? AND dia = ?",
+		doc, dia,
+	).QueryRow(&horario); err == orm.ErrNoRows {
 		c.Ctx.Output.SetStatus(http.StatusOK)
 		c.Data["json"] = models.ApiResponse{Code: http.StatusNotFound, Message: "Horario no encontrado"}
 		c.ServeJSON()
@@ -221,7 +234,10 @@ func (c *HorarioTrabajadorController) Put() {
 		}
 	}
 
-	if _, err := o.Update(&horario); err != nil {
+	if _, err := o.Raw(
+		"UPDATE horario_trabajador SET hora_inicio = ?, hora_fin = ? WHERE pk_documento_trabajador = ? AND dia = ?",
+		horario.HORA_INICIO, horario.HORA_FIN, doc, dia,
+	).Exec(); err != nil {
 		c.Ctx.Output.SetStatus(http.StatusInternalServerError)
 		c.Data["json"] = models.ApiResponse{Code: http.StatusInternalServerError, Message: "Error al actualizar horario", Cause: err.Error()}
 		c.ServeJSON()
@@ -263,9 +279,12 @@ func (c *HorarioTrabajadorController) Delete() {
 		return
 	}
 
-	horario := models.HorarioTrabajador{PK_DOCUMENTO_TRABAJADOR: doc, DIA: dia}
 	o := orm.NewOrm()
-	if err := o.Read(&horario); err == orm.ErrNoRows {
+	var horario models.HorarioTrabajador
+	if err := o.Raw(
+		"SELECT pk_documento_trabajador, dia FROM horario_trabajador WHERE pk_documento_trabajador = ? AND dia = ?",
+		doc, dia,
+	).QueryRow(&horario); err == orm.ErrNoRows {
 		c.Ctx.Output.SetStatus(http.StatusOK)
 		c.Data["json"] = models.ApiResponse{Code: http.StatusNotFound, Message: "Horario no encontrado"}
 		c.ServeJSON()
@@ -277,7 +296,10 @@ func (c *HorarioTrabajadorController) Delete() {
 		return
 	}
 
-	if _, err := o.Delete(&horario); err != nil {
+	if _, err := o.Raw(
+		"DELETE FROM horario_trabajador WHERE pk_documento_trabajador = ? AND dia = ?",
+		doc, dia,
+	).Exec(); err != nil {
 		c.Ctx.Output.SetStatus(http.StatusInternalServerError)
 		c.Data["json"] = models.ApiResponse{Code: http.StatusInternalServerError, Message: "Error al eliminar horario", Cause: err.Error()}
 		c.ServeJSON()

--- a/controllers/TrabajadorController.go
+++ b/controllers/TrabajadorController.go
@@ -106,8 +106,8 @@ func (c *TrabajadorController) GetAll() {
 		}
 		trabajadores[i].FECHA_INGRESO = trabajadores[i].FECHA_INGRESO.In(database.BogotaZone)
 		var horarios []models.HorarioTrabajador
-		if _, err := o.QueryTable(new(models.HorarioTrabajador)).
-			Filter("PK_DOCUMENTO_TRABAJADOR", trabajadores[i].PK_DOCUMENTO_TRABAJADOR).
+		if _, err := o.QueryTable("horario_trabajador").
+			Filter("pk_documento_trabajador", trabajadores[i].PK_DOCUMENTO_TRABAJADOR).
 			All(&horarios); err == nil {
 			trabajadores[i].HORARIOS = horarios
 		}
@@ -173,8 +173,8 @@ func (c *TrabajadorController) GetById() {
 
 	trabajador.PASSWORD = ""
 	var horarios []models.HorarioTrabajador
-	if _, err := o.QueryTable(new(models.HorarioTrabajador)).
-		Filter("PK_DOCUMENTO_TRABAJADOR", trabajador.PK_DOCUMENTO_TRABAJADOR).
+	if _, err := o.QueryTable("horario_trabajador").
+		Filter("pk_documento_trabajador", trabajador.PK_DOCUMENTO_TRABAJADOR).
 		All(&horarios); err == nil {
 		trabajador.HORARIOS = horarios
 	}

--- a/controllers/horario_trabajador_controller_test.go
+++ b/controllers/horario_trabajador_controller_test.go
@@ -42,12 +42,7 @@ func TestHorarioTrabajadorPostSuccess(t *testing.T) {
 	MockExec = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Result, error) {
 		return mockResult{}, nil
 	}
-	MockQuery = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
-		cols := []string{"pk_documento_trabajador"}
-		vals := [][]driver.Value{{int64(1)}}
-		return &mockRows{columns: cols, values: vals}, nil
-	}
-	defer func() { MockExec = nil; MockQuery = nil }()
+	defer func() { MockExec = nil }()
 
 	body := `{"documentoTrabajador":1,"dia":"lunes","horaInicio":"08:00:00","horaFin":"17:00:00"}`
 	c, w := setupHTCtx(http.MethodPost, "/horario_trabajador", body)

--- a/models/HorarioTrabajador.go
+++ b/models/HorarioTrabajador.go
@@ -3,23 +3,17 @@ package models
 import (
 	"encoding/json"
 	"time"
-
-	"github.com/beego/beego/v2/client/orm"
 )
 
 type HorarioTrabajador struct {
 	PK_DOCUMENTO_TRABAJADOR int64     `orm:"column(pk_documento_trabajador);pk" json:"documentoTrabajador"`
-	DIA                     DiaSemana `orm:"column(dia);type(text)" json:"dia"`
+	DIA                     DiaSemana `orm:"column(dia);type(text);pk" json:"dia"`
 	HORA_INICIO             time.Time `orm:"column(hora_inicio);type(time)" json:"horaInicio"`
 	HORA_FIN                time.Time `orm:"column(hora_fin);type(time)" json:"horaFin"`
 }
 
 func (h *HorarioTrabajador) TableName() string {
 	return "horario_trabajador"
-}
-
-func init() {
-	orm.RegisterModel(new(HorarioTrabajador))
 }
 
 func (h HorarioTrabajador) MarshalJSON() ([]byte, error) {

--- a/tests/seed_data.go
+++ b/tests/seed_data.go
@@ -26,12 +26,10 @@ func SeedTestData() {
 
 	inicio, _ := time.Parse("15:04:05", "08:00:00")
 	fin, _ := time.Parse("15:04:05", "16:00:00")
-	if _, err := o.Insert(&models.HorarioTrabajador{
-		PK_DOCUMENTO_TRABAJADOR: 1,
-		DIA:                     "Lunes",
-		HORA_INICIO:             inicio,
-		HORA_FIN:                fin,
-	}); err != nil {
+	if _, err := o.Raw(
+		"INSERT INTO horario_trabajador (pk_documento_trabajador, dia, hora_inicio, hora_fin) VALUES (?, ?, ?, ?)",
+		1, models.DiaLunes, inicio, fin,
+	).Exec(); err != nil {
 		log.Println("seed horario_trabajador:", err)
 	}
 }


### PR DESCRIPTION
## Summary
- model composite key for worker schedules
- query schedules using raw SQL in controller
- adapt tests and seed data for composite key

## Testing
- `go test ./...` *(fails: models.Producto.IMAGEN, unsupport field type)*

------
https://chatgpt.com/codex/tasks/task_e_68b45fcb12e88325988a5acd3ace01c4