### PR TITLE
Pass payroll date into auto-generation procedure

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,9 @@ Go-based REST API for managing restaurant operations such as customers, orders, 
 - `POST /producto_pedido` and `PUT /producto_pedido` no longer accept `precio` in the payload; the
   database trigger assigns it automatically.
 - **Payroll (nómina)** operations:
-  - `POST /nominas` accepts optional `generar_nomina_automatica` and
-    `verificar_nomina` flags to auto-generate payments and verify payroll records.
+- `POST /nominas` accepts optional `generar_nomina_automatica` and
+  `verificar_nomina` flags to auto-generate payments (passing the payroll
+  date as `p_fecha`) and verify payroll records without requiring an ID.
 - `PUT /nominas?id=...` transitions a payroll to `pago`.
 - `DELETE /nominas?id=...` performs a logical deletion setting the state to `no pago`.
 

--- a/controllers/NominaController.go
+++ b/controllers/NominaController.go
@@ -140,7 +140,7 @@ func (c *NominaController) Post() {
 
 	// Ejecutar funciones adicionales si se solicitan
 	if gen {
-		if _, err := o.Raw("CALL generar_nomina_automatica(?)", input.PK_ID_NOMINA).Exec(); err != nil {
+		if _, err := o.Raw("CALL generar_nomina_automatica(?, ?)", input.PK_ID_NOMINA, input.FECHA).Exec(); err != nil {
 			c.Ctx.Output.SetStatus(http.StatusInternalServerError)
 			c.Data["json"] = models.ApiResponse{
 				Code:    http.StatusInternalServerError,
@@ -153,7 +153,7 @@ func (c *NominaController) Post() {
 	}
 
 	if ver {
-		if _, err := o.Raw("CALL verificar_nomina(?)", input.PK_ID_NOMINA).Exec(); err != nil {
+		if _, err := o.Raw("CALL verificar_nomina()").Exec(); err != nil {
 			c.Ctx.Output.SetStatus(http.StatusInternalServerError)
 			c.Data["json"] = models.ApiResponse{
 				Code:    http.StatusInternalServerError,

--- a/main.go
+++ b/main.go
@@ -49,7 +49,7 @@ func generarNominaAutomatica() {
 			if _, err := o.Insert(&nomina); err != nil {
 				fmt.Println("Error al crear la nómina:", err)
 			} else {
-				if _, err := o.Raw("CALL generar_nomina_automatica(?)", nomina.PK_ID_NOMINA).Exec(); err != nil {
+				if _, err := o.Raw("CALL generar_nomina_automatica(?, ?)", nomina.PK_ID_NOMINA, nomina.FECHA).Exec(); err != nil {
 					fmt.Println("Error al generar la nómina automática:", err)
 				} else {
 					fmt.Println("Nómina generada automáticamente con éxito.")

--- a/tests/nomina_functions_test.go
+++ b/tests/nomina_functions_test.go
@@ -11,45 +11,36 @@ import (
 )
 
 func TestNominaGenerarYVerificar(t *testing.T) {
-       body := strings.NewReader("{}")
-       req := httptest.NewRequest(
-               http.MethodPost,
-               "/nominas?generar_nomina_automatica=true&verificar_nomina=true&p_nomina_id=1&p_fecha=2024-01-01",
-               body,
-       )
-       req.Header.Set("Content-Type", "application/json")
-       w := sendRequest(req)
-       if w.Code != http.StatusCreated {
-               t.Fatalf("nomina generation/verification failed or DB unavailable: %d %s", w.Code, w.Body.String())
-       }
+	body := strings.NewReader(`{"FECHA":"2024-01-01T00:00:00Z"}`)
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/nominas?generar_nomina_automatica=true&verificar_nomina=true",
+		body,
+	)
+	req.Header.Set("Content-Type", "application/json")
+	w := sendRequest(req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("nomina generation/verification failed or DB unavailable: %d %s", w.Code, w.Body.String())
+	}
 
-       var resp models.ApiResponse
-       if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
-               t.Fatalf("failed to unmarshal response: %v", err)
-       }
+	var resp models.ApiResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
 
-       if resp.Message != "Funciones de nómina ejecutadas correctamente" {
-               t.Errorf("unexpected response message: %s", resp.Message)
-       }
+	if resp.Message != "Nómina creada correctamente" {
+		t.Errorf("unexpected response message: %s", resp.Message)
+	}
 
-       dataMap, ok := resp.Data.(map[string]interface{})
-       if !ok {
-               t.Fatalf("expected response data to be a map, got %T", resp.Data)
-       }
-       nominaPayload, ok := dataMap["nomina"]
-       if !ok {
-               t.Fatalf("expected 'nomina' field in response data")
-       }
-
-       dataBytes, err := json.Marshal(nominaPayload)
-       if err != nil {
-               t.Fatalf("failed to marshal nomina payload: %v", err)
-       }
-       var nomina models.Nomina
-       if err := json.Unmarshal(dataBytes, &nomina); err != nil {
-               t.Fatalf("failed to unmarshal nomina: %v", err)
-       }
-       if nomina.PK_ID_NOMINA == 0 {
-               t.Errorf("expected valid nomina ID, got %d", nomina.PK_ID_NOMINA)
-       }
+	dataBytes, err := json.Marshal(resp.Data)
+	if err != nil {
+		t.Fatalf("failed to marshal response data: %v", err)
+	}
+	var nomina models.Nomina
+	if err := json.Unmarshal(dataBytes, &nomina); err != nil {
+		t.Fatalf("failed to unmarshal nomina: %v", err)
+	}
+	if nomina.PK_ID_NOMINA == 0 {
+		t.Errorf("expected valid nomina ID, got %d", nomina.PK_ID_NOMINA)
+	}
 }


### PR DESCRIPTION
## Summary
- include `p_fecha` when invoking `generar_nomina_automatica`
- drop payroll ID argument from `verificar_nomina`
- refresh payroll tests and README

## Testing
- `go test ./...` *(fails: field: models.DetallePedido.PKIDProducto, one model must have one pk field only)*

------
https://chatgpt.com/codex/tasks/task_e_68b4c65234a48325837ff0ed4bf5e8c9