### PR TITLE
Add SQL migration for detalle_pedido price trigger

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,11 @@ Go-based REST API for managing restaurant operations such as customers, orders, 
    ```sh
    go mod download
    ```
-4. Configuration files reside in `conf/` (`app.conf`, `app.test.conf`).
+4. Run the SQL migrations to set up database functions:
+   ```sh
+   psql -d <dbname> -f database/migrations/001_set_precio_detalle_pedido.sql
+   ```
+5. Configuration files reside in `conf/` (`app.conf`, `app.test.conf`).
 
 ## Development
 - Start the development server with live reload and Swagger generation:

--- a/database/migrations/001_set_precio_detalle_pedido.sql
+++ b/database/migrations/001_set_precio_detalle_pedido.sql
@@ -1,0 +1,20 @@
+-- Sets the price of detalle_pedido rows based on the current product price.
+-- This function and trigger ensure the precio field is populated automatically
+-- when inserting or updating records in the detalle_pedido table.
+
+CREATE OR REPLACE FUNCTION set_precio_detalle_pedido()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.precio := (
+        SELECT precio FROM producto WHERE pk_id_producto = NEW.pk_id_producto
+    );
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS tr_set_precio_detalle_pedido ON detalle_pedido;
+
+CREATE TRIGGER tr_set_precio_detalle_pedido
+BEFORE INSERT OR UPDATE ON detalle_pedido
+FOR EACH ROW
+EXECUTE FUNCTION set_precio_detalle_pedido();


### PR DESCRIPTION
## Summary
- add migration defining `set_precio_detalle_pedido` and its trigger
- document running SQL migration in setup instructions

## Testing
- `go test ./...` *(fails: init global config instance failed. If you do not use this, just ignore it.  open conf/app.conf: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b466bd630483258348de4fba9a6870