### PR TITLE
Refactor Restaurante model types

### DIFF
--- a/controllers/RestauranteController.go
+++ b/controllers/RestauranteController.go
@@ -38,13 +38,6 @@ func (c *RestauranteController) GetAll() {
 		c.ServeJSON()
 		return
 	}
-	// Formatear HORA si es necesario
-	for i := range restaurantes {
-		if len(restaurantes[i].HORA_APERTURA) > 19 {
-			restaurantes[i].HORA_APERTURA = restaurantes[i].HORA_APERTURA[11:19] // Solo toma HH:mm:ss
-		}
-	}
-
 	c.Ctx.Output.SetStatus(http.StatusOK)
 	c.Data["json"] = models.ApiResponse{
 		Code:    http.StatusOK,
@@ -79,7 +72,7 @@ func (c *RestauranteController) GetById() {
 		return
 	}
 
-	restaurante := models.Restaurante{PK_ID_RESTAURANTE: id}
+	restaurante := models.Restaurante{PK_ID_RESTAURANTE: int64(id)}
 
 	err = o.Read(&restaurante)
 	if err == orm.ErrNoRows {
@@ -177,7 +170,7 @@ func (c *RestauranteController) Put() {
 		return
 	}
 
-	restaurante := models.Restaurante{PK_ID_RESTAURANTE: id}
+	restaurante := models.Restaurante{PK_ID_RESTAURANTE: int64(id)}
 
 	if o.Read(&restaurante) == nil {
 		var updatedRestaurante models.Restaurante
@@ -193,7 +186,7 @@ func (c *RestauranteController) Put() {
 		}
 
 		// Asignar el ID original al modelo actualizado
-		updatedRestaurante.PK_ID_RESTAURANTE = id
+		updatedRestaurante.PK_ID_RESTAURANTE = int64(id)
 
 		_, err := o.Update(&updatedRestaurante)
 		if err != nil {
@@ -251,7 +244,7 @@ func (c *RestauranteController) Delete() {
 		return
 	}
 
-	restaurante := models.Restaurante{PK_ID_RESTAURANTE: id}
+	restaurante := models.Restaurante{PK_ID_RESTAURANTE: int64(id)}
 
 	if _, err := o.Delete(&restaurante); err == nil {
 		c.Ctx.Output.SetStatus(http.StatusOK)

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -4001,13 +4001,15 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "horaApertura": {
-                    "type": "string"
+                    "type": "string",
+                    "format": "date-time"
                 },
                 "nombreRestaurante": {
                     "type": "string"
                 },
                 "restauranteId": {
-                    "type": "integer"
+                    "type": "integer",
+                    "format": "int64"
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -3994,13 +3994,15 @@
             "type": "object",
             "properties": {
                 "horaApertura": {
-                    "type": "string"
+                    "type": "string",
+                    "format": "date-time"
                 },
                 "nombreRestaurante": {
                     "type": "string"
                 },
                 "restauranteId": {
-                    "type": "integer"
+                    "type": "integer",
+                    "format": "int64"
                 }
             }
         },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -20,6 +20,7 @@ definitions:
         type: string
       horaApertura:
         type: string
+        format: date-time
       horaCierre:
         type: string
     type: object
@@ -269,6 +270,7 @@ definitions:
     properties:
       horaApertura:
         type: string
+        format: date-time
       nombreRestaurante:
         type: string
       restauranteId:

--- a/models/Restaurante.go
+++ b/models/Restaurante.go
@@ -1,12 +1,16 @@
 package models
 
-import "github.com/beego/beego/v2/client/orm"
+import (
+	"time"
+
+	"github.com/beego/beego/v2/client/orm"
+)
 
 type Restaurante struct {
-	PK_ID_RESTAURANTE    int    `orm:"column(pk_id_restaurante);pk" json:"restauranteId"`
-	NOMBRE_RESTAURANTE   string `orm:"column(nombre_restaurante)" json:"nombreRestaurante"`
-	HORA_APERTURA        string `orm:"column(hora_apertura);type(time)" json:"horaApertura"`
-	PK_ID_CAMBIO_HORARIO *int   `orm:"column(pk_id_cambio_horario);null" json:"-"`
+	PK_ID_RESTAURANTE    int64     `orm:"column(pk_id_restaurante);pk" json:"restauranteId"`
+	NOMBRE_RESTAURANTE   string    `orm:"column(nombre_restaurante)" json:"nombreRestaurante"`
+	HORA_APERTURA        time.Time `orm:"column(hora_apertura);type(time)" json:"horaApertura"`
+	PK_ID_CAMBIO_HORARIO int64     `orm:"column(pk_id_cambio_horario);null" json:"-"`
 }
 
 func (t *Restaurante) TableName() string {

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -492,7 +492,8 @@
             "type": "object",
             "properties": {
                 "horaApertura": {
-                    "type": "string"
+                    "type": "string",
+                    "format": "date-time"
                 },
                 "nombreRestaurante": {
                     "type": "string"

--- a/swagger/swagger.yml
+++ b/swagger/swagger.yml
@@ -42,6 +42,7 @@ definitions:
         format: datetime
       horaApertura:
         type: string
+        format: date-time
         format: datetime
       horaCierre:
         type: string
@@ -351,6 +352,7 @@ definitions:
     properties:
       horaApertura:
         type: string
+        format: date-time
       nombreRestaurante:
         type: string
       restauranteId:


### PR DESCRIPTION
## Summary
- use int64 for restaurante primary keys
- switch hora apertura to time.Time
- document time field format in swagger specs

## Testing
- `go test ./...` *(fails: field: models.DetallePedido.PKIDProducto, one model must have one pk field only)*

------
https://chatgpt.com/codex/tasks/task_e_68b4c1ca70908325a9088429ed03cb57