### PR TITLE
test: update nomina function params

### DIFF
--- a/tests/nomina_functions_test.go
+++ b/tests/nomina_functions_test.go
@@ -11,35 +11,45 @@ import (
 )
 
 func TestNominaGenerarYVerificar(t *testing.T) {
-	body := strings.NewReader("{}")
-	req := httptest.NewRequest(http.MethodPost, "/nominas?generar_nomina_automatica=true&verificar_nomina=true", body)
-	req.Header.Set("Content-Type", "application/json")
-	w := sendRequest(req)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("nomina generation/verification failed or DB unavailable: %d %s", w.Code, w.Body.String())
-	}
+       body := strings.NewReader("{}")
+       req := httptest.NewRequest(
+               http.MethodPost,
+               "/nominas?generar_nomina_automatica=true&verificar_nomina=true&p_nomina_id=1&p_fecha=2024-01-01",
+               body,
+       )
+       req.Header.Set("Content-Type", "application/json")
+       w := sendRequest(req)
+       if w.Code != http.StatusCreated {
+               t.Fatalf("nomina generation/verification failed or DB unavailable: %d %s", w.Code, w.Body.String())
+       }
 
-	var resp models.ApiResponse
-	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
-		t.Fatalf("failed to unmarshal response: %v", err)
-	}
+       var resp models.ApiResponse
+       if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+               t.Fatalf("failed to unmarshal response: %v", err)
+       }
 
-	if resp.Message != "Nómina creada correctamente" {
-		t.Errorf("unexpected response message: %s", resp.Message)
-	}
+       if resp.Message != "Funciones de nómina ejecutadas correctamente" {
+               t.Errorf("unexpected response message: %s", resp.Message)
+       }
 
-	if resp.Data == nil {
-		t.Fatalf("expected response data")
-	}
-	dataBytes, err := json.Marshal(resp.Data)
-	if err != nil {
-		t.Fatalf("failed to marshal data: %v", err)
-	}
-	var nomina models.Nomina
-	if err := json.Unmarshal(dataBytes, &nomina); err != nil {
-		t.Fatalf("failed to unmarshal nomina: %v", err)
-	}
-	if nomina.PK_ID_NOMINA == 0 {
-		t.Errorf("expected valid nomina ID, got %d", nomina.PK_ID_NOMINA)
-	}
+       dataMap, ok := resp.Data.(map[string]interface{})
+       if !ok {
+               t.Fatalf("expected response data to be a map, got %T", resp.Data)
+       }
+       nominaPayload, ok := dataMap["nomina"]
+       if !ok {
+               t.Fatalf("expected 'nomina' field in response data")
+       }
+
+       dataBytes, err := json.Marshal(nominaPayload)
+       if err != nil {
+               t.Fatalf("failed to marshal nomina payload: %v", err)
+       }
+       var nomina models.Nomina
+       if err := json.Unmarshal(dataBytes, &nomina); err != nil {
+               t.Fatalf("failed to unmarshal nomina: %v", err)
+       }
+       if nomina.PK_ID_NOMINA == 0 {
+               t.Errorf("expected valid nomina ID, got %d", nomina.PK_ID_NOMINA)
+       }
 }


### PR DESCRIPTION
## Summary
- send `p_nomina_id` and `p_fecha` when invoking nomina generation and verification
- assert updated response message and schema including `nomina` payload

## Testing
- `go test ./tests -run NominaGenerarYVerificar -count=1 -v` *(fails: field: models.Producto.IMAGEN, unsupport field type)*

------
https://chatgpt.com/codex/tasks/task_e_68b4810608908325a89bd6536aa344fa