### PR TITLE
Add cancelado order status and state validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ Go-based REST API for managing restaurant operations such as customers, orders, 
 - **States** are modeled with enums under `models/enums.go`:
   - `EstadoReserva`: `pendiente`, `confirmada`, `cancelada`, `cumplida`.
   - `EstadoNomina`: `pago`, `no pago`.
-  - Additional enums exist for domicilios, pagos, pedidos, productos y días de la semana.
+  - `EstadoPedido`: `iniciado`, `terminado`, `cancelado`.
+  - Additional enums exist for domicilios, pagos, productos y días de la semana.
 - **Price history** for products is stored in the `precio_producto_hist` table. A new entry is
   created when a product is registered or its price changes, storing the effective date of the
   change.

--- a/controllers/PedidoController.go
+++ b/controllers/PedidoController.go
@@ -297,6 +297,16 @@ func (c *PedidoController) UpdateEstadoPedido() {
 	pedidoID, _ := c.GetInt64("pedido_id")
 	estado := c.GetString("estado")
 
+	if estado != models.EstadoPedidoIniciado && estado != models.EstadoPedidoTerminado && estado != models.EstadoPedidoCancelado {
+		c.Ctx.Output.SetStatus(400)
+		c.Data["json"] = models.ApiResponse{
+			Code:    400,
+			Message: "Estado inválido",
+		}
+		c.ServeJSON()
+		return
+	}
+
 	o := orm.NewOrm()
 
 	// Buscar el pedido

--- a/controllers/pedido_controller_test.go
+++ b/controllers/pedido_controller_test.go
@@ -111,6 +111,25 @@ func TestPedidoUpdateEstadoPedidoNotFound(t *testing.T) {
 	}
 }
 
+func TestPedidoUpdateEstadoPedidoInvalidEstado(t *testing.T) {
+	r := httptest.NewRequest(http.MethodPut, "/pedidos/actualizar-estado?pedido_id=1&estado=foo", nil)
+	w := httptest.NewRecorder()
+	ctx := beegoCtx.NewContext()
+	ctx.Reset(w, r)
+	c := PedidoController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	c.UpdateEstadoPedido()
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "Estado inválido") {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
+}
+
 func TestPedidoGetPedidoDetailsMissingID(t *testing.T) {
 	r := httptest.NewRequest(http.MethodGet, "/pedidos/detalles", nil)
 	w := httptest.NewRecorder()
@@ -449,7 +468,7 @@ func TestPedidoUpdateEstadoPedidoSuccess(t *testing.T) {
 	}
 	defer func() { MockQuery = nil; MockExec = nil }()
 
-	r := httptest.NewRequest(http.MethodPut, "/pedidos/actualizar-estado?pedido_id=1&estado=terminado", nil)
+	r := httptest.NewRequest(http.MethodPut, "/pedidos/actualizar-estado?pedido_id=1&estado=cancelado", nil)
 	w := httptest.NewRecorder()
 	ctx := beegoCtx.NewContext()
 	ctx.Reset(w, r)

--- a/models/enums.go
+++ b/models/enums.go
@@ -27,11 +27,13 @@ const (
 )
 
 // EstadoPedido represents the estado_pedido_enum values.
+// Valores válidos: "iniciado", "terminado", "cancelado".
 type EstadoPedido = string
 
 const (
 	EstadoPedidoIniciado  EstadoPedido = "iniciado"
 	EstadoPedidoTerminado EstadoPedido = "terminado"
+	EstadoPedidoCancelado EstadoPedido = "cancelado"
 )
 
 // EstadoProducto represents the estado_producto_enum values.


### PR DESCRIPTION
## Summary
- extend `EstadoPedido` with a new `cancelado` status and document allowed values
- validate pedido state updates to allow only iniciado, terminado or cancelado
- cover cancelado and invalid estado scenarios in tests and README

## Testing
- `go test ./controllers -run UpdateEstadoPedido -count=1` *(fails: init global config instance failed. If you do not use this, just ignore it.  open conf/app.conf: no such file or directory)*
- `go test ./...` *(fails: field: models.Producto.IMAGEN, unsupport field type , may be miss setting tag)*

------
https://chatgpt.com/codex/tasks/task_e_68b4ec67580c832599da49cf7ff46e87