### PR TITLE
Normalize enum literals to uppercase

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ Go-based REST API for managing restaurant operations such as customers, orders, 
 
 ## Enumerated Types and Payroll
 - **States** are modeled with enums under `models/enums.go`:
-  - `EstadoReserva`: `pendiente`, `confirmada`, `cancelada`, `cumplida`.
-  - `EstadoNomina`: `pago`, `no pago`.
+  - `EstadoReserva`: `PENDIENTE`, `CONFIRMADA`, `CANCELADA`, `CUMPLIDA`.
+  - `EstadoNomina`: `PAGO`, `NO_PAGO`.
   - Additional enums exist for domicilios, pagos, pedidos, productos y días de la semana.
 - **Price history** for products is stored in the `precio_producto_hist` table. A new entry is
   created when a product is registered or its price changes, storing the effective date of the
@@ -61,8 +61,8 @@ Go-based REST API for managing restaurant operations such as customers, orders, 
 - `POST /nominas` accepts optional `generar_nomina_automatica` and
   `verificar_nomina` flags to auto-generate payments (passing the payroll
   date as `p_fecha`) and verify payroll records without requiring an ID.
-- `PUT /nominas?id=...` transitions a payroll to `pago`.
-- `DELETE /nominas?id=...` performs a logical deletion setting the state to `no pago`.
+- `PUT /nominas?id=...` transitions a payroll to `PAGO`.
+- `DELETE /nominas?id=...` performs a logical deletion setting the state to `NO_PAGO`.
 
 ## Database Tables
 - **nomina**: stores payroll records including amount, state, and audit timestamps.

--- a/controllers/DomicilioController.go
+++ b/controllers/DomicilioController.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"restaurante/models"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/beego/beego/v2/client/orm"
@@ -17,7 +18,7 @@ type DomicilioController struct {
 }
 
 func isValidEstadoDomicilio(e string) bool {
-	switch models.EstadoDomicilio(e) {
+	switch models.EstadoDomicilio(strings.ToUpper(e)) {
 	case models.EstadoDomicilioPendiente, models.EstadoDomicilioEnCamino, models.EstadoDomicilioEntregado:
 		return true
 	}
@@ -49,7 +50,7 @@ func (c *DomicilioController) GetAll() {
 	telefono := c.GetString("telefono")
 	updatedBy := c.GetString("updated_by")
 	fecha := c.GetString("fecha")
-	estado := c.GetString("estado")
+	estado := strings.ToUpper(c.GetString("estado"))
 	trabajadorID, _ := c.GetInt("trabajador") // ID del domiciliario solicitante
 
 	// Aplicar filtros opcionales SOLO si se proporcionan
@@ -344,6 +345,7 @@ func (c *DomicilioController) Post() {
 
 	// Procesar campos opcionales
 	if estado, ok := input["estado"].(string); ok {
+		estado = strings.ToUpper(estado)
 		if !isValidEstadoDomicilio(estado) {
 			c.Ctx.Output.SetStatus(http.StatusBadRequest)
 			c.Data["json"] = models.ApiResponse{
@@ -455,6 +457,7 @@ func (c *DomicilioController) Put() {
 		domicilio.TELEFONO = telefono
 	}
 	if estado, ok := input["estado"].(string); ok {
+		estado = strings.ToUpper(estado)
 		if !isValidEstadoDomicilio(estado) {
 			c.Ctx.Output.SetStatus(http.StatusBadRequest)
 			c.Data["json"] = models.ApiResponse{

--- a/controllers/HorarioTrabajadorController.go
+++ b/controllers/HorarioTrabajadorController.go
@@ -16,7 +16,7 @@ type HorarioTrabajadorController struct {
 }
 
 func isValidDia(dia string) bool {
-	switch models.DiaSemana(strings.ToLower(dia)) {
+	switch models.DiaSemana(strings.ToUpper(dia)) {
 	case models.DiaLunes, models.DiaMartes, models.DiaMiercoles,
 		models.DiaJueves, models.DiaViernes, models.DiaSabado, models.DiaDomingo:
 		return true
@@ -47,7 +47,7 @@ func (c *HorarioTrabajadorController) GetAll() {
 		conds = append(conds, "pk_documento_trabajador = ?")
 		args = append(args, doc)
 	}
-	if dia := c.GetString("dia"); dia != "" {
+	if dia := strings.ToUpper(c.GetString("dia")); dia != "" {
 		conds = append(conds, "dia = ?")
 		args = append(args, dia)
 	}
@@ -107,7 +107,8 @@ func (c *HorarioTrabajadorController) Post() {
 		return
 	}
 
-	if !isValidDia(input.DIA) {
+	dia := strings.ToUpper(input.DIA)
+	if !isValidDia(dia) {
 		c.Ctx.Output.SetStatus(http.StatusBadRequest)
 		c.Data["json"] = models.ApiResponse{Code: http.StatusBadRequest, Message: "Día inválido"}
 		c.ServeJSON()
@@ -128,7 +129,7 @@ func (c *HorarioTrabajadorController) Post() {
 
 	horario := models.HorarioTrabajador{
 		PK_DOCUMENTO_TRABAJADOR: input.PK_DOCUMENTO_TRABAJADOR,
-		DIA:                     input.DIA,
+		DIA:                     dia,
 		HORA_INICIO:             horaInicio,
 		HORA_FIN:                horaFin,
 	}
@@ -180,7 +181,7 @@ func (c *HorarioTrabajadorController) Put() {
 		c.ServeJSON()
 		return
 	}
-	dia := c.GetString("dia")
+	dia := strings.ToUpper(c.GetString("dia"))
 	if dia == "" || !isValidDia(dia) {
 		c.Ctx.Output.SetStatus(http.StatusBadRequest)
 		c.Data["json"] = models.ApiResponse{Code: http.StatusBadRequest, Message: "Parámetro 'dia' inválido"}

--- a/controllers/NominaController.go
+++ b/controllers/NominaController.go
@@ -191,7 +191,7 @@ func (c *NominaController) Post() {
 
 // @Title Update
 // @Summary Actualizar el estado de una nómina
-// @Description Cambia el estado de una nómina existente a "pago".
+// @Description Cambia el estado de una nómina existente a "PAGO".
 // @Tags nominas
 // @Accept json
 // @Produce json
@@ -231,12 +231,12 @@ func (c *NominaController) Put() {
 		return
 	}
 
-	// Cambiar el estado a "pago" si no lo está ya
+	// Cambiar el estado a "PAGO" si no lo está ya
 	if nomina.ESTADO_NOMINA == models.EstadoNominaPago {
 		c.Ctx.Output.SetStatus(http.StatusBadRequest)
 		c.Data["json"] = models.ApiResponse{
 			Code:    http.StatusBadRequest,
-			Message: "La nómina ya está en estado 'pago'",
+			Message: "La nómina ya está en estado 'PAGO'",
 		}
 		c.ServeJSON()
 		return
@@ -259,7 +259,7 @@ func (c *NominaController) Put() {
 	c.Ctx.Output.SetStatus(http.StatusOK)
 	c.Data["json"] = models.ApiResponse{
 		Code:    http.StatusOK,
-		Message: "Estado de la nómina actualizado a 'pago' correctamente",
+		Message: "Estado de la nómina actualizado a 'PAGO' correctamente",
 		Data:    nomina,
 	}
 	c.ServeJSON()
@@ -267,7 +267,7 @@ func (c *NominaController) Put() {
 
 // @Title Delete
 // @Summary Eliminar una nómina (lógica)
-// @Description Marca una nómina como "no pago" en lugar de eliminarla físicamente.
+// @Description Marca una nómina como "NO_PAGO" en lugar de eliminarla físicamente.
 // @Tags nominas
 // @Accept json
 // @Produce json

--- a/controllers/NominaTrabajadorController.go
+++ b/controllers/NominaTrabajadorController.go
@@ -233,9 +233,9 @@ func (c *NominaTrabajadorController) GetByTrabajador() {
 
 	// Filtrar por nóminas pagas o no pagas
 	if pagas {
-		sql += ` AND n."estado_nomina" = 'pago'`
+		sql += ` AND n."estado_nomina" = 'PAGO'`
 	} else if noPagas {
-		sql += ` AND n."estado_nomina" = 'no pago'`
+		sql += ` AND n."estado_nomina" = 'NO_PAGO'`
 	}
 
 	// Filtrar por mes y año

--- a/controllers/PagoController.go
+++ b/controllers/PagoController.go
@@ -6,6 +6,7 @@ import (
 	"restaurante/database"
 	"restaurante/models"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/beego/beego/v2/client/orm"
@@ -28,9 +29,9 @@ var pagoNewOrm = func() ormer { return orm.NewOrm() }
 
 // Estados permitidos para los pagos
 var estadosPagoPermitidos = map[string]bool{
-	"pagado":    true,
-	"pendiente": true,
-	"no pago":   true,
+	"PAGADO":    true,
+	"PENDIENTE": true,
+	"NO_PAGO":   true,
 }
 
 // @Title GetAll
@@ -43,7 +44,7 @@ var estadosPagoPermitidos = map[string]bool{
 // @Param   dia      query   int      false   "Filtrar por dia (1-31)"
 // @Param   mes      query   int      false   "Filtrar por mes (1-12)"
 // @Param   anio     query   int      false   "Filtrar por año (YYYY)"
-// @Param   estado   query   string   false   "Filtrar por estado del pago (pagado, pendiente, no pago)"
+// @Param   estado   query   string   false   "Filtrar por estado del pago (PAGADO, PENDIENTE, NO_PAGO)"
 // @Param   metodo_pago     query   int      false   "Filtrar por metodo de pago"
 // @Success 200 {array} models.Pago "Lista de pagos"
 // @Failure 500 {object} models.ApiResponse "Error en la base de datos"
@@ -77,7 +78,7 @@ func (c *PagoController) GetAll() {
 	dia, _ := c.GetInt("dia")
 	mes, _ := c.GetInt("mes")
 	anio, _ := c.GetInt("anio")
-	estado := c.GetString("estado")
+	estado := strings.ToUpper(c.GetString("estado"))
 	metodo_pago, _ := c.GetInt("metodo_pago")
 
 	// Filtrar los pagos según los parámetros proporcionados
@@ -253,12 +254,13 @@ func (c *PagoController) Post() {
 	}
 
 	if in.EstadoPago != "" {
+		in.EstadoPago = strings.ToUpper(in.EstadoPago)
 		if !estadosPagoPermitidos[in.EstadoPago] {
 			c.Ctx.Output.SetStatus(http.StatusBadRequest)
 			c.Data["json"] = models.ApiResponse{
 				Code:    http.StatusBadRequest,
 				Message: "Estado de pago inválido",
-				Cause:   "El estado debe ser 'pagado', 'pendiente' o 'no pago'",
+				Cause:   "El estado debe ser 'PAGADO', 'PENDIENTE' o 'NO_PAGO'",
 			}
 			c.ServeJSON()
 			return
@@ -282,7 +284,7 @@ func (c *PagoController) Post() {
 		FECHA:             fecha,
 		HORA:              hora,
 		MONTO:             in.Monto,
-		ESTADO_PAGO:       in.EstadoPago,   // e.g. "pagado"
+		ESTADO_PAGO:       in.EstadoPago,   // e.g. "PAGADO"
 		PK_ID_METODO_PAGO: in.MetodoPagoId, // FK
 		UPDATED_BY:        updatedBy,       // opcional
 		// UPDATED_AT se maneja con auto_now en el modelo
@@ -405,11 +407,12 @@ func (c *PagoController) Put() {
 	}
 
 	if estado, ok := input["ESTADO_PAGO"].(string); ok && estado != "" {
+		estado = strings.ToUpper(estado)
 		if !estadosPagoPermitidos[estado] {
 			c.Ctx.Output.SetStatus(http.StatusBadRequest)
 			c.Data["json"] = models.ApiResponse{
 				Code:    http.StatusBadRequest,
-				Message: "Estado de pago inválido. Debe ser 'pagado', 'pendiente' o 'no pago'",
+				Message: "Estado de pago inválido. Debe ser 'PAGADO', 'PENDIENTE' o 'NO_PAGO'",
 			}
 			c.ServeJSON()
 			return

--- a/controllers/PedidoController.go
+++ b/controllers/PedidoController.go
@@ -127,7 +127,7 @@ func (c *PedidoController) GetAll() {
 
 // @Title PostPedido
 // @Summary Crear un nuevo pedido
-// @Description Crea un nuevo pedido. Fuerza FECHA/HORA (Bogotá) y ESTADO_PEDIDO=iniciado. Lee 'delivery' del JSON.
+// @Description Crea un nuevo pedido. Fuerza FECHA/HORA (Bogotá) y ESTADO_PEDIDO=INICIADO. Lee 'delivery' del JSON.
 // @Tags pedido
 // @Accept json
 // @Produce json
@@ -234,7 +234,7 @@ func (c *PedidoController) AssignDomicilio() {
 
 // @Title AssignPago
 // @Summary Asignar un pago a un pedido
-// @Description Asigna un pago existente a un pedido y actualiza su estado a "terminado" y el pago a "pagado".
+// @Description Asigna un pago existente a un pedido y actualiza su estado a "TERMINADO" y el pago a "PAGADO".
 // @Tags pedido
 // @Accept json
 // @Produce json

--- a/controllers/ProductoController.go
+++ b/controllers/ProductoController.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"restaurante/models"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/beego/beego/v2/client/orm"
@@ -137,6 +138,8 @@ func (c *ProductoController) Post() {
 		return
 	}
 
+	producto.ESTADO_PRODUCTO = models.EstadoProducto(strings.ToUpper(string(producto.ESTADO_PRODUCTO)))
+
 	if err := validateProducto(&producto); err != nil {
 		c.Ctx.Output.SetStatus(http.StatusBadRequest)
 		c.Data["json"] = models.ApiResponse{Code: http.StatusBadRequest, Message: err.Error()}
@@ -204,7 +207,7 @@ func (c *ProductoController) Put() {
 		producto.CALORIAS = input.CALORIAS
 		producto.DESCRIPCION = input.DESCRIPCION
 		producto.PRECIO = input.PRECIO
-		producto.ESTADO_PRODUCTO = input.ESTADO_PRODUCTO
+		producto.ESTADO_PRODUCTO = models.EstadoProducto(strings.ToUpper(string(input.ESTADO_PRODUCTO)))
 		producto.CANTIDAD = input.CANTIDAD
 		producto.PK_ID_SUBCATEGORIA = input.PK_ID_SUBCATEGORIA
 		if len(input.IMAGEN) > 0 {
@@ -301,7 +304,7 @@ func (c *ProductoController) Delete() {
 		c.ServeJSON()
 		return
 	}
-	// Cambiar el estado del producto a "no disponible" para el borrado lógico
+	// Cambiar el estado del producto a "NO_DISPONIBLE" para el borrado lógico
 	producto.ESTADO_PRODUCTO = models.EstadoProductoNoDisponible
 	if _, err := o.Update(producto, "ESTADO_PRODUCTO"); err != nil {
 		c.Ctx.Output.SetStatus(http.StatusInternalServerError)
@@ -333,7 +336,7 @@ func validateProducto(producto *models.Producto) error {
 		return fmt.Errorf("el campo 'CALORIAS' debe ser un número positivo")
 	}
 	if producto.ESTADO_PRODUCTO != models.EstadoProductoDisponible && producto.ESTADO_PRODUCTO != models.EstadoProductoNoDisponible {
-		return fmt.Errorf("el campo 'ESTADO_PRODUCTO' debe ser 'disponible' o 'no disponible'")
+		return fmt.Errorf("el campo 'ESTADO_PRODUCTO' debe ser 'DISPONIBLE' o 'NO_DISPONIBLE'")
 	}
 	return nil
 }

--- a/controllers/ReservaController.go
+++ b/controllers/ReservaController.go
@@ -243,7 +243,7 @@ func (c *ReservaController) Post() {
 				c.Data["json"] = models.ApiResponse{
 					Code:    http.StatusBadRequest,
 					Message: "Estado de reserva inválido",
-					Cause:   "El estado debe ser uno de los siguientes: pendiente, confirmada, cancelada, cumplida",
+					Cause:   "El estado debe ser uno de los siguientes: PENDIENTE, CONFIRMADA, CANCELADA, CUMPLIDA",
 				}
 				c.ServeJSON()
 				return
@@ -530,7 +530,7 @@ func (c *ReservaController) GetByParameter() {
 
 // @Title Delete
 // @Summary Cancelar una reserva
-// @Description Actualiza el estado de una reserva a "cancelada".
+// @Description Actualiza el estado de una reserva a "CANCELADA".
 // @Tags reservas
 // @Accept json
 // @Produce json
@@ -566,8 +566,8 @@ func (c *ReservaController) Delete() {
 		return
 	}
 
-	// Actualizar el estado a cancelada
-	estadoCancelada := "cancelada"
+	// Actualizar el estado a CANCELADA
+	estadoCancelada := models.EstadoReservaCancelada
 	reserva.ESTADO_RESERVA = &estadoCancelada
 	reserva.UPDATED_AT = time.Now() // Actualizar la fecha de modificación
 

--- a/controllers/horario_trabajador_controller_test.go
+++ b/controllers/horario_trabajador_controller_test.go
@@ -44,7 +44,7 @@ func TestHorarioTrabajadorPostSuccess(t *testing.T) {
 	}
 	defer func() { MockExec = nil }()
 
-	body := `{"documentoTrabajador":1,"dia":"lunes","horaInicio":"08:00:00","horaFin":"17:00:00"}`
+	body := `{"documentoTrabajador":1,"dia":"LUNES","horaInicio":"08:00:00","horaFin":"17:00:00"}`
 	c, w := setupHTCtx(http.MethodPost, "/horario_trabajador", body)
 	c.Post()
 	if w.Code != http.StatusCreated {
@@ -70,7 +70,7 @@ func TestHorarioTrabajadorPutInvalidDia(t *testing.T) {
 func TestHorarioTrabajadorPutSuccess(t *testing.T) {
 	MockQuery = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
 		cols := []string{"pk_documento_trabajador", "dia", "hora_inicio", "hora_fin"}
-		vals := [][]driver.Value{{int64(1), "lunes", time.Date(2024, 1, 1, 8, 0, 0, 0, time.UTC), time.Date(2024, 1, 1, 17, 0, 0, 0, time.UTC)}}
+		vals := [][]driver.Value{{int64(1), "LUNES", time.Date(2024, 1, 1, 8, 0, 0, 0, time.UTC), time.Date(2024, 1, 1, 17, 0, 0, 0, time.UTC)}}
 		return &mockRows{columns: cols, values: vals}, nil
 	}
 	MockExec = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Result, error) {
@@ -79,7 +79,7 @@ func TestHorarioTrabajadorPutSuccess(t *testing.T) {
 	defer func() { MockExec = nil; MockQuery = nil }()
 
 	body := `{"horaFin":"18:00:00"}`
-	c, w := setupHTCtx(http.MethodPut, "/horario_trabajador?documento=1&dia=lunes", body)
+	c, w := setupHTCtx(http.MethodPut, "/horario_trabajador?documento=1&dia=LUNES", body)
 	c.Put()
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", w.Code)

--- a/controllers/pago_controller_test.go
+++ b/controllers/pago_controller_test.go
@@ -111,7 +111,7 @@ func TestPagoGetAllWithoutDB(t *testing.T) {
 	}
 }
 func TestPagoPostMissingFecha(t *testing.T) {
-	body := `{"horaPago":"10:00:00","monto":1000,"estadoPago":"pagado","metodoPagoId":1}`
+	body := `{"horaPago":"10:00:00","monto":1000,"estadoPago":"PAGADO","metodoPagoId":1}`
 	r := httptest.NewRequest(http.MethodPost, "/pagos", strings.NewReader(body))
 	w := httptest.NewRecorder()
 	ctx := context.NewContext()
@@ -129,7 +129,7 @@ func TestPagoPostMissingFecha(t *testing.T) {
 }
 
 func TestPagoPostInvalidHora(t *testing.T) {
-	body := `{"fechaPago":"2024-01-01","horaPago":"25:00","monto":1000,"estadoPago":"pagado","metodoPagoId":1}`
+	body := `{"fechaPago":"2024-01-01","horaPago":"25:00","monto":1000,"estadoPago":"PAGADO","metodoPagoId":1}`
 	r := httptest.NewRequest(http.MethodPost, "/pagos", strings.NewReader(body))
 	w := httptest.NewRecorder()
 	ctx := context.NewContext()
@@ -165,7 +165,7 @@ func TestPagoPostInvalidEstado(t *testing.T) {
 }
 
 func TestPagoPostMissingMetodoPago(t *testing.T) {
-	body := `{"fechaPago":"2024-01-01","horaPago":"10:00:00","monto":1000,"estadoPago":"pagado"}`
+	body := `{"fechaPago":"2024-01-01","horaPago":"10:00:00","monto":1000,"estadoPago":"PAGADO"}`
 	r := httptest.NewRequest(http.MethodPost, "/pagos", strings.NewReader(body))
 	w := httptest.NewRecorder()
 	ctx := context.NewContext()
@@ -183,7 +183,7 @@ func TestPagoPostMissingMetodoPago(t *testing.T) {
 }
 
 func TestPagoPostMissingHora(t *testing.T) {
-	body := `{"fechaPago":"2024-01-01","monto":1000,"estadoPago":"pagado","metodoPagoId":1}`
+	body := `{"fechaPago":"2024-01-01","monto":1000,"estadoPago":"PAGADO","metodoPagoId":1}`
 	r := httptest.NewRequest(http.MethodPost, "/pagos", strings.NewReader(body))
 	w := httptest.NewRecorder()
 	ctx := context.NewContext()
@@ -199,7 +199,7 @@ func TestPagoPostMissingHora(t *testing.T) {
 }
 
 func TestPagoPostSuccess(t *testing.T) {
-	body := `{"estadoPago":"pagado","fechaPago":"2024-01-01","horaPago":"10:00:00","metodoPagoId":1,"monto":1000}`
+	body := `{"estadoPago":"PAGADO","fechaPago":"2024-01-01","horaPago":"10:00:00","metodoPagoId":1,"monto":1000}`
 	r := httptest.NewRequest(http.MethodPost, "/pagos", strings.NewReader(body))
 	w := httptest.NewRecorder()
 	ctx := context.NewContext()
@@ -225,7 +225,7 @@ func TestPagoPostSuccess(t *testing.T) {
 }
 
 func TestPagoPostMissingMonto(t *testing.T) {
-	body := `{"fechaPago":"2024-01-01","horaPago":"10:00:00","estadoPago":"pagado","metodoPagoId":1}`
+	body := `{"fechaPago":"2024-01-01","horaPago":"10:00:00","estadoPago":"PAGADO","metodoPagoId":1}`
 	r := httptest.NewRequest(http.MethodPost, "/pagos", strings.NewReader(body))
 	w := httptest.NewRecorder()
 	ctx := context.NewContext()
@@ -241,7 +241,7 @@ func TestPagoPostMissingMonto(t *testing.T) {
 }
 
 func TestPagoPostInvalidFecha(t *testing.T) {
-	body := `{"fechaPago":"2024-13-01","horaPago":"10:00:00","monto":1000,"estadoPago":"pagado","metodoPagoId":1}`
+	body := `{"fechaPago":"2024-13-01","horaPago":"10:00:00","monto":1000,"estadoPago":"PAGADO","metodoPagoId":1}`
 	r := httptest.NewRequest(http.MethodPost, "/pagos", strings.NewReader(body))
 	w := httptest.NewRecorder()
 	ctx := context.NewContext()
@@ -384,7 +384,7 @@ func TestPagoDeleteNotFound(t *testing.T) {
 func TestPagoGetAllSuccess(t *testing.T) {
 	orig := pagoNewOrm
 	pagoNewOrm = func() ormer {
-		pagos := []models.Pago{{PK_ID_PAGO: int64(1), FECHA: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC), HORA: time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC), ESTADO_PAGO: "pagado", PK_ID_METODO_PAGO: int64(1)}}
+		pagos := []models.Pago{{PK_ID_PAGO: int64(1), FECHA: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC), HORA: time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC), ESTADO_PAGO: "PAGADO", PK_ID_METODO_PAGO: int64(1)}}
 		return fakeOrmer{queryAll: func(res interface{}, cols ...string) (int64, error) {
 			ptr := res.(*[]models.Pago)
 			*ptr = pagos
@@ -436,12 +436,12 @@ func TestPagoGetAllFilterOthers(t *testing.T) {
 	orig := pagoNewOrm
 	pagoNewOrm = func() ormer {
 		pagos := []models.Pago{
-			{FECHA: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC), HORA: time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC), ESTADO_PAGO: "pagado", PK_ID_METODO_PAGO: int64(1)},
-			{FECHA: time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC), HORA: time.Date(2024, 1, 2, 10, 0, 0, 0, time.UTC), ESTADO_PAGO: "pagado", PK_ID_METODO_PAGO: int64(1)},
-			{FECHA: time.Date(2024, 2, 1, 0, 0, 0, 0, time.UTC), HORA: time.Date(2024, 2, 1, 10, 0, 0, 0, time.UTC), ESTADO_PAGO: "pagado", PK_ID_METODO_PAGO: int64(1)},
-			{FECHA: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC), HORA: time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC), ESTADO_PAGO: "pagado", PK_ID_METODO_PAGO: int64(1)},
-			{FECHA: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC), HORA: time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC), ESTADO_PAGO: "no pago", PK_ID_METODO_PAGO: int64(1)},
-			{FECHA: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC), HORA: time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC), ESTADO_PAGO: "pagado", PK_ID_METODO_PAGO: int64(2)},
+			{FECHA: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC), HORA: time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC), ESTADO_PAGO: "PAGADO", PK_ID_METODO_PAGO: int64(1)},
+			{FECHA: time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC), HORA: time.Date(2024, 1, 2, 10, 0, 0, 0, time.UTC), ESTADO_PAGO: "PAGADO", PK_ID_METODO_PAGO: int64(1)},
+			{FECHA: time.Date(2024, 2, 1, 0, 0, 0, 0, time.UTC), HORA: time.Date(2024, 2, 1, 10, 0, 0, 0, time.UTC), ESTADO_PAGO: "PAGADO", PK_ID_METODO_PAGO: int64(1)},
+			{FECHA: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC), HORA: time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC), ESTADO_PAGO: "PAGADO", PK_ID_METODO_PAGO: int64(1)},
+			{FECHA: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC), HORA: time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC), ESTADO_PAGO: "NO_PAGO", PK_ID_METODO_PAGO: int64(1)},
+			{FECHA: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC), HORA: time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC), ESTADO_PAGO: "PAGADO", PK_ID_METODO_PAGO: int64(2)},
 		}
 		return fakeOrmer{queryAll: func(res interface{}, cols ...string) (int64, error) {
 			ptr := res.(*[]models.Pago)
@@ -450,7 +450,7 @@ func TestPagoGetAllFilterOthers(t *testing.T) {
 		}}
 	}
 	t.Cleanup(func() { pagoNewOrm = orig })
-	r := httptest.NewRequest(http.MethodGet, "/pagos?dia=1&mes=1&anio=2024&estado=pagado&metodo_pago=1", nil)
+	r := httptest.NewRequest(http.MethodGet, "/pagos?dia=1&mes=1&anio=2024&estado=PAGADO&metodo_pago=1", nil)
 	w := httptest.NewRecorder()
 	ctx := context.NewContext()
 	ctx.Reset(w, r)
@@ -466,7 +466,7 @@ func TestPagoGetAllFilterOthers(t *testing.T) {
 func TestPagoGetAllNoResults(t *testing.T) {
 	orig := pagoNewOrm
 	pagoNewOrm = func() ormer {
-		pagos := []models.Pago{{FECHA: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC), HORA: time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC), ESTADO_PAGO: "pagado", PK_ID_METODO_PAGO: int64(1)}}
+		pagos := []models.Pago{{FECHA: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC), HORA: time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC), ESTADO_PAGO: "PAGADO", PK_ID_METODO_PAGO: int64(1)}}
 		return fakeOrmer{queryAll: func(res interface{}, cols ...string) (int64, error) {
 			ptr := res.(*[]models.Pago)
 			*ptr = pagos
@@ -536,7 +536,7 @@ func TestPagoPostInsertError(t *testing.T) {
 		return fakeOrmer{insert: func(m interface{}) (int64, error) { return 0, fmt.Errorf("fail") }}
 	}
 	t.Cleanup(func() { pagoNewOrm = orig })
-	body := `{"estadoPago":"pagado","fechaPago":"2024-01-01","horaPago":"10:00:00","metodoPagoId":1,"monto":1000}`
+	body := `{"estadoPago":"PAGADO","fechaPago":"2024-01-01","horaPago":"10:00:00","metodoPagoId":1,"monto":1000}`
 	r := httptest.NewRequest(http.MethodPost, "/pagos", strings.NewReader(body))
 	w := httptest.NewRecorder()
 	ctx := context.NewContext()
@@ -560,7 +560,7 @@ func TestPagoPutSuccess(t *testing.T) {
 		}
 	}
 	t.Cleanup(func() { pagoNewOrm = orig })
-	body := `{"FECHA":"2024-02-02","HORA":"11:00:00","MONTO":2000,"ESTADO_PAGO":"pendiente","UPDATED_BY":"me","PK_ID_METODO_PAGO":1}`
+	body := `{"FECHA":"2024-02-02","HORA":"11:00:00","MONTO":2000,"ESTADO_PAGO":"PENDIENTE","UPDATED_BY":"me","PK_ID_METODO_PAGO":1}`
 	r := httptest.NewRequest(http.MethodPut, "/pagos?id=1", strings.NewReader(body))
 	w := httptest.NewRecorder()
 	ctx := context.NewContext()
@@ -584,7 +584,7 @@ func TestPagoPutSuccessWithoutUpdatedBy(t *testing.T) {
 		}
 	}
 	t.Cleanup(func() { pagoNewOrm = orig })
-	body := `{"FECHA":"2024-02-02","HORA":"11:00:00","MONTO":2000,"ESTADO_PAGO":"pendiente","PK_ID_METODO_PAGO":1}`
+	body := `{"FECHA":"2024-02-02","HORA":"11:00:00","MONTO":2000,"ESTADO_PAGO":"PENDIENTE","PK_ID_METODO_PAGO":1}`
 	r := httptest.NewRequest(http.MethodPut, "/pagos?id=1", strings.NewReader(body))
 	w := httptest.NewRecorder()
 	ctx := context.NewContext()

--- a/controllers/pedido_controller_test.go
+++ b/controllers/pedido_controller_test.go
@@ -93,7 +93,7 @@ func TestPedidoAssignPagoNotFound(t *testing.T) {
 }
 
 func TestPedidoUpdateEstadoPedidoNotFound(t *testing.T) {
-	r := httptest.NewRequest(http.MethodPut, "/pedidos/actualizar-estado?pedido_id=1&estado=terminado", nil)
+	r := httptest.NewRequest(http.MethodPut, "/pedidos/actualizar-estado?pedido_id=1&estado=TERMINADO", nil)
 	w := httptest.NewRecorder()
 	ctx := beegoCtx.NewContext()
 	ctx.Reset(w, r)
@@ -231,7 +231,7 @@ func TestPedidoGetAllWithResults(t *testing.T) {
 	MockQuery = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
 		cols := []string{"pk_id_pedido", "fecha", "hora", "delivery", "estado_pedido", "pk_id_domicilio", "pk_id_pago", "pk_id_restaurante", "updated_at", "updated_by"}
 		now := time.Now()
-		vals := [][]driver.Value{{int64(1), now, now, false, "iniciado", nil, nil, nil, now, "tester"}}
+		vals := [][]driver.Value{{int64(1), now, now, false, "INICIADO", nil, nil, nil, now, "tester"}}
 		return &mockRows{columns: cols, values: vals}, nil
 	}
 	defer func() { MockQuery = nil }()
@@ -283,7 +283,7 @@ func TestPedidoAssignDomicilioUpdateError(t *testing.T) {
 	MockQuery = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
 		cols := []string{"pk_id_pedido", "fecha", "hora", "delivery", "estado_pedido", "pk_id_domicilio", "pk_id_pago", "pk_id_restaurante", "updated_at", "updated_by"}
 		now := time.Now()
-		vals := [][]driver.Value{{int64(1), now, now, false, "iniciado", nil, nil, nil, now, "tester"}}
+		vals := [][]driver.Value{{int64(1), now, now, false, "INICIADO", nil, nil, nil, now, "tester"}}
 		return &mockRows{columns: cols, values: vals}, nil
 	}
 	MockExec = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Result, error) {
@@ -313,7 +313,7 @@ func TestPedidoAssignDomicilioSuccess(t *testing.T) {
 	MockQuery = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
 		cols := []string{"pk_id_pedido", "fecha", "hora", "delivery", "estado_pedido", "pk_id_domicilio", "pk_id_pago", "pk_id_restaurante", "updated_at", "updated_by"}
 		now := time.Now()
-		vals := [][]driver.Value{{int64(1), now, now, false, "iniciado", nil, nil, nil, now, "tester"}}
+		vals := [][]driver.Value{{int64(1), now, now, false, "INICIADO", nil, nil, nil, now, "tester"}}
 		return &mockRows{columns: cols, values: vals}, nil
 	}
 	MockExec = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Result, error) {
@@ -343,7 +343,7 @@ func TestPedidoAssignPagoUpdateError(t *testing.T) {
 	MockQuery = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
 		cols := []string{"pk_id_pedido", "fecha", "hora", "delivery", "estado_pedido", "pk_id_domicilio", "pk_id_pago", "pk_id_restaurante", "updated_at", "updated_by"}
 		now := time.Now()
-		vals := [][]driver.Value{{int64(1), now, now, false, "iniciado", nil, nil, nil, now, "tester"}}
+		vals := [][]driver.Value{{int64(1), now, now, false, "INICIADO", nil, nil, nil, now, "tester"}}
 		return &mockRows{columns: cols, values: vals}, nil
 	}
 	MockExec = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Result, error) {
@@ -376,12 +376,12 @@ func TestPedidoAssignPagoSuccess(t *testing.T) {
 			qCount++
 			cols := []string{"pk_id_pedido", "fecha", "hora", "delivery", "estado_pedido", "pk_id_domicilio", "pk_id_pago", "pk_id_restaurante", "updated_at", "updated_by"}
 			now := time.Now()
-			vals := [][]driver.Value{{int64(1), now, now, false, "iniciado", nil, nil, nil, now, "tester"}}
+			vals := [][]driver.Value{{int64(1), now, now, false, "INICIADO", nil, nil, nil, now, "tester"}}
 			return &mockRows{columns: cols, values: vals}, nil
 		}
 		cols := []string{"pk_id_pago", "fecha", "hora", "monto", "estado_pago", "pk_id_metodo_pago", "updated_at", "updated_by"}
 		now := time.Now()
-		vals := [][]driver.Value{{int64(1), now, now, int64(100), "pendiente", int64(1), now, "tester"}}
+		vals := [][]driver.Value{{int64(1), now, now, int64(100), "PENDIENTE", int64(1), now, "tester"}}
 		return &mockRows{columns: cols, values: vals}, nil
 	}
 	MockExec = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Result, error) {
@@ -411,7 +411,7 @@ func TestPedidoUpdateEstadoPedidoUpdateError(t *testing.T) {
 	MockQuery = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
 		cols := []string{"pk_id_pedido", "fecha", "hora", "delivery", "estado_pedido", "pk_id_domicilio", "pk_id_pago", "pk_id_restaurante", "updated_at", "updated_by"}
 		now := time.Now()
-		vals := [][]driver.Value{{int64(1), now, now, false, "iniciado", nil, nil, nil, now, "tester"}}
+		vals := [][]driver.Value{{int64(1), now, now, false, "INICIADO", nil, nil, nil, now, "tester"}}
 		return &mockRows{columns: cols, values: vals}, nil
 	}
 	MockExec = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Result, error) {
@@ -419,7 +419,7 @@ func TestPedidoUpdateEstadoPedidoUpdateError(t *testing.T) {
 	}
 	defer func() { MockQuery = nil; MockExec = nil }()
 
-	r := httptest.NewRequest(http.MethodPut, "/pedidos/actualizar-estado?pedido_id=1&estado=terminado", nil)
+	r := httptest.NewRequest(http.MethodPut, "/pedidos/actualizar-estado?pedido_id=1&estado=TERMINADO", nil)
 	w := httptest.NewRecorder()
 	ctx := beegoCtx.NewContext()
 	ctx.Reset(w, r)
@@ -441,7 +441,7 @@ func TestPedidoUpdateEstadoPedidoSuccess(t *testing.T) {
 	MockQuery = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
 		cols := []string{"pk_id_pedido", "fecha", "hora", "delivery", "estado_pedido", "pk_id_domicilio", "pk_id_pago", "pk_id_restaurante", "updated_at", "updated_by"}
 		now := time.Now()
-		vals := [][]driver.Value{{int64(1), now, now, false, "iniciado", nil, nil, nil, now, "tester"}}
+		vals := [][]driver.Value{{int64(1), now, now, false, "INICIADO", nil, nil, nil, now, "tester"}}
 		return &mockRows{columns: cols, values: vals}, nil
 	}
 	MockExec = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Result, error) {
@@ -449,7 +449,7 @@ func TestPedidoUpdateEstadoPedidoSuccess(t *testing.T) {
 	}
 	defer func() { MockQuery = nil; MockExec = nil }()
 
-	r := httptest.NewRequest(http.MethodPut, "/pedidos/actualizar-estado?pedido_id=1&estado=terminado", nil)
+	r := httptest.NewRequest(http.MethodPut, "/pedidos/actualizar-estado?pedido_id=1&estado=TERMINADO", nil)
 	w := httptest.NewRecorder()
 	ctx := beegoCtx.NewContext()
 	ctx.Reset(w, r)
@@ -470,7 +470,7 @@ func TestPedidoUpdateEstadoPedidoSuccess(t *testing.T) {
 func TestPedidoGetPedidoDetailsSuccess(t *testing.T) {
 	MockQuery = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
 		cols := []string{"pk_id_pedido", "fecha", "hora", "delivery", "estado_pedido", "metodo_pago", "productos", "pago_id", "metodo_pago_id", "domicilio_id", "pk_documento_cliente"}
-		vals := [][]driver.Value{{int64(1), "2024-01-01", "12:00:00", false, "terminado", "NEQUI", "[]", int64(2), int64(3), int64(4), int64(5)}}
+		vals := [][]driver.Value{{int64(1), "2024-01-01", "12:00:00", false, "TERMINADO", "NEQUI", "[]", int64(2), int64(3), int64(4), int64(5)}}
 		return &mockRows{columns: cols, values: vals}, nil
 	}
 	defer func() { MockQuery = nil }()
@@ -494,7 +494,7 @@ func TestPedidoGetPedidoDetailsSuccess(t *testing.T) {
 		"\"fechaPedido\":\"2024-01-01\"",
 		"\"horaPedido\":\"12:00:00\"",
 		"\"delivery\":false",
-		"\"estadoPedido\":\"terminado\"",
+		"\"estadoPedido\":\"TERMINADO\"",
 		"\"pagoId\":2",
 		"\"metodoPagoId\":3",
 		"\"domicilioId\":4",

--- a/controllers/producto_controller_test.go
+++ b/controllers/producto_controller_test.go
@@ -14,16 +14,16 @@ import (
 func int64Ptr(i int64) *int64 { return &i }
 
 func TestValidateProducto(t *testing.T) {
-	valid := &models.Producto{NOMBRE: "A", PRECIO: 10, ESTADO_PRODUCTO: "disponible"}
+	valid := &models.Producto{NOMBRE: "A", PRECIO: 10, ESTADO_PRODUCTO: "DISPONIBLE"}
 	if err := validateProducto(valid); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 
 	tests := []models.Producto{
-		{PRECIO: 10, ESTADO_PRODUCTO: "disponible"},                                      // missing name
-		{NOMBRE: "B", PRECIO: 0, ESTADO_PRODUCTO: "disponible"},                          // zero price
-		{NOMBRE: "B", PRECIO: -5, ESTADO_PRODUCTO: "disponible"},                         // negative price
-		{NOMBRE: "B", PRECIO: 10, CALORIAS: int64Ptr(-1), ESTADO_PRODUCTO: "disponible"}, // negative calories
+		{PRECIO: 10, ESTADO_PRODUCTO: "DISPONIBLE"},                                      // missing name
+		{NOMBRE: "B", PRECIO: 0, ESTADO_PRODUCTO: "DISPONIBLE"},                          // zero price
+		{NOMBRE: "B", PRECIO: -5, ESTADO_PRODUCTO: "DISPONIBLE"},                         // negative price
+		{NOMBRE: "B", PRECIO: 10, CALORIAS: int64Ptr(-1), ESTADO_PRODUCTO: "DISPONIBLE"}, // negative calories
 		{NOMBRE: "B", PRECIO: 10, ESTADO_PRODUCTO: "OTRO"},                               // invalid estado
 	}
 
@@ -89,7 +89,7 @@ func TestProductoGetByIdNotFound(t *testing.T) {
 }
 
 func TestProductoPostMissingNombre(t *testing.T) {
-	body := bytes.NewBufferString(`{"estadoProducto":"disponible","precio":10}`)
+	body := bytes.NewBufferString(`{"estadoProducto":"DISPONIBLE","precio":10}`)
 	r := httptest.NewRequest(http.MethodPost, "/productos", body)
 	r.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()

--- a/models/enums.go
+++ b/models/enums.go
@@ -4,63 +4,63 @@ package models
 type EstadoDomicilio = string
 
 const (
-	EstadoDomicilioPendiente EstadoDomicilio = "pendiente"
-	EstadoDomicilioEnCamino  EstadoDomicilio = "en camino"
-	EstadoDomicilioEntregado EstadoDomicilio = "entregado"
+	EstadoDomicilioPendiente EstadoDomicilio = "PENDIENTE"
+	EstadoDomicilioEnCamino  EstadoDomicilio = "EN_CAMINO"
+	EstadoDomicilioEntregado EstadoDomicilio = "ENTREGADO"
 )
 
 // EstadoNomina represents the estado_nomina_enum values.
 type EstadoNomina = string
 
 const (
-	EstadoNominaPago   EstadoNomina = "pago"
-	EstadoNominaNoPago EstadoNomina = "no pago"
+	EstadoNominaPago   EstadoNomina = "PAGO"
+	EstadoNominaNoPago EstadoNomina = "NO_PAGO"
 )
 
 // EstadoPago represents the estado_pago_enum values.
 type EstadoPago = string
 
 const (
-	EstadoPagoPagado    EstadoPago = "pagado"
-	EstadoPagoPendiente EstadoPago = "pendiente"
-	EstadoPagoNoPago    EstadoPago = "no pago"
+	EstadoPagoPagado    EstadoPago = "PAGADO"
+	EstadoPagoPendiente EstadoPago = "PENDIENTE"
+	EstadoPagoNoPago    EstadoPago = "NO_PAGO"
 )
 
 // EstadoPedido represents the estado_pedido_enum values.
 type EstadoPedido = string
 
 const (
-	EstadoPedidoIniciado  EstadoPedido = "iniciado"
-	EstadoPedidoTerminado EstadoPedido = "terminado"
+	EstadoPedidoIniciado  EstadoPedido = "INICIADO"
+	EstadoPedidoTerminado EstadoPedido = "TERMINADO"
 )
 
 // EstadoProducto represents the estado_producto_enum values.
 type EstadoProducto = string
 
 const (
-	EstadoProductoDisponible   EstadoProducto = "disponible"
-	EstadoProductoNoDisponible EstadoProducto = "no disponible"
+	EstadoProductoDisponible   EstadoProducto = "DISPONIBLE"
+	EstadoProductoNoDisponible EstadoProducto = "NO_DISPONIBLE"
 )
 
 // EstadoReserva represents the estado_reserva_enum values.
 type EstadoReserva = string
 
 const (
-	EstadoReservaPendiente  EstadoReserva = "pendiente"
-	EstadoReservaConfirmada EstadoReserva = "confirmada"
-	EstadoReservaCancelada  EstadoReserva = "cancelada"
-	EstadoReservaCumplida   EstadoReserva = "cumplida"
+	EstadoReservaPendiente  EstadoReserva = "PENDIENTE"
+	EstadoReservaConfirmada EstadoReserva = "CONFIRMADA"
+	EstadoReservaCancelada  EstadoReserva = "CANCELADA"
+	EstadoReservaCumplida   EstadoReserva = "CUMPLIDA"
 )
 
 // DiaSemana represents the dia_semana_enum values.
 type DiaSemana = string
 
 const (
-	DiaLunes     DiaSemana = "lunes"
-	DiaMartes    DiaSemana = "martes"
-	DiaMiercoles DiaSemana = "miercoles"
-	DiaJueves    DiaSemana = "jueves"
-	DiaViernes   DiaSemana = "viernes"
-	DiaSabado    DiaSemana = "sabado"
-	DiaDomingo   DiaSemana = "domingo"
+	DiaLunes     DiaSemana = "LUNES"
+	DiaMartes    DiaSemana = "MARTES"
+	DiaMiercoles DiaSemana = "MIERCOLES"
+	DiaJueves    DiaSemana = "JUEVES"
+	DiaViernes   DiaSemana = "VIERNES"
+	DiaSabado    DiaSemana = "SABADO"
+	DiaDomingo   DiaSemana = "DOMINGO"
 )

--- a/tests/enums_test.go
+++ b/tests/enums_test.go
@@ -8,10 +8,10 @@ import (
 // TestEstadoEnums verifies that the enumerated constants map to the expected string values.
 func TestEstadoEnums(t *testing.T) {
 	reservas := map[string]models.EstadoReserva{
-		"pendiente":  models.EstadoReservaPendiente,
-		"confirmada": models.EstadoReservaConfirmada,
-		"cancelada":  models.EstadoReservaCancelada,
-		"cumplida":   models.EstadoReservaCumplida,
+		"PENDIENTE":  models.EstadoReservaPendiente,
+		"CONFIRMADA": models.EstadoReservaConfirmada,
+		"CANCELADA":  models.EstadoReservaCancelada,
+		"CUMPLIDA":   models.EstadoReservaCumplida,
 	}
 	for expect, val := range reservas {
 		if string(val) != expect {
@@ -20,8 +20,8 @@ func TestEstadoEnums(t *testing.T) {
 	}
 
 	nominas := map[string]models.EstadoNomina{
-		"pago":    models.EstadoNominaPago,
-		"no pago": models.EstadoNominaNoPago,
+		"PAGO":    models.EstadoNominaPago,
+		"NO_PAGO": models.EstadoNominaNoPago,
 	}
 	for expect, val := range nominas {
 		if string(val) != expect {
@@ -30,9 +30,9 @@ func TestEstadoEnums(t *testing.T) {
 	}
 
 	domicilios := map[string]models.EstadoDomicilio{
-		"pendiente": models.EstadoDomicilioPendiente,
-		"en camino": models.EstadoDomicilioEnCamino,
-		"entregado": models.EstadoDomicilioEntregado,
+		"PENDIENTE": models.EstadoDomicilioPendiente,
+		"EN_CAMINO": models.EstadoDomicilioEnCamino,
+		"ENTREGADO": models.EstadoDomicilioEntregado,
 	}
 	for expect, val := range domicilios {
 		if string(val) != expect {
@@ -41,9 +41,9 @@ func TestEstadoEnums(t *testing.T) {
 	}
 
 	pagos := map[string]models.EstadoPago{
-		"pagado":    models.EstadoPagoPagado,
-		"pendiente": models.EstadoPagoPendiente,
-		"no pago":   models.EstadoPagoNoPago,
+		"PAGADO":    models.EstadoPagoPagado,
+		"PENDIENTE": models.EstadoPagoPendiente,
+		"NO_PAGO":   models.EstadoPagoNoPago,
 	}
 	for expect, val := range pagos {
 		if string(val) != expect {
@@ -52,8 +52,8 @@ func TestEstadoEnums(t *testing.T) {
 	}
 
 	pedidos := map[string]models.EstadoPedido{
-		"iniciado":  models.EstadoPedidoIniciado,
-		"terminado": models.EstadoPedidoTerminado,
+		"INICIADO":  models.EstadoPedidoIniciado,
+		"TERMINADO": models.EstadoPedidoTerminado,
 	}
 	for expect, val := range pedidos {
 		if string(val) != expect {
@@ -62,8 +62,8 @@ func TestEstadoEnums(t *testing.T) {
 	}
 
 	productos := map[string]models.EstadoProducto{
-		"disponible":    models.EstadoProductoDisponible,
-		"no disponible": models.EstadoProductoNoDisponible,
+		"DISPONIBLE":    models.EstadoProductoDisponible,
+		"NO_DISPONIBLE": models.EstadoProductoNoDisponible,
 	}
 	for expect, val := range productos {
 		if string(val) != expect {
@@ -72,13 +72,13 @@ func TestEstadoEnums(t *testing.T) {
 	}
 
 	dias := map[string]models.DiaSemana{
-		"lunes":     models.DiaLunes,
-		"martes":    models.DiaMartes,
-		"miercoles": models.DiaMiercoles,
-		"jueves":    models.DiaJueves,
-		"viernes":   models.DiaViernes,
-		"sabado":    models.DiaSabado,
-		"domingo":   models.DiaDomingo,
+		"LUNES":     models.DiaLunes,
+		"MARTES":    models.DiaMartes,
+		"MIERCOLES": models.DiaMiercoles,
+		"JUEVES":    models.DiaJueves,
+		"VIERNES":   models.DiaViernes,
+		"SABADO":    models.DiaSabado,
+		"DOMINGO":   models.DiaDomingo,
 	}
 	for expect, val := range dias {
 		if string(val) != expect {


### PR DESCRIPTION
## Summary
- convert enum string values to `UPPER_CASE` with underscores
- align controllers and tests with new enum literals
- document updated enum values in README

## Testing
- `go test ./...` *(fails: field models.Producto.IMAGEN unsupport field type; missing conf/app.conf)*

------
https://chatgpt.com/codex/tasks/task_e_68b4edb2aff48325988bd3601559b388