### PR TITLE
Encode product images as Base64

### DIFF
--- a/controllers/ProductoController.go
+++ b/controllers/ProductoController.go
@@ -1,8 +1,8 @@
 package controllers
 
 import (
+	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"reflect"
 	"restaurante/models"
@@ -120,16 +120,9 @@ func (c *ProductoController) GetById() {
 // @Summary Crear un nuevo producto
 // @Description Crea un nuevo producto en la base de datos.
 // @Tags productos
-// @Accept multipart/form-data
+// @Accept json
 // @Produce json
-// @Param   NOMBRE        formData  string  true   "Nombre del producto"
-// @Param   CALORIAS      formData  int     false  "Calorías del producto"
-// @Param   DESCRIPCION   formData  string  false  "Descripción del producto"
-// @Param   ESTADO_PRODUCTO formData  string true   "Estado del producto"
-// @Param   PRECIO        formData  int     true   "Precio del producto"
-// @Param   IMAGEN        formData  file    false  "Imagen del producto (opcional)"
-// @Param   CANTIDAD      formData  int     false  "Cantidad del producto"
-// @Param   PK_ID_SUBCATEGORIA formData int true   "ID de la subcategoría del producto"
+// @Param   producto  body     models.Producto true "Producto con imagen Base64"
 // @Success 201 {object} models.Producto "Producto creado"
 // @Failure 400 {object} models.ApiResponse "Error en la solicitud"
 // @Router /productos [post]
@@ -137,75 +130,37 @@ func (c *ProductoController) Post() {
 	o := orm.NewOrm()
 	var producto models.Producto
 
-	// Validar campos obligatorios
-	producto.NOMBRE = c.GetString("NOMBRE")
-	producto.PK_ID_SUBCATEGORIA, _ = c.GetInt64("PK_ID_SUBCATEGORIA")
-	producto.ESTADO_PRODUCTO = c.GetString("ESTADO_PRODUCTO")
-	calorias, _ := c.GetInt64("CALORIAS")
-	producto.CALORIAS = &calorias
-	producto.DESCRIPCION = c.GetString("DESCRIPCION")
-	producto.PRECIO, _ = c.GetInt64("PRECIO")
-	producto.CANTIDAD, _ = c.GetInt("CANTIDAD")
+	if err := json.Unmarshal(c.Ctx.Input.RequestBody, &producto); err != nil {
+		c.Ctx.Output.SetStatus(http.StatusBadRequest)
+		c.Data["json"] = models.ApiResponse{Code: http.StatusBadRequest, Message: "JSON inválido", Cause: err.Error()}
+		c.ServeJSON()
+		return
+	}
 
 	if err := validateProducto(&producto); err != nil {
 		c.Ctx.Output.SetStatus(http.StatusBadRequest)
-		c.Data["json"] = models.ApiResponse{
-			Code:    http.StatusBadRequest,
-			Message: err.Error(),
-		}
+		c.Data["json"] = models.ApiResponse{Code: http.StatusBadRequest, Message: err.Error()}
 		c.ServeJSON()
 		return
 	}
 
-	// Manejar la imagen opcional
-	imagen, err := handleImageUpload(&c.Controller)
-	if err != nil {
-		c.Ctx.Output.SetStatus(http.StatusBadRequest)
-		c.Data["json"] = models.ApiResponse{
-			Code:    http.StatusBadRequest,
-			Message: err.Error(),
-		}
-		c.ServeJSON()
-		return
-	}
-	producto.IMAGEN = imagen
-
-	// Insertar en la base de datos
-	_, err = o.Insert(&producto)
-	if err != nil {
+	if _, err := o.Insert(&producto); err != nil {
 		c.Ctx.Output.SetStatus(http.StatusInternalServerError)
-		c.Data["json"] = models.ApiResponse{
-			Code:    http.StatusInternalServerError,
-			Message: "Error al crear el producto",
-			Cause:   err.Error(),
-		}
+		c.Data["json"] = models.ApiResponse{Code: http.StatusInternalServerError, Message: "Error al crear el producto", Cause: err.Error()}
 		c.ServeJSON()
 		return
 	}
 
-	// Registrar historial de precios
-	hist := models.PrecioProductoHist{
-		PKIDProducto:  producto.PK_ID_PRODUCTO,
-		Precio:        producto.PRECIO,
-		FechaVigencia: time.Now(),
-	}
+	hist := models.PrecioProductoHist{PKIDProducto: producto.PK_ID_PRODUCTO, Precio: producto.PRECIO, FechaVigencia: time.Now()}
 	if _, err := o.Insert(&hist); err != nil {
 		c.Ctx.Output.SetStatus(http.StatusInternalServerError)
-		c.Data["json"] = models.ApiResponse{
-			Code:    http.StatusInternalServerError,
-			Message: "Error al registrar historial de precios",
-			Cause:   err.Error(),
-		}
+		c.Data["json"] = models.ApiResponse{Code: http.StatusInternalServerError, Message: "Error al registrar historial de precios", Cause: err.Error()}
 		c.ServeJSON()
 		return
 	}
 
 	c.Ctx.Output.SetStatus(http.StatusCreated)
-	c.Data["json"] = models.ApiResponse{
-		Code:    http.StatusCreated,
-		Message: "Producto creado correctamente",
-		Data:    producto,
-	}
+	c.Data["json"] = models.ApiResponse{Code: http.StatusCreated, Message: "Producto creado correctamente", Data: producto}
 	c.ServeJSON()
 }
 
@@ -213,32 +168,21 @@ func (c *ProductoController) Post() {
 // @Summary Actualizar un producto
 // @Description Actualiza los datos de un producto existente, incluyendo una imagen en formato Base64.
 // @Tags productos
-// @Accept multipart/form-data
+// @Accept json
 // @Produce json
-// @Param   id            query    int     true   "ID del Producto"
-// @Param   NOMBRE        formData  string  true   "Nombre del producto"
-// @Param   CALORIAS      formData  int     false   "Calorías del producto"
-// @Param   DESCRIPCION   formData  string  false  "Descripción del producto"
-// @Param   ESTADO_PRODUCTO formData  string    true   "Estado del producto"
-// @Param   PRECIO        formData  int     true   "Precio del producto"
-// @Param   IMAGEN        formData  file    false  "Imagen del producto (opcional)"
-// @Param   CANTIDAD        formData  int     false   "Cantidad del producto"
+// @Param   id        query   int              true  "ID del Producto"
+// @Param   producto  body    models.Producto true  "Datos del producto"
 // @Success 200 {object} models.Producto "Producto actualizado"
 // @Failure 404 {object} models.ApiResponse "Producto no encontrado"
 // @Router /productos [put]
 func (c *ProductoController) Put() {
 	o := orm.NewOrm()
 
-	// Obtener el ID del query parameter
 	idStr := c.GetString("id")
 	id, err := strconv.Atoi(idStr)
 	if err != nil || id == 0 {
 		c.Ctx.Output.SetStatus(http.StatusBadRequest)
-		c.Data["json"] = models.ApiResponse{
-			Code:    http.StatusBadRequest,
-			Message: "El parámetro 'id' es inválido o está ausente.",
-			Cause:   err.Error(),
-		}
+		c.Data["json"] = models.ApiResponse{Code: http.StatusBadRequest, Message: "El parámetro 'id' es inválido o está ausente.", Cause: err.Error()}
 		c.ServeJSON()
 		return
 	}
@@ -246,99 +190,64 @@ func (c *ProductoController) Put() {
 	producto := models.Producto{PK_ID_PRODUCTO: int64(id)}
 
 	if o.Read(&producto) == nil {
-		// Copiar los valores actuales para comparación
 		original := producto
 
-		// Actualizar los campos
-		producto.NOMBRE = c.GetString("NOMBRE")
-		calorias, _ := c.GetInt64("CALORIAS")
-		producto.CALORIAS = &calorias
-		producto.DESCRIPCION = c.GetString("DESCRIPCION")
-		producto.PRECIO, _ = c.GetInt64("PRECIO")
-		producto.ESTADO_PRODUCTO = c.GetString("ESTADO_PRODUCTO")
-		producto.CANTIDAD, _ = c.GetInt("CANTIDAD")
+		var input models.Producto
+		if err := json.Unmarshal(c.Ctx.Input.RequestBody, &input); err != nil {
+			c.Ctx.Output.SetStatus(http.StatusBadRequest)
+			c.Data["json"] = models.ApiResponse{Code: http.StatusBadRequest, Message: "JSON inválido", Cause: err.Error()}
+			c.ServeJSON()
+			return
+		}
 
-		// Validar datos
+		producto.NOMBRE = input.NOMBRE
+		producto.CALORIAS = input.CALORIAS
+		producto.DESCRIPCION = input.DESCRIPCION
+		producto.PRECIO = input.PRECIO
+		producto.ESTADO_PRODUCTO = input.ESTADO_PRODUCTO
+		producto.CANTIDAD = input.CANTIDAD
+		producto.PK_ID_SUBCATEGORIA = input.PK_ID_SUBCATEGORIA
+		if len(input.IMAGEN) > 0 {
+			producto.IMAGEN = input.IMAGEN
+		}
+
 		if err := validateProducto(&producto); err != nil {
 			c.Ctx.Output.SetStatus(http.StatusBadRequest)
-			c.Data["json"] = models.ApiResponse{
-				Code:    http.StatusBadRequest,
-				Message: err.Error(),
-			}
+			c.Data["json"] = models.ApiResponse{Code: http.StatusBadRequest, Message: err.Error()}
 			c.ServeJSON()
 			return
 		}
 
-		// Manejar imagen opcional
-		imagen, err := handleImageUpload(&c.Controller)
-		if err != nil {
-			c.Ctx.Output.SetStatus(http.StatusBadRequest)
-			c.Data["json"] = models.ApiResponse{
-				Code:    http.StatusBadRequest,
-				Message: err.Error(),
-			}
-			c.ServeJSON()
-			return
-		}
-		if imagen != nil {
-			producto.IMAGEN = imagen
-		}
-
-		// Verificar si hubo cambios
 		if reflect.DeepEqual(producto, original) {
 			c.Ctx.Output.SetStatus(http.StatusNotModified)
-			c.Data["json"] = models.ApiResponse{
-				Code:    http.StatusNotModified,
-				Message: "No se realizaron cambios en el producto",
-			}
+			c.Data["json"] = models.ApiResponse{Code: http.StatusNotModified, Message: "No se realizaron cambios en el producto"}
 			c.ServeJSON()
 			return
 		}
 
-		// Actualizar en base de datos
 		if _, err = o.Update(&producto); err != nil {
 			c.Ctx.Output.SetStatus(http.StatusInternalServerError)
-			c.Data["json"] = models.ApiResponse{
-				Code:    http.StatusInternalServerError,
-				Message: "Error al actualizar el producto.",
-				Cause:   err.Error(),
-			}
+			c.Data["json"] = models.ApiResponse{Code: http.StatusInternalServerError, Message: "Error al actualizar el producto.", Cause: err.Error()}
 			c.ServeJSON()
 			return
 		}
 
-		// Si cambió el precio, registrar nuevo historial
 		if producto.PRECIO != original.PRECIO {
-			hist := models.PrecioProductoHist{
-				PKIDProducto:  producto.PK_ID_PRODUCTO,
-				Precio:        producto.PRECIO,
-				FechaVigencia: time.Now(),
-			}
+			hist := models.PrecioProductoHist{PKIDProducto: producto.PK_ID_PRODUCTO, Precio: producto.PRECIO, FechaVigencia: time.Now()}
 			if _, err := o.Insert(&hist); err != nil {
 				c.Ctx.Output.SetStatus(http.StatusInternalServerError)
-				c.Data["json"] = models.ApiResponse{
-					Code:    http.StatusInternalServerError,
-					Message: "Error al registrar historial de precios",
-					Cause:   err.Error(),
-				}
+				c.Data["json"] = models.ApiResponse{Code: http.StatusInternalServerError, Message: "Error al registrar historial de precios", Cause: err.Error()}
 				c.ServeJSON()
 				return
 			}
 		}
 
 		c.Ctx.Output.SetStatus(http.StatusOK)
-		c.Data["json"] = models.ApiResponse{
-			Code:    http.StatusOK,
-			Message: "Producto actualizado",
-			Data:    producto,
-		}
+		c.Data["json"] = models.ApiResponse{Code: http.StatusOK, Message: "Producto actualizado", Data: producto}
 		c.ServeJSON()
 	} else {
 		c.Ctx.Output.SetStatus(http.StatusOK)
-		c.Data["json"] = models.ApiResponse{
-			Code:    http.StatusNotFound,
-			Message: "Producto no encontrado.",
-		}
+		c.Data["json"] = models.ApiResponse{Code: http.StatusNotFound, Message: "Producto no encontrado."}
 		c.ServeJSON()
 	}
 
@@ -411,28 +320,6 @@ func (c *ProductoController) Delete() {
 		Message: "Producto desactivado correctamente.",
 	}
 	c.ServeJSON()
-}
-
-// Funciones auxiliares
-func handleImageUpload(c *web.Controller) ([]byte, error) {
-	file, fileHeader, err := c.GetFile("IMAGEN")
-	if err != nil {
-		if err == http.ErrMissingFile {
-			return nil, nil
-		}
-		return nil, fmt.Errorf("error al obtener la imagen: %v", err)
-	}
-	defer file.Close()
-
-	if fileHeader.Size > 1024*1024 {
-		return nil, fmt.Errorf("la imagen no debe superar los 1MB")
-	}
-
-	fileBytes, err := ioutil.ReadAll(file)
-	if err != nil {
-		return nil, fmt.Errorf("error al leer la imagen: %v", err)
-	}
-	return fileBytes, nil
 }
 
 func validateProducto(producto *models.Producto) error {

--- a/controllers/producto_controller_test.go
+++ b/controllers/producto_controller_test.go
@@ -2,73 +2,14 @@ package controllers
 
 import (
 	"bytes"
-	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
-	"github.com/beego/beego/v2/server/web"
 	"github.com/beego/beego/v2/server/web/context"
 	"restaurante/models"
 )
-
-func setupProductoController(t *testing.T, data []byte) *web.Controller {
-	body := &bytes.Buffer{}
-	writer := multipart.NewWriter(body)
-	if data != nil {
-		part, err := writer.CreateFormFile("IMAGEN", "test.png")
-		if err != nil {
-			t.Fatalf("CreateFormFile: %v", err)
-		}
-		if _, err := part.Write(data); err != nil {
-			t.Fatalf("write data: %v", err)
-		}
-	}
-	writer.Close()
-	req := httptest.NewRequest(http.MethodPost, "/", body)
-	req.Header.Set("Content-Type", writer.FormDataContentType())
-	w := httptest.NewRecorder()
-	ctx := context.NewContext()
-	ctx.Reset(w, req)
-	c := &web.Controller{}
-	c.Ctx = ctx
-	return c
-}
-
-func TestProductoHandleImageUploadMissingFile(t *testing.T) {
-	c := setupProductoController(t, nil)
-	img, err := handleImageUpload(c)
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
-	if img != nil {
-		t.Errorf("expected nil, got %v", img)
-	}
-}
-
-func TestProductoHandleImageUploadTooLarge(t *testing.T) {
-	data := bytes.Repeat([]byte("a"), 1024*1024+1)
-	c := setupProductoController(t, data)
-	img, err := handleImageUpload(c)
-	if err == nil || !strings.Contains(err.Error(), "1MB") {
-		t.Fatalf("expected size error, got %v", err)
-	}
-	if img != nil {
-		t.Errorf("expected nil on error")
-	}
-}
-
-func TestProductoHandleImageUploadSuccess(t *testing.T) {
-	c := setupProductoController(t, []byte("hello"))
-	img, err := handleImageUpload(c)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if !bytes.Equal(img, []byte("hello")) {
-		t.Errorf("unexpected image data: %v", img)
-	}
-}
 
 func int64Ptr(i int64) *int64 { return &i }
 
@@ -148,15 +89,9 @@ func TestProductoGetByIdNotFound(t *testing.T) {
 }
 
 func TestProductoPostMissingNombre(t *testing.T) {
-	body := &bytes.Buffer{}
-	writer := multipart.NewWriter(body)
-	writer.WriteField("nombre", "")
-	writer.WriteField("estadoProducto", "disponible")
-	writer.WriteField("precio", "10")
-	writer.Close()
-
+	body := bytes.NewBufferString(`{"estadoProducto":"disponible","precio":10}`)
 	r := httptest.NewRequest(http.MethodPost, "/productos", body)
-	r.Header.Set("Content-Type", writer.FormDataContentType())
+	r.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 	ctx := context.NewContext()
 	ctx.Reset(w, r)

--- a/models/Producto.go
+++ b/models/Producto.go
@@ -1,6 +1,8 @@
 package models
 
 import (
+	"encoding/base64"
+	"encoding/json"
 	"os"
 
 	"github.com/beego/beego/v2/client/orm"
@@ -20,6 +22,60 @@ type Producto struct {
 
 func (p *Producto) TableName() string {
 	return "producto"
+}
+
+type productoJSON struct {
+	PKIDProducto     int64          `json:"productoId"`
+	NOMBRE           string         `json:"nombre"`
+	CALORIAS         *int64         `json:"calorias"`
+	DESCRIPCION      string         `json:"descripcion"`
+	PRECIO           int64          `json:"precio"`
+	ESTADO_PRODUCTO  EstadoProducto `json:"estadoProducto"`
+	IMAGEN           string         `json:"imagen,omitempty"`
+	CANTIDAD         int            `json:"cantidad"`
+	PKIDSubcategoria int64          `json:"subcategoriaId"`
+}
+
+func (p Producto) MarshalJSON() ([]byte, error) {
+	pj := productoJSON{
+		PKIDProducto:     p.PK_ID_PRODUCTO,
+		NOMBRE:           p.NOMBRE,
+		CALORIAS:         p.CALORIAS,
+		DESCRIPCION:      p.DESCRIPCION,
+		PRECIO:           p.PRECIO,
+		ESTADO_PRODUCTO:  p.ESTADO_PRODUCTO,
+		CANTIDAD:         p.CANTIDAD,
+		PKIDSubcategoria: p.PK_ID_SUBCATEGORIA,
+	}
+	if len(p.IMAGEN) > 0 {
+		pj.IMAGEN = base64.StdEncoding.EncodeToString(p.IMAGEN)
+	}
+	return json.Marshal(pj)
+}
+
+func (p *Producto) UnmarshalJSON(data []byte) error {
+	var pj productoJSON
+	if err := json.Unmarshal(data, &pj); err != nil {
+		return err
+	}
+	p.PK_ID_PRODUCTO = pj.PKIDProducto
+	p.NOMBRE = pj.NOMBRE
+	p.CALORIAS = pj.CALORIAS
+	p.DESCRIPCION = pj.DESCRIPCION
+	p.PRECIO = pj.PRECIO
+	p.ESTADO_PRODUCTO = pj.ESTADO_PRODUCTO
+	if pj.IMAGEN != "" {
+		img, err := base64.StdEncoding.DecodeString(pj.IMAGEN)
+		if err != nil {
+			return err
+		}
+		p.IMAGEN = img
+	} else {
+		p.IMAGEN = nil
+	}
+	p.CANTIDAD = pj.CANTIDAD
+	p.PK_ID_SUBCATEGORIA = pj.PKIDSubcategoria
+	return nil
 }
 
 func init() {

--- a/models/producto_test.go
+++ b/models/producto_test.go
@@ -1,6 +1,9 @@
 package models
 
 import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
 	"reflect"
 	"strings"
 	"testing"
@@ -18,5 +21,34 @@ func TestProductoImagenFieldType(t *testing.T) {
 	tag := field.Tag.Get("orm")
 	if !strings.Contains(tag, "type(bytea)") {
 		t.Fatalf("expected orm tag to contain type(bytea), got %q", tag)
+	}
+}
+
+func TestProductoMarshalUnmarshalJSON(t *testing.T) {
+	calorias := int64(100)
+	p := Producto{
+		PK_ID_PRODUCTO:     1,
+		NOMBRE:             "Test",
+		CALORIAS:           &calorias,
+		DESCRIPCION:        "desc",
+		PRECIO:             5,
+		ESTADO_PRODUCTO:    EstadoProductoDisponible,
+		IMAGEN:             []byte("hello"),
+		CANTIDAD:           2,
+		PK_ID_SUBCATEGORIA: 3,
+	}
+	data, err := json.Marshal(p)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if !strings.Contains(string(data), base64.StdEncoding.EncodeToString([]byte("hello"))) {
+		t.Fatalf("expected base64 image in json: %s", string(data))
+	}
+	var out Producto
+	if err := json.Unmarshal(data, &out); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if !bytes.Equal(out.IMAGEN, p.IMAGEN) {
+		t.Fatalf("expected image %v, got %v", p.IMAGEN, out.IMAGEN)
 	}
 }


### PR DESCRIPTION
## Summary
- Encode `Producto.IMAGEN` as Base64 via custom `MarshalJSON`/`UnmarshalJSON`
- Accept product payloads with Base64 images in `ProductoController` POST and PUT endpoints
- Adjust controller and model tests for the new image format

## Testing
- `go test ./...` *(fails: field: models.DetallePedido.PKIDProducto, one model must have one pk field only)*

------
https://chatgpt.com/codex/tasks/task_e_68b4e92b3aa88325905f42fcc8663aaf