### PR TITLE
Use int64 and time.Time for reservations

### DIFF
--- a/controllers/ReservaController.go
+++ b/controllers/ReservaController.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"restaurante/database"
 	"restaurante/models"
-	"strconv"
 	"time"
 
 	"github.com/beego/beego/v2/client/orm"
@@ -81,10 +80,7 @@ func (c *ReservaController) GetAll() {
 		reservas[i].CREATED_AT = reservas[i].CREATED_AT.In(database.BogotaZone)
 		reservas[i].UPDATED_AT = reservas[i].UPDATED_AT.In(database.BogotaZone)
 		reservas[i].FECHA = reservas[i].FECHA.UTC()
-
-		if len(reservas[i].HORA) >= 19 {
-			reservas[i].HORA = reservas[i].HORA[11:19]
-		}
+		reservas[i].HORA = reservas[i].HORA.UTC()
 	}
 
 	c.Ctx.Output.SetStatus(http.StatusOK)
@@ -108,7 +104,7 @@ func (c *ReservaController) GetAll() {
 // @Router /reservas/search [get]
 func (c *ReservaController) GetById() {
 	o := ormNew()
-	id, err := c.GetInt("id")
+	id, err := c.GetInt64("id")
 
 	if err != nil || id == 0 {
 		c.Ctx.Output.SetStatus(http.StatusBadRequest)
@@ -137,9 +133,7 @@ func (c *ReservaController) GetById() {
 	reserva.FECHA = reserva.FECHA.In(database.BogotaZone)
 	reserva.CREATED_AT = reserva.CREATED_AT.In(database.BogotaZone)
 	reserva.UPDATED_AT = reserva.UPDATED_AT.In(database.BogotaZone)
-	if len(reserva.HORA) >= 19 {
-		reserva.HORA = reserva.HORA[11:19] // Formato HH:MM:SS
-	}
+	reserva.HORA = reserva.HORA.UTC()
 
 	c.Ctx.Output.SetStatus(http.StatusOK)
 	c.Data["json"] = models.ApiResponse{
@@ -205,7 +199,7 @@ func (c *ReservaController) Post() {
 
 	// Procesar HORA
 	if horaStr, ok := input["horaReserva"].(string); ok && horaStr != "" {
-		_, err := time.Parse("15:04:05", horaStr)
+		parsedHora, err := time.Parse("15:04:05", horaStr)
 		if err != nil {
 			c.Ctx.Output.SetStatus(http.StatusBadRequest)
 			c.Data["json"] = models.ApiResponse{
@@ -216,7 +210,7 @@ func (c *ReservaController) Post() {
 			c.ServeJSON()
 			return
 		}
-		reserva.HORA = horaStr
+		reserva.HORA = parsedHora
 	} else {
 		c.Ctx.Output.SetStatus(http.StatusBadRequest)
 		c.Data["json"] = models.ApiResponse{
@@ -333,8 +327,7 @@ func (c *ReservaController) Put() {
 	o := ormNew()
 
 	// Obtener el ID de la reserva desde los parámetros
-	idStr := c.GetString("id")
-	id, err := strconv.Atoi(idStr)
+	id, err := c.GetInt64("id")
 	if err != nil || id == 0 {
 		c.Ctx.Output.SetStatus(http.StatusBadRequest)
 		c.Data["json"] = models.ApiResponse{
@@ -388,7 +381,7 @@ func (c *ReservaController) Put() {
 	}
 
 	if horaStr, ok := input["horaReserva"].(string); ok && horaStr != "" {
-		_, err := time.Parse("15:04:05", horaStr)
+		parsedHora, err := time.Parse("15:04:05", horaStr)
 		if err != nil {
 			c.Ctx.Output.SetStatus(http.StatusBadRequest)
 			c.Data["json"] = models.ApiResponse{
@@ -399,7 +392,7 @@ func (c *ReservaController) Put() {
 			c.ServeJSON()
 			return
 		}
-		reserva.HORA = horaStr
+		reserva.HORA = parsedHora
 	}
 
 	if personas, ok := input["personas"].(float64); ok {
@@ -523,9 +516,7 @@ func (c *ReservaController) GetByParameter() {
 		reservas[i].CREATED_AT = reservas[i].CREATED_AT.In(database.BogotaZone)
 		reservas[i].UPDATED_AT = reservas[i].UPDATED_AT.In(database.BogotaZone)
 		reservas[i].FECHA = reservas[i].FECHA.UTC()
-		if len(reservas[i].HORA) >= 19 {
-			reservas[i].HORA = reservas[i].HORA[11:19]
-		}
+		reservas[i].HORA = reservas[i].HORA.UTC()
 	}
 
 	c.Ctx.Output.SetStatus(http.StatusOK)
@@ -551,8 +542,7 @@ func (c *ReservaController) Delete() {
 	o := ormNew()
 
 	// Obtener el ID de la reserva desde los parámetros
-	idStr := c.GetString("id")
-	id, err := strconv.Atoi(idStr)
+	id, err := c.GetInt64("id")
 	if err != nil || id == 0 {
 		c.Ctx.Output.SetStatus(http.StatusBadRequest)
 		c.Data["json"] = models.ApiResponse{

--- a/controllers/reserva_controller_test.go
+++ b/controllers/reserva_controller_test.go
@@ -222,12 +222,13 @@ func TestReservaDeleteInvalidID(t *testing.T) {
 }
 
 func TestReservaGetAllSuccess(t *testing.T) {
+	hora, _ := time.Parse(time.RFC3339, "2024-01-01T12:00:00Z")
 	db := []models.Reserva{{
-		PK_ID_RESERVA: 1,
+		PK_ID_RESERVA: int64(1),
 		CREATED_AT:    time.Now(),
 		UPDATED_AT:    time.Now(),
 		FECHA:         time.Now(),
-		HORA:          "2024-01-01T12:00:00Z",
+		HORA:          hora,
 	}}
 	ormNew = func() orm.Ormer { return nil }
 	queryAllReservas = func(o orm.Ormer, reservas *[]models.Reserva) (int64, error) {
@@ -249,12 +250,13 @@ func TestReservaGetAllSuccess(t *testing.T) {
 }
 
 func TestReservaGetByIdScenarios(t *testing.T) {
-	db := map[int]models.Reserva{1: {
-		PK_ID_RESERVA: 1,
+	hora, _ := time.Parse(time.RFC3339, "2024-01-01T12:00:00Z")
+	db := map[int64]models.Reserva{1: {
+		PK_ID_RESERVA: int64(1),
 		FECHA:         time.Now(),
 		CREATED_AT:    time.Now(),
 		UPDATED_AT:    time.Now(),
-		HORA:          "2024-01-01T12:00:00Z",
+		HORA:          hora,
 	}}
 	ormNew = func() orm.Ormer { return nil }
 	readReserva = func(o orm.Ormer, r *models.Reserva) error {
@@ -488,12 +490,13 @@ func TestReservaPostSuccess(t *testing.T) {
 }
 
 func TestReservaPutScenarios(t *testing.T) {
-	db := map[int]models.Reserva{1: {
-		PK_ID_RESERVA: 1,
+	hora, _ := time.Parse("15:04:05", "12:00:00")
+	db := map[int64]models.Reserva{1: {
+		PK_ID_RESERVA: int64(1),
 		FECHA:         time.Now(),
 		CREATED_AT:    time.Now(),
 		UPDATED_AT:    time.Now(),
-		HORA:          "12:00:00",
+		HORA:          hora,
 	}}
 	ormNew = func() orm.Ormer { return nil }
 	readReserva = func(o orm.Ormer, r *models.Reserva) error {
@@ -637,13 +640,14 @@ func TestReservaPutScenarios(t *testing.T) {
 }
 
 func TestReservaGetByParameterSuccess(t *testing.T) {
+	hora, _ := time.Parse(time.RFC3339, "2024-01-01T12:00:00Z")
 	db := []models.Reserva{{
-		PK_ID_RESERVA:  1,
+		PK_ID_RESERVA:  int64(1),
 		PK_ID_CONTACTO: 123,
 		FECHA:          time.Now(),
 		CREATED_AT:     time.Now(),
 		UPDATED_AT:     time.Now(),
-		HORA:           "2024-01-01T12:00:00Z",
+		HORA:           hora,
 	}}
 	ormNew = func() orm.Ormer { return nil }
 	queryReservasByParam = func(o orm.Ormer, contacto int64, fecha time.Time, useContacto, useFecha bool, reservas *[]models.Reserva) (int64, error) {
@@ -666,7 +670,7 @@ func TestReservaGetByParameterSuccess(t *testing.T) {
 }
 
 func TestReservaDeleteScenarios(t *testing.T) {
-	db := map[int]models.Reserva{1: {PK_ID_RESERVA: 1}}
+	db := map[int64]models.Reserva{1: {PK_ID_RESERVA: int64(1)}}
 	ormNew = func() orm.Ormer { return nil }
 	readReserva = func(o orm.Ormer, r *models.Reserva) error {
 		res, ok := db[r.PK_ID_RESERVA]
@@ -727,10 +731,10 @@ func TestReservaDeleteScenarios(t *testing.T) {
 
 func TestReservaPutInvalidEstadoIgnored(t *testing.T) {
 	pend := models.EstadoReservaPendiente
-	db := map[int]models.Reserva{1: {PK_ID_RESERVA: 1, ESTADO_RESERVA: &pend}}
+	db := map[int64]models.Reserva{1: {PK_ID_RESERVA: int64(1), ESTADO_RESERVA: &pend}}
 	ormNew = func() orm.Ormer { return nil }
 	readReserva = func(o orm.Ormer, r *models.Reserva) error {
-		if res, ok := db[int(r.PK_ID_RESERVA)]; ok {
+		if res, ok := db[r.PK_ID_RESERVA]; ok {
 			*r = res
 			return nil
 		}

--- a/models/Reserva.go
+++ b/models/Reserva.go
@@ -8,9 +8,9 @@ import (
 )
 
 type Reserva struct {
-	PK_ID_RESERVA     int            `orm:"column(pk_id_reserva);pk;auto" json:"reservaId"`
+	PK_ID_RESERVA     int64          `orm:"column(pk_id_reserva);pk;auto" json:"reservaId"`
 	FECHA             time.Time      `orm:"column(fecha);type(date)" json:"fechaReserva"`
-	HORA              string         `orm:"column(hora);type(time);size(8)" json:"horaReserva"`
+	HORA              time.Time      `orm:"column(hora);type(time);size(8)" json:"horaReserva"`
 	PERSONAS          int            `orm:"column(personas)" json:"personas"`
 	PK_ID_CONTACTO    int64          `orm:"column(pk_id_contacto)" json:"contactoId"`
 	PK_ID_RESTAURANTE int64          `orm:"column(pk_id_restaurante)" json:"restauranteId"`
@@ -34,9 +34,11 @@ func (t Reserva) MarshalJSON() ([]byte, error) {
 	type Alias Reserva
 	return json.Marshal(&struct {
 		FECHA string `json:"fechaReserva"`
+		HORA  string `json:"horaReserva"`
 		Alias
 	}{
 		FECHA: t.FECHA.Format("02-01-2006"),
+		HORA:  t.HORA.Format("15:04:05"),
 		Alias: (Alias)(t),
 	})
 }


### PR DESCRIPTION
## Summary
- use `int64` for `PK_ID_RESERVA` and `time.Time` for `HORA`
- adjust reservation controller for new time type and ID handling
- update reservation tests to match

## Testing
- `go test ./models -run Reserva -count=1` *(fails: field: models.DetallePedido.PKIDProducto, one model must have one pk field only)*

------
https://chatgpt.com/codex/tasks/task_e_68b4c060db7c832592ab9d651e5708c7