### PR TITLE
Mark product ID as part of order detail primary key

### DIFF
--- a/models/DetallePedido.go
+++ b/models/DetallePedido.go
@@ -4,7 +4,7 @@ import "github.com/beego/beego/v2/client/orm"
 
 type DetallePedido struct {
 	PKIDPedido   int64 `orm:"column(pk_id_pedido);pk" json:"pedidoId"`
-	PKIDProducto int64 `orm:"column(pk_id_producto)" json:"productoId"` // part of composite PK
+	PKIDProducto int64 `orm:"column(pk_id_producto);pk" json:"productoId"` // part of composite PK
 	Precio       int64 `orm:"column(precio);type(bigint)" json:"precio"`
 	Cantidad     int   `orm:"column(cantidad)" json:"cantidad"`
 }


### PR DESCRIPTION
## Summary
- mark `pk_id_producto` as part of the `detalle_pedido` composite primary key

## Testing
- `go test ./...` *(fails: field: models.DetallePedido.PKIDProducto, one model must have one pk field only)*

------
https://chatgpt.com/codex/tasks/task_e_68b4bde3eed083259d5cceb79f48ee87