### PR TITLE
Refactor DetallePedido to embed composite primary key

### DIFF
--- a/controllers/ProductoPedidoController.go
+++ b/controllers/ProductoPedidoController.go
@@ -133,9 +133,11 @@ func (c *ProductoPedidoController) Post() {
 	var detalles []models.DetallePedido
 	for _, d := range input.Detalles {
 		detalle := models.DetallePedido{
-			PKIDPedido:   input.PedidoId,
-			PKIDProducto: d.PKIDProducto,
-			Cantidad:     d.Cantidad,
+			DetallePedidoPK: models.DetallePedidoPK{
+				PKIDPedido:   input.PedidoId,
+				PKIDProducto: d.PKIDProducto,
+			},
+			Cantidad: d.Cantidad,
 		}
 		if _, err := o.Insert(&detalle); err != nil {
 			c.Data["json"] = models.ApiResponse{
@@ -250,9 +252,11 @@ func (c *ProductoPedidoController) Update() {
 	var detalles []models.DetallePedido
 	for _, d := range nuevosProductos {
 		detalle := models.DetallePedido{
-			PKIDPedido:   pedidoID,
-			PKIDProducto: d.PKIDProducto,
-			Cantidad:     d.Cantidad,
+			DetallePedidoPK: models.DetallePedidoPK{
+				PKIDPedido:   pedidoID,
+				PKIDProducto: d.PKIDProducto,
+			},
+			Cantidad: d.Cantidad,
 		}
 		if _, err := o.Insert(&detalle); err != nil {
 			c.Data["json"] = models.ApiResponse{

--- a/controllers/producto_pedido_controller_test.go
+++ b/controllers/producto_pedido_controller_test.go
@@ -250,7 +250,14 @@ func TestProductoPedidoGetAllSuccess(t *testing.T) {
 			case *models.DetallePedido:
 				return fakeQueryPP{all: func(res interface{}, cols ...string) (int64, error) {
 					detalles := res.(*[]models.DetallePedido)
-					*detalles = append(*detalles, models.DetallePedido{PKIDPedido: 1, PKIDProducto: 1, Cantidad: 1, Precio: 1000})
+					*detalles = append(
+						*detalles,
+						models.DetallePedido{
+							DetallePedidoPK: models.DetallePedidoPK{PKIDPedido: 1, PKIDProducto: 1},
+							Cantidad:        1,
+							Precio:          1000,
+						},
+					)
 					return 1, nil
 				}}
 			default:
@@ -290,7 +297,11 @@ func TestProductoPedidoPostSuccess(t *testing.T) {
 			query: func(i interface{}) orm.QuerySeter {
 				return fakeQueryPP{one: func(res interface{}, cols ...string) error {
 					if d, ok := res.(*models.DetallePedido); ok {
-						*d = models.DetallePedido{PKIDPedido: 1, PKIDProducto: 1, Cantidad: 1, Precio: 1000}
+						*d = models.DetallePedido{
+							DetallePedidoPK: models.DetallePedidoPK{PKIDPedido: 1, PKIDProducto: 1},
+							Cantidad:        1,
+							Precio:          1000,
+						}
 					}
 					return nil
 				}}
@@ -335,7 +346,11 @@ func TestProductoPedidoUpdateSuccess(t *testing.T) {
 				}
 				return fakeQueryPP{one: func(res interface{}, cols ...string) error {
 					if d, ok := res.(*models.DetallePedido); ok {
-						*d = models.DetallePedido{PKIDPedido: 1, PKIDProducto: 1, Cantidad: 1, Precio: 1000}
+						*d = models.DetallePedido{
+							DetallePedidoPK: models.DetallePedidoPK{PKIDPedido: 1, PKIDProducto: 1},
+							Cantidad:        1,
+							Precio:          1000,
+						}
 					}
 					return nil
 				}}

--- a/models/DetallePedido.go
+++ b/models/DetallePedido.go
@@ -2,11 +2,18 @@ package models
 
 import "github.com/beego/beego/v2/client/orm"
 
+// DetallePedidoPK encapsulates the composite primary key for DetallePedido.
+type DetallePedidoPK struct {
+	PKIDPedido   int64 `orm:"column(pk_id_pedido)" json:"pedidoId"`
+	PKIDProducto int64 `orm:"column(pk_id_producto)" json:"productoId"`
+}
+
+// DetallePedido represents a product within a pedido.
+// The composite primary key is defined in the embedded DetallePedidoPK struct.
 type DetallePedido struct {
-	PKIDPedido   int64 `orm:"column(pk_id_pedido);pk" json:"pedidoId"`
-	PKIDProducto int64 `orm:"column(pk_id_producto);pk" json:"productoId"` // part of composite PK
-	Precio       int64 `orm:"column(precio);type(bigint)" json:"precio"`
-	Cantidad     int   `orm:"column(cantidad)" json:"cantidad"`
+	DetallePedidoPK `orm:"pk"`
+	Precio          int64 `orm:"column(precio);type(bigint)" json:"precio"`
+	Cantidad        int   `orm:"column(cantidad)" json:"cantidad"`
 }
 
 func (d *DetallePedido) TableName() string {

--- a/models/pedido_test.go
+++ b/models/pedido_test.go
@@ -49,7 +49,10 @@ func TestDetallePedidoPrecioAuto(t *testing.T) {
 		}
 		return 1, nil
 	}}
-	detalle := DetallePedido{PKIDPedido: 1, PKIDProducto: 1, Cantidad: 1}
+	detalle := DetallePedido{
+		DetallePedidoPK: DetallePedidoPK{PKIDPedido: 1, PKIDProducto: 1},
+		Cantidad:        1,
+	}
 	if _, err := o.Insert(&detalle); err != nil {
 		t.Fatalf("insert returned error: %v", err)
 	}

--- a/tests/detalle_pedido_trigger_test.go
+++ b/tests/detalle_pedido_trigger_test.go
@@ -44,7 +44,10 @@ func TestDetallePedidoTriggerOnInsert(t *testing.T) {
 	if err := o.QueryTable(new(models.Producto)).Filter("PK_ID_PRODUCTO", 1).One(&prod); err != nil {
 		t.Fatalf("producto not found or DB unavailable: %v", err)
 	}
-	det := models.DetallePedido{PKIDPedido: 9999, PKIDProducto: prod.PK_ID_PRODUCTO, Cantidad: 1}
+	det := models.DetallePedido{
+		DetallePedidoPK: models.DetallePedidoPK{PKIDPedido: 9999, PKIDProducto: prod.PK_ID_PRODUCTO},
+		Cantidad:        1,
+	}
 	if _, err := o.Insert(&det); err != nil {
 		t.Fatalf("insert detalle_pedido failed: %v", err)
 	}

--- a/tests/seed_data.go
+++ b/tests/seed_data.go
@@ -43,9 +43,8 @@ func SeedTestData() {
 	}
 
 	if _, err := o.Insert(&models.DetallePedido{
-		PKIDPedido:   1,
-		PKIDProducto: 1,
-		Cantidad:     1,
+		DetallePedidoPK: models.DetallePedidoPK{PKIDPedido: 1, PKIDProducto: 1},
+		Cantidad:        1,
 	}); err != nil {
 		log.Println("seed detalle_pedido:", err)
 	}


### PR DESCRIPTION
## Summary
- encapsulate DetallePedido composite primary key in DetallePedidoPK and embed it
- adjust ProductoPedidoController to populate embedded key
- update tests and seed data to new composite key structure

## Testing
- `go test ./...` *(fails: field: models.Producto.IMAGEN, unsupport field type , may be miss setting tag)*
- `go run main.go` *(fails: field: models.Producto.IMAGEN, unsupport field type , may be miss setting tag)*

------
https://chatgpt.com/codex/tasks/task_e_68b4eab0fa7883259e964f3bc63d8a1a