### PR TITLE
Add cancelado status to EstadoPedido

### DIFF
--- a/models/enums.go
+++ b/models/enums.go
@@ -33,6 +33,7 @@ type EstadoPedido = string
 const (
 	EstadoPedidoIniciado  EstadoPedido = "INICIADO"
 	EstadoPedidoTerminado EstadoPedido = "TERMINADO"
+	EstadoPedidoCancelado EstadoPedido = "CANCELADO"
 )
 
 // EstadoProducto represents the estado_producto_enum values.

--- a/tests/enums_test.go
+++ b/tests/enums_test.go
@@ -54,6 +54,7 @@ func TestEstadoEnums(t *testing.T) {
 	pedidos := map[string]models.EstadoPedido{
 		"INICIADO":  models.EstadoPedidoIniciado,
 		"TERMINADO": models.EstadoPedidoTerminado,
+		"CANCELADO": models.EstadoPedidoCancelado,
 	}
 	for expect, val := range pedidos {
 		if string(val) != expect {


### PR DESCRIPTION
## Summary
- add `EstadoPedidoCancelado` constant
- test that `EstadoPedido` enums include `CANCELADO`

## Testing
- `go test -v ./...` *(fails: field: models.Producto.IMAGEN, unsupport field type , may be miss setting tag)*

------
https://chatgpt.com/codex/tasks/task_e_68b4fe97a46083259f81c74ab1d499c9