### PR TITLE
Refactor Pedido ID and time types

### DIFF
--- a/controllers/PedidoClienteController.go
+++ b/controllers/PedidoClienteController.go
@@ -146,7 +146,7 @@ func (c *PedidoClienteController) Post() {
 		}
 
 		// Validar que el pedido existe
-		pedido := models.Pedido{PK_ID_PEDIDO: relacion.PK_ID_PEDIDO}
+		pedido := models.Pedido{PK_ID_PEDIDO: int64(relacion.PK_ID_PEDIDO)}
 		if err := pcReadPedido(txOrm, &pedido); err != nil {
 			c.Ctx.Output.SetStatus(http.StatusOK)
 			c.Data["json"] = models.ApiResponse{

--- a/controllers/PedidoController.go
+++ b/controllers/PedidoController.go
@@ -161,7 +161,7 @@ func (c *PedidoController) Post() {
 	// Construimos el pedido conforme a las reglas
 	var pedido models.Pedido
 	pedido.FECHA = now
-	pedido.HORA = now.Format("15:04:05") // string HH:mm:ss
+	pedido.HORA = now
 	pedido.ESTADO_PEDIDO = models.EstadoPedidoIniciado
 
 	// Si el cliente mandó delivery en el body, lo respetamos; si no, false
@@ -206,7 +206,7 @@ func (c *PedidoController) Post() {
 // @Security BearerAuth
 // @Router /pedidos/asignar-domicilio [post]
 func (c *PedidoController) AssignDomicilio() {
-	pedidoID, _ := c.GetInt("pedido_id")
+	pedidoID, _ := c.GetInt64("pedido_id")
 	domicilioID, _ := c.GetInt64("domicilio_id")
 	o := orm.NewOrm()
 
@@ -246,8 +246,8 @@ func (c *PedidoController) AssignDomicilio() {
 // @Security BearerAuth
 // @Router /pedidos/asignar-pago [post]
 func (c *PedidoController) AssignPago() {
-	pedidoID, _ := c.GetInt("pedido_id")
-	pagoID, _ := c.GetInt("pago_id")
+	pedidoID, _ := c.GetInt64("pedido_id")
+	pagoID, _ := c.GetInt64("pago_id")
 	o := orm.NewOrm()
 
 	// Leer pedido
@@ -270,7 +270,7 @@ func (c *PedidoController) AssignPago() {
 	}
 
 	// También cambiamos el estado en la tabla PAGO
-	pago := models.Pago{PK_ID_PAGO: int64(pagoID)}
+	pago := models.Pago{PK_ID_PAGO: pagoID}
 	if err := o.Read(&pago); err == nil {
 		pago.ESTADO_PAGO = models.EstadoPagoPagado
 		o.Update(&pago, "ESTADO_PAGO")
@@ -294,7 +294,7 @@ func (c *PedidoController) AssignPago() {
 // @Security BearerAuth
 // @Router /pedidos/actualizar-estado [put]
 func (c *PedidoController) UpdateEstadoPedido() {
-	pedidoID, _ := c.GetInt("pedido_id")
+	pedidoID, _ := c.GetInt64("pedido_id")
 	estado := c.GetString("estado")
 
 	o := orm.NewOrm()

--- a/controllers/pedido_controller_test.go
+++ b/controllers/pedido_controller_test.go
@@ -231,7 +231,7 @@ func TestPedidoGetAllWithResults(t *testing.T) {
 	MockQuery = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
 		cols := []string{"pk_id_pedido", "fecha", "hora", "delivery", "estado_pedido", "pk_id_domicilio", "pk_id_pago", "pk_id_restaurante", "updated_at", "updated_by"}
 		now := time.Now()
-		vals := [][]driver.Value{{int64(1), now, "12:00:00", false, "iniciado", nil, nil, nil, now, "tester"}}
+		vals := [][]driver.Value{{int64(1), now, now, false, "iniciado", nil, nil, nil, now, "tester"}}
 		return &mockRows{columns: cols, values: vals}, nil
 	}
 	defer func() { MockQuery = nil }()
@@ -283,7 +283,7 @@ func TestPedidoAssignDomicilioUpdateError(t *testing.T) {
 	MockQuery = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
 		cols := []string{"pk_id_pedido", "fecha", "hora", "delivery", "estado_pedido", "pk_id_domicilio", "pk_id_pago", "pk_id_restaurante", "updated_at", "updated_by"}
 		now := time.Now()
-		vals := [][]driver.Value{{int64(1), now, "12:00:00", false, "iniciado", nil, nil, nil, now, "tester"}}
+		vals := [][]driver.Value{{int64(1), now, now, false, "iniciado", nil, nil, nil, now, "tester"}}
 		return &mockRows{columns: cols, values: vals}, nil
 	}
 	MockExec = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Result, error) {
@@ -313,7 +313,7 @@ func TestPedidoAssignDomicilioSuccess(t *testing.T) {
 	MockQuery = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
 		cols := []string{"pk_id_pedido", "fecha", "hora", "delivery", "estado_pedido", "pk_id_domicilio", "pk_id_pago", "pk_id_restaurante", "updated_at", "updated_by"}
 		now := time.Now()
-		vals := [][]driver.Value{{int64(1), now, "12:00:00", false, "iniciado", nil, nil, nil, now, "tester"}}
+		vals := [][]driver.Value{{int64(1), now, now, false, "iniciado", nil, nil, nil, now, "tester"}}
 		return &mockRows{columns: cols, values: vals}, nil
 	}
 	MockExec = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Result, error) {
@@ -343,7 +343,7 @@ func TestPedidoAssignPagoUpdateError(t *testing.T) {
 	MockQuery = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
 		cols := []string{"pk_id_pedido", "fecha", "hora", "delivery", "estado_pedido", "pk_id_domicilio", "pk_id_pago", "pk_id_restaurante", "updated_at", "updated_by"}
 		now := time.Now()
-		vals := [][]driver.Value{{int64(1), now, "12:00:00", false, "iniciado", nil, nil, nil, now, "tester"}}
+		vals := [][]driver.Value{{int64(1), now, now, false, "iniciado", nil, nil, nil, now, "tester"}}
 		return &mockRows{columns: cols, values: vals}, nil
 	}
 	MockExec = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Result, error) {
@@ -376,12 +376,12 @@ func TestPedidoAssignPagoSuccess(t *testing.T) {
 			qCount++
 			cols := []string{"pk_id_pedido", "fecha", "hora", "delivery", "estado_pedido", "pk_id_domicilio", "pk_id_pago", "pk_id_restaurante", "updated_at", "updated_by"}
 			now := time.Now()
-			vals := [][]driver.Value{{int64(1), now, "12:00:00", false, "iniciado", nil, nil, nil, now, "tester"}}
+			vals := [][]driver.Value{{int64(1), now, now, false, "iniciado", nil, nil, nil, now, "tester"}}
 			return &mockRows{columns: cols, values: vals}, nil
 		}
 		cols := []string{"pk_id_pago", "fecha", "hora", "monto", "estado_pago", "pk_id_metodo_pago", "updated_at", "updated_by"}
 		now := time.Now()
-		vals := [][]driver.Value{{int64(1), now, "12:00:00", int64(100), "pendiente", int64(1), now, "tester"}}
+		vals := [][]driver.Value{{int64(1), now, now, int64(100), "pendiente", int64(1), now, "tester"}}
 		return &mockRows{columns: cols, values: vals}, nil
 	}
 	MockExec = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Result, error) {
@@ -411,7 +411,7 @@ func TestPedidoUpdateEstadoPedidoUpdateError(t *testing.T) {
 	MockQuery = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
 		cols := []string{"pk_id_pedido", "fecha", "hora", "delivery", "estado_pedido", "pk_id_domicilio", "pk_id_pago", "pk_id_restaurante", "updated_at", "updated_by"}
 		now := time.Now()
-		vals := [][]driver.Value{{int64(1), now, "12:00:00", false, "iniciado", nil, nil, nil, now, "tester"}}
+		vals := [][]driver.Value{{int64(1), now, now, false, "iniciado", nil, nil, nil, now, "tester"}}
 		return &mockRows{columns: cols, values: vals}, nil
 	}
 	MockExec = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Result, error) {
@@ -441,7 +441,7 @@ func TestPedidoUpdateEstadoPedidoSuccess(t *testing.T) {
 	MockQuery = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
 		cols := []string{"pk_id_pedido", "fecha", "hora", "delivery", "estado_pedido", "pk_id_domicilio", "pk_id_pago", "pk_id_restaurante", "updated_at", "updated_by"}
 		now := time.Now()
-		vals := [][]driver.Value{{int64(1), now, "12:00:00", false, "iniciado", nil, nil, nil, now, "tester"}}
+		vals := [][]driver.Value{{int64(1), now, now, false, "iniciado", nil, nil, nil, now, "tester"}}
 		return &mockRows{columns: cols, values: vals}, nil
 	}
 	MockExec = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Result, error) {

--- a/models/Pedido.go
+++ b/models/Pedido.go
@@ -8,14 +8,14 @@ import (
 )
 
 type Pedido struct {
-	PK_ID_PEDIDO         int          `orm:"column(pk_id_pedido);pk;auto" json:"pedidoId"`
+	PK_ID_PEDIDO         int64        `orm:"column(pk_id_pedido);pk;auto" json:"pedidoId"`
 	FECHA                time.Time    `orm:"column(fecha);type(date)" json:"fechaPedido"`
-	HORA                 string       `orm:"column(hora);type(time)" json:"horaPedido"`
+	HORA                 time.Time    `orm:"column(hora);type(time)" json:"horaPedido"`
 	DELIVERY             bool         `orm:"column(delivery);type(boolean)" json:"delivery"`
 	ESTADO_PEDIDO        EstadoPedido `orm:"column(estado_pedido)" json:"estadoPedido"`
 	PK_ID_DOMICILIO      *int64       `orm:"column(pk_id_domicilio);null" json:"domicilioId,omitempty"`
-	PK_ID_PAGO           *int         `orm:"column(pk_id_pago);null" json:"pagoId"`
-	PK_ID_RESTAURANTE    *int         `orm:"column(pk_id_restaurante);null" json:"restauranteId"`
+	PK_ID_PAGO           *int64       `orm:"column(pk_id_pago);null" json:"pagoId"`
+	PK_ID_RESTAURANTE    *int64       `orm:"column(pk_id_restaurante);null" json:"restauranteId"`
 	PK_DOCUMENTO_CLIENTE int64        `orm:"column(pk_documento_cliente)" json:"documentoCliente"`
 	UPDATED_AT           time.Time    `orm:"column(updated_at);type(timestamp);auto_now" json:"updatedAt"`
 	UPDATED_BY           string       `orm:"column(updated_by)" json:"updatedBy"`
@@ -47,10 +47,12 @@ func (d Pedido) MarshalJSON() ([]byte, error) {
 	type Alias Pedido
 	return json.Marshal(&struct {
 		FECHA      string `json:"fechaPedido"`
+		HORA       string `json:"horaPedido"`
 		UPDATED_AT string `json:"updatedAt"`
 		Alias
 	}{
 		FECHA:      d.FECHA.Format("02-01-2006"),
+		HORA:       d.HORA.Format("15:04:05"),
 		UPDATED_AT: d.UPDATED_AT.Format("02-01-2006 15:04:05"),
 		Alias:      (Alias)(d),
 	})


### PR DESCRIPTION
## Summary
- Use int64 for Pedido identifiers and foreign keys
- Store Pedido time as `time.Time` and format on JSON marshal
- Adjust controllers and tests for new Pedido types

## Testing
- `go build ./...`
- `go test ./controllers -run Pedido -count=1` *(fails: field: models.Producto.IMAGEN, unsupport field type , may be miss setting tag)*

------
https://chatgpt.com/codex/tasks/task_e_68b48cfe60f883259e7a4cd100d14149