### PR TITLE
Mark Dia field as primary key in RestauranteDia model

### DIFF
--- a/models/RestauranteDia.go
+++ b/models/RestauranteDia.go
@@ -3,8 +3,8 @@ package models
 import "github.com/beego/beego/v2/client/orm"
 
 type RestauranteDia struct {
-	PKIDRestaurante int64     `orm:"column(pk_id_restaurante);pk" json:"restauranteId"`
-	Dia             DiaSemana `orm:"column(dia);type(text)" json:"dia"`
+       PKIDRestaurante int64     `orm:"column(pk_id_restaurante);pk" json:"restauranteId"`
+       Dia             DiaSemana `orm:"column(dia);type(text);pk" json:"dia"`
 }
 
 func (r *RestauranteDia) TableName() string {


### PR DESCRIPTION
## Summary
- Make Dia field part of the primary key in RestauranteDia

## Testing
- `timeout 10 go test ./...` *(fails: field: models.DetallePedido.PKIDProducto, one model must have one pk field only)*

------
https://chatgpt.com/codex/tasks/task_e_68b4c31e0fa083259703a5374e64000f