### PR TITLE
Fail fast in tests and ensure seed data

### DIFF
--- a/tests/detalle_pedido_trigger_test.go
+++ b/tests/detalle_pedido_trigger_test.go
@@ -24,11 +24,11 @@ func getOrmer() (orm.Ormer, error) {
 func TestDetallePedidoTrigger(t *testing.T) {
 	o, err := getOrmer()
 	if err != nil {
-		t.Skipf("orm not available: %v", err)
+		t.Fatalf("orm not available: %v", err)
 	}
 	var d models.DetallePedido
 	if err := o.QueryTable(new(models.DetallePedido)).Filter("PKIDPedido", 1).Filter("PKIDProducto", 1).One(&d); err != nil {
-		t.Skipf("detalle_pedido not found or DB unavailable: %v", err)
+		t.Fatalf("detalle_pedido not found or DB unavailable: %v", err)
 	}
 	if d.Precio == 0 {
 		t.Errorf("expected precio to be set by trigger, got 0")
@@ -38,21 +38,35 @@ func TestDetallePedidoTrigger(t *testing.T) {
 func TestDetallePedidoTriggerOnInsert(t *testing.T) {
 	o, err := getOrmer()
 	if err != nil {
-		t.Skipf("orm not available: %v", err)
+		t.Fatalf("orm not available: %v", err)
 	}
 	var prod models.Producto
 	if err := o.QueryTable(new(models.Producto)).Filter("PK_ID_PRODUCTO", 1).One(&prod); err != nil {
-		t.Skipf("producto not found or DB unavailable: %v", err)
+		t.Fatalf("producto not found or DB unavailable: %v", err)
 	}
 	det := models.DetallePedido{PKIDPedido: 9999, PKIDProducto: prod.PK_ID_PRODUCTO, Cantidad: 1}
 	if _, err := o.Insert(&det); err != nil {
-		t.Skipf("insert detalle_pedido failed: %v", err)
+		t.Fatalf("insert detalle_pedido failed: %v", err)
 	}
 	defer o.Delete(&det)
 	if err := o.Read(&det); err != nil {
-		t.Skipf("read detalle_pedido failed: %v", err)
+		t.Fatalf("read detalle_pedido failed: %v", err)
 	}
 	if det.Precio != prod.PRECIO {
 		t.Errorf("expected precio %d, got %d", prod.PRECIO, det.Precio)
+	}
+}
+
+func TestSetPrecioDetallePedidoTriggerExists(t *testing.T) {
+	o, err := getOrmer()
+	if err != nil {
+		t.Fatalf("orm not available: %v", err)
+	}
+	var count int
+	if err := o.Raw("SELECT COUNT(*) FROM pg_trigger WHERE tgname = ?", "set_precio_detalle_pedido").QueryRow(&count); err != nil {
+		t.Fatalf("cannot query trigger existence: %v", err)
+	}
+	if count == 0 {
+		t.Fatalf("trigger set_precio_detalle_pedido not found")
 	}
 }

--- a/tests/nomina_functions_test.go
+++ b/tests/nomina_functions_test.go
@@ -16,7 +16,7 @@ func TestNominaGenerarYVerificar(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json")
 	w := sendRequest(req)
 	if w.Code != http.StatusCreated {
-		t.Skipf("nomina generation/verification failed or DB unavailable: %d %s", w.Code, w.Body.String())
+		t.Fatalf("nomina generation/verification failed or DB unavailable: %d %s", w.Code, w.Body.String())
 	}
 
 	var resp models.ApiResponse

--- a/tests/producto_precio_hist_test.go
+++ b/tests/producto_precio_hist_test.go
@@ -28,23 +28,23 @@ func TestProductoPriceHistoryLifecycle(t *testing.T) {
 	req.Header.Set("Content-Type", writer.FormDataContentType())
 	w := sendRequest(req)
 	if w.Code != http.StatusCreated {
-		t.Skipf("product creation failed or DB unavailable: %d %s", w.Code, w.Body.String())
+		t.Fatalf("product creation failed or DB unavailable: %d %s", w.Code, w.Body.String())
 	}
 
 	o, err := getOrmer()
 	if err != nil {
-		t.Skipf("orm not available: %v", err)
+		t.Fatalf("orm not available: %v", err)
 	}
 	var p models.Producto
 	if err := o.QueryTable(new(models.Producto)).Filter("NOMBRE", name).One(&p); err != nil {
-		t.Skipf("producto not found: %v", err)
+		t.Fatalf("producto not found: %v", err)
 	}
 	defer o.QueryTable(new(models.PrecioProductoHist)).Filter("PKIDProducto", p.PK_ID_PRODUCTO).Delete()
 	defer o.Delete(&p)
 
 	var hist []models.PrecioProductoHist
 	if _, err := o.QueryTable(new(models.PrecioProductoHist)).Filter("PKIDProducto", p.PK_ID_PRODUCTO).All(&hist); err != nil {
-		t.Skipf("cannot query history: %v", err)
+		t.Fatalf("cannot query history: %v", err)
 	}
 	if len(hist) != 1 || hist[0].Precio != p.PRECIO || hist[0].FechaVigencia.IsZero() {
 		t.Errorf("unexpected initial history: %+v", hist)
@@ -60,12 +60,12 @@ func TestProductoPriceHistoryLifecycle(t *testing.T) {
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	w = sendRequest(req)
 	if w.Code != http.StatusOK {
-		t.Skipf("product update failed: %d %s", w.Code, w.Body.String())
+		t.Fatalf("product update failed: %d %s", w.Code, w.Body.String())
 	}
 
 	hist = nil
 	if _, err := o.QueryTable(new(models.PrecioProductoHist)).Filter("PKIDProducto", p.PK_ID_PRODUCTO).All(&hist); err != nil {
-		t.Skipf("cannot query history after update: %v", err)
+		t.Fatalf("cannot query history after update: %v", err)
 	}
 	if len(hist) != 2 {
 		t.Fatalf("expected 2 history records, got %d", len(hist))

--- a/tests/seed_data.go
+++ b/tests/seed_data.go
@@ -24,15 +24,21 @@ func SeedTestData() {
 		log.Println("seed subcategoria:", err)
 	}
 
-	if _, err := o.Insert(&models.Producto{
-		PK_ID_PRODUCTO:     1,
-		NOMBRE:             "Producto Prueba",
-		DESCRIPCION:        "Usado en tests",
-		PRECIO:             1000,
-		ESTADO_PRODUCTO:    models.EstadoProductoDisponible,
-		CANTIDAD:           1,
-		PK_ID_SUBCATEGORIA: 1,
-	}); err != nil {
+	prod := models.Producto{PK_ID_PRODUCTO: 1}
+	if err := o.Read(&prod); err == orm.ErrNoRows {
+		prod = models.Producto{
+			PK_ID_PRODUCTO:     1,
+			NOMBRE:             "Producto Prueba",
+			DESCRIPCION:        "Usado en tests",
+			PRECIO:             1000,
+			ESTADO_PRODUCTO:    models.EstadoProductoDisponible,
+			CANTIDAD:           1,
+			PK_ID_SUBCATEGORIA: 1,
+		}
+		if _, err := o.Insert(&prod); err != nil {
+			log.Println("seed producto:", err)
+		}
+	} else if err != nil {
 		log.Println("seed producto:", err)
 	}
 


### PR DESCRIPTION
## Summary
- Replace `t.Skipf` calls with `t.Fatalf` across tests to surface database issues
- Ensure `SeedTestData` inserts a valid product if missing
- Add explicit check for `set_precio_detalle_pedido` trigger

## Testing
- `go test ./...` *(fails: open conf/app.conf: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b479484ce08325b92b50c69b51d502