### PR TITLE
Simplify payroll procedure calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,7 @@ Go-based REST API for managing restaurant operations such as customers, orders, 
   database trigger assigns it automatically.
 - **Payroll (nómina)** operations:
   - `POST /nominas` accepts optional `generar_nomina_automatica` and
-    `verificar_nomina` parameters (`fecha_inicio` y `fecha_fin`) to
-    auto-generate payments and verify payroll records.
+    `verificar_nomina` flags to auto-generate payments and verify payroll records.
 - `PUT /nominas?id=...` transitions a payroll to `pago`.
 - `DELETE /nominas?id=...` performs a logical deletion setting the state to `no pago`.
 

--- a/controllers/NominaController.go
+++ b/controllers/NominaController.go
@@ -126,44 +126,6 @@ func (c *NominaController) Post() {
 
 	input.MONTO = 0 // Dejar en 0 para que sea calculado automáticamente por la función
 
-	var fechaInicio, fechaFin time.Time
-	if gen || ver {
-		fechaInicioStr := c.GetString("fecha_inicio")
-		fechaFinStr := c.GetString("fecha_fin")
-		if fechaInicioStr == "" || fechaFinStr == "" {
-			c.Ctx.Output.SetStatus(http.StatusBadRequest)
-			c.Data["json"] = models.ApiResponse{
-				Code:    http.StatusBadRequest,
-				Message: "Se requieren los parámetros fecha_inicio y fecha_fin",
-			}
-			c.ServeJSON()
-			return
-		}
-		var err error
-		fechaInicio, err = time.Parse("2006-01-02", fechaInicioStr)
-		if err != nil {
-			c.Ctx.Output.SetStatus(http.StatusBadRequest)
-			c.Data["json"] = models.ApiResponse{
-				Code:    http.StatusBadRequest,
-				Message: "Formato de fecha inválido para fecha_inicio",
-				Cause:   err.Error(),
-			}
-			c.ServeJSON()
-			return
-		}
-		fechaFin, err = time.Parse("2006-01-02", fechaFinStr)
-		if err != nil {
-			c.Ctx.Output.SetStatus(http.StatusBadRequest)
-			c.Data["json"] = models.ApiResponse{
-				Code:    http.StatusBadRequest,
-				Message: "Formato de fecha inválido para fecha_fin",
-				Cause:   err.Error(),
-			}
-			c.ServeJSON()
-			return
-		}
-	}
-
 	_, err := o.Insert(&input)
 	if err != nil {
 		c.Ctx.Output.SetStatus(http.StatusInternalServerError)
@@ -177,31 +139,31 @@ func (c *NominaController) Post() {
 	}
 
 	// Ejecutar funciones adicionales si se solicitan
-       if gen {
-               if _, err := o.Raw("CALL generar_nomina_automatica(?, ?, ?)", input.PK_ID_NOMINA, fechaInicio.Format("2006-01-02"), fechaFin.Format("2006-01-02")).Exec(); err != nil {
-                       c.Ctx.Output.SetStatus(http.StatusInternalServerError)
-                       c.Data["json"] = models.ApiResponse{
-                               Code:    http.StatusInternalServerError,
-                               Message: "Error al generar nómina automática",
-                               Cause:   err.Error(),
-                       }
-                       c.ServeJSON()
-                       return
-               }
-       }
+	if gen {
+		if _, err := o.Raw("CALL generar_nomina_automatica(?)", input.PK_ID_NOMINA).Exec(); err != nil {
+			c.Ctx.Output.SetStatus(http.StatusInternalServerError)
+			c.Data["json"] = models.ApiResponse{
+				Code:    http.StatusInternalServerError,
+				Message: "Error al generar nómina automática",
+				Cause:   err.Error(),
+			}
+			c.ServeJSON()
+			return
+		}
+	}
 
-       if ver {
-               if _, err := o.Raw("CALL verificar_nomina(?, ?, ?)", input.PK_ID_NOMINA, fechaInicio.Format("2006-01-02"), fechaFin.Format("2006-01-02")).Exec(); err != nil {
-                       c.Ctx.Output.SetStatus(http.StatusInternalServerError)
-                       c.Data["json"] = models.ApiResponse{
-                               Code:    http.StatusInternalServerError,
-                               Message: "Error al verificar nómina",
-                               Cause:   err.Error(),
-                       }
-                       c.ServeJSON()
-                       return
-               }
-       }
+	if ver {
+		if _, err := o.Raw("CALL verificar_nomina(?)", input.PK_ID_NOMINA).Exec(); err != nil {
+			c.Ctx.Output.SetStatus(http.StatusInternalServerError)
+			c.Data["json"] = models.ApiResponse{
+				Code:    http.StatusInternalServerError,
+				Message: "Error al verificar nómina",
+				Cause:   err.Error(),
+			}
+			c.ServeJSON()
+			return
+		}
+	}
 
 	var updatedNomina models.Nomina
 	err = o.QueryTable(new(models.Nomina)).

--- a/controllers/nomina_controller_test.go
+++ b/controllers/nomina_controller_test.go
@@ -45,44 +45,6 @@ func TestNominaPostInvalidJSON(t *testing.T) {
 	}
 }
 
-func TestNominaPostMissingDatesForAutoGeneration(t *testing.T) {
-	r := httptest.NewRequest(http.MethodPost, "/nominas?generar_nomina_automatica=true", strings.NewReader("{}"))
-	w := httptest.NewRecorder()
-	ctx := context.NewContext()
-	ctx.Reset(w, r)
-	c := NominaController{}
-	c.Ctx = ctx
-	c.Data = make(map[interface{}]interface{})
-
-	c.Post()
-
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("expected status 400, got %d", w.Code)
-	}
-	if !strings.Contains(w.Body.String(), "fecha_inicio") {
-		t.Errorf("unexpected body: %s", w.Body.String())
-	}
-}
-
-func TestNominaPostMissingDatesForVerification(t *testing.T) {
-	r := httptest.NewRequest(http.MethodPost, "/nominas?verificar_nomina=true", strings.NewReader("{}"))
-	w := httptest.NewRecorder()
-	ctx := context.NewContext()
-	ctx.Reset(w, r)
-	c := NominaController{}
-	c.Ctx = ctx
-	c.Data = make(map[interface{}]interface{})
-
-	c.Post()
-
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("expected status 400, got %d", w.Code)
-	}
-	if !strings.Contains(w.Body.String(), "fecha_inicio") {
-		t.Errorf("unexpected body: %s", w.Body.String())
-	}
-}
-
 func TestNominaPostDBError(t *testing.T) {
 	r := httptest.NewRequest(http.MethodPost, "/nominas", nil)
 	w := httptest.NewRecorder()

--- a/main.go
+++ b/main.go
@@ -41,9 +41,6 @@ func generarNominaAutomatica() {
 		if now.Hour() == 0 && now.Minute() == 0 {
 			fmt.Println("Ejecutando generación automática de nómina...")
 
-			inicio := now.AddDate(0, 0, -1).Format("2006-01-02")
-			fin := now.AddDate(0, 0, -1).Format("2006-01-02")
-
 			nomina := models.Nomina{
 				FECHA:         now,
 				ESTADO_NOMINA: models.EstadoNominaNoPago,
@@ -52,7 +49,7 @@ func generarNominaAutomatica() {
 			if _, err := o.Insert(&nomina); err != nil {
 				fmt.Println("Error al crear la nómina:", err)
 			} else {
-				if _, err := o.Raw("CALL generar_nomina_automatica(?, ?, ?)", nomina.PK_ID_NOMINA, inicio, fin).Exec(); err != nil {
+				if _, err := o.Raw("CALL generar_nomina_automatica(?)", nomina.PK_ID_NOMINA).Exec(); err != nil {
 					fmt.Println("Error al generar la nómina automática:", err)
 				} else {
 					fmt.Println("Nómina generada automáticamente con éxito.")

--- a/tests/nomina_functions_test.go
+++ b/tests/nomina_functions_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestNominaGenerarYVerificar(t *testing.T) {
 	body := strings.NewReader("{}")
-	req := httptest.NewRequest(http.MethodPost, "/nominas?generar_nomina_automatica=true&verificar_nomina=true&fecha_inicio=2023-01-01&fecha_fin=2023-01-31", body)
+	req := httptest.NewRequest(http.MethodPost, "/nominas?generar_nomina_automatica=true&verificar_nomina=true", body)
 	req.Header.Set("Content-Type", "application/json")
 	w := sendRequest(req)
 	if w.Code != http.StatusCreated {


### PR DESCRIPTION
## Summary
- Drop `fecha_inicio`/`fecha_fin` args from payroll generation and verification
- Call payroll procedures with ID only in API and scheduled job
- Update tests and README for new procedure signatures

## Testing
- `go test ./controllers -count=1` *(fails: init global config instance failed. open conf/app.conf: no such file or directory; field: models.Producto.IMAGEN, unsupport field type)*
- `go test ./tests -run TestNominaGenerarYVerificar -count=1 -v` *(fails: init global config instance failed. open conf/app.conf: no such file or directory; field: models.Producto.IMAGEN, unsupport field type)*

------
https://chatgpt.com/codex/tasks/task_e_68b462fa358c832588cc85a277e91eaa