### PR TITLE
use int64 for domicilio IDs

### DIFF
--- a/controllers/DomicilioController.go
+++ b/controllers/DomicilioController.go
@@ -127,7 +127,7 @@ func (c *DomicilioController) GetAll() {
 // @Router /domicilios/search [get]
 func (c *DomicilioController) GetById() {
 	o := orm.NewOrm()
-	id, err := c.GetInt("id")
+	id, err := c.GetInt64("id")
 	if err != nil || id == 0 {
 		c.Ctx.Output.SetStatus(http.StatusBadRequest)
 		c.Data["json"] = models.ApiResponse{
@@ -410,7 +410,7 @@ func (c *DomicilioController) Put() {
 
 	// Obtener el ID del domicilio
 	idStr := c.GetString("id")
-	id, err := strconv.Atoi(idStr)
+	id, err := strconv.ParseInt(idStr, 10, 64)
 	if err != nil || id == 0 {
 		c.Ctx.Output.SetStatus(http.StatusBadRequest)
 		c.Data["json"] = models.ApiResponse{
@@ -513,7 +513,7 @@ func (c *DomicilioController) Delete() {
 	o := orm.NewOrm()
 
 	idStr := c.GetString("id")
-	id, err := strconv.Atoi(idStr)
+	id, err := strconv.ParseInt(idStr, 10, 64)
 	if err != nil || id == 0 {
 		c.Ctx.Output.SetStatus(http.StatusBadRequest)
 		c.Data["json"] = models.ApiResponse{
@@ -559,7 +559,7 @@ func (c *DomicilioController) Delete() {
 // @Security BearerAuth
 // @Router /domicilios/asignar [post]
 func (c *DomicilioController) AsignarDomiciliario() {
-	domicilioID, _ := c.GetInt("domicilio_id")
+	domicilioID, _ := c.GetInt64("domicilio_id")
 	trabajadorID, _ := c.GetInt("trabajador_id")
 
 	o := orm.NewOrm()

--- a/controllers/PedidoController.go
+++ b/controllers/PedidoController.go
@@ -207,7 +207,7 @@ func (c *PedidoController) Post() {
 // @Router /pedidos/asignar-domicilio [post]
 func (c *PedidoController) AssignDomicilio() {
 	pedidoID, _ := c.GetInt("pedido_id")
-	domicilioID, _ := c.GetInt("domicilio_id")
+	domicilioID, _ := c.GetInt64("domicilio_id")
 	o := orm.NewOrm()
 
 	// Leer pedido

--- a/models/Domicilio.go
+++ b/models/Domicilio.go
@@ -8,7 +8,7 @@ import (
 )
 
 type Domicilio struct {
-	PK_ID_DOMICILIO         int             `orm:"column(pk_id_domicilio);pk;auto" json:"domicilioId"`
+	PK_ID_DOMICILIO         int64           `orm:"column(pk_id_domicilio);pk;auto" json:"domicilioId"`
 	DIRECCION               string          `orm:"column(direccion);type(text)" json:"direccion"`
 	TELEFONO                string          `orm:"column(telefono);type(text)" json:"telefono"`
 	ESTADO_DOMICILIO        EstadoDomicilio `orm:"column(estado_domicilio);type(text)" json:"estado"`

--- a/models/Pedido.go
+++ b/models/Pedido.go
@@ -13,7 +13,7 @@ type Pedido struct {
 	HORA                 string       `orm:"column(hora);type(time)" json:"horaPedido"`
 	DELIVERY             bool         `orm:"column(delivery);type(boolean)" json:"delivery"`
 	ESTADO_PEDIDO        EstadoPedido `orm:"column(estado_pedido)" json:"estadoPedido"`
-	PK_ID_DOMICILIO      *int         `orm:"column(pk_id_domicilio);null" json:"domicilioId,omitempty"`
+	PK_ID_DOMICILIO      *int64       `orm:"column(pk_id_domicilio);null" json:"domicilioId,omitempty"`
 	PK_ID_PAGO           *int         `orm:"column(pk_id_pago);null" json:"pagoId"`
 	PK_ID_RESTAURANTE    *int         `orm:"column(pk_id_restaurante);null" json:"restauranteId"`
 	PK_DOCUMENTO_CLIENTE int64        `orm:"column(pk_documento_cliente)" json:"documentoCliente"`


### PR DESCRIPTION
## Summary
- use int64 for domicilio primary key and associated relations
- update controllers to parse domicilio IDs as int64

## Testing
- `go test ./...` *(fails: field: models.Producto.IMAGEN, unsupport field type , may be miss setting tag)*

------
https://chatgpt.com/codex/tasks/task_e_68b48a790de883258fa7a49a1eb38a3b