### PR TITLE
Seed basic product data for tests

### DIFF
--- a/tests/seed_data.go
+++ b/tests/seed_data.go
@@ -16,6 +16,26 @@ func SeedTestData() {
 		log.Println("seed metodo_pago:", err)
 	}
 
+	if _, err := o.Insert(&models.Categoria{PK_ID_CATEGORIA: 1, NOMBRE: "General"}); err != nil {
+		log.Println("seed categoria:", err)
+	}
+
+	if _, err := o.Insert(&models.Subcategoria{PK_ID_SUBCATEGORIA: 1, PK_ID_CATEGORIA: 1, NOMBRE: "Subgeneral"}); err != nil {
+		log.Println("seed subcategoria:", err)
+	}
+
+	if _, err := o.Insert(&models.Producto{
+		PK_ID_PRODUCTO:     1,
+		NOMBRE:             "Producto Prueba",
+		DESCRIPCION:        "Usado en tests",
+		PRECIO:             1000,
+		ESTADO_PRODUCTO:    models.EstadoProductoDisponible,
+		CANTIDAD:           1,
+		PK_ID_SUBCATEGORIA: 1,
+	}); err != nil {
+		log.Println("seed producto:", err)
+	}
+
 	if _, err := o.Insert(&models.DetallePedido{
 		PKIDPedido:   1,
 		PKIDProducto: 1,


### PR DESCRIPTION
## Summary
- Seed Categoria and Subcategoria records for tests
- Add a default Producto linked to the seeded Subcategoria

## Testing
- `go test ./tests` *(fails: field: models.Producto.IMAGEN, unsupport field type , may be miss setting tag)*

------
https://chatgpt.com/codex/tasks/task_e_68b477e526d88325b94d0db776e662c5