### PR TITLE
Align models with DB schema and add validation

### DIFF
--- a/controllers/DomicilioController.go
+++ b/controllers/DomicilioController.go
@@ -360,7 +360,7 @@ func (c *DomicilioController) Post() {
 		domicilio.ENTREGADO = entregado
 	}
 	if observaciones, ok := input["observaciones"].(string); ok {
-		domicilio.OBSERVACIONES = observaciones
+		domicilio.OBSERVACIONES = &observaciones
 	}
 	if createdBy, ok := input["createdBy"].(string); ok {
 		domicilio.CREATED_BY = &createdBy
@@ -562,7 +562,7 @@ func (c *DomicilioController) Delete() {
 // @Router /domicilios/asignar [post]
 func (c *DomicilioController) AsignarDomiciliario() {
 	domicilioID, _ := c.GetInt64("domicilio_id")
-	trabajadorID, _ := c.GetInt("trabajador_id")
+	trabajadorID, _ := c.GetInt64("trabajador_id")
 
 	o := orm.NewOrm()
 

--- a/controllers/cambios_horario_controller_test.go
+++ b/controllers/cambios_horario_controller_test.go
@@ -294,7 +294,7 @@ func TestCambiosHorario_GetAll_WithHoras(t *testing.T) {
 				FECHA:                time.Date(2024, 10, 12, 0, 0, 0, 0, time.UTC),
 				ABIERTO:              true,
 				HORA_APERTURA:        &horaApertura,
-				HORA_CIERRE:          &horaCierre,
+				HORA_CIERRE:          horaCierre,
 			},
 		}
 		return 1, nil
@@ -324,7 +324,7 @@ func TestCambiosHorario_GetByCurrentDate_Success(t *testing.T) {
 			FECHA:                d,
 			ABIERTO:              true,
 			HORA_APERTURA:        &ha,
-			HORA_CIERRE:          &hc,
+			HORA_CIERRE:          hc,
 		}
 		return nil
 	}

--- a/controllers/pago_controller_test.go
+++ b/controllers/pago_controller_test.go
@@ -384,7 +384,8 @@ func TestPagoDeleteNotFound(t *testing.T) {
 func TestPagoGetAllSuccess(t *testing.T) {
 	orig := pagoNewOrm
 	pagoNewOrm = func() ormer {
-		pagos := []models.Pago{{PK_ID_PAGO: int64(1), FECHA: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC), HORA: time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC), ESTADO_PAGO: "PAGADO", PK_ID_METODO_PAGO: int64(1)}}
+		metodo := int64(1)
+		pagos := []models.Pago{{PK_ID_PAGO: int64(1), FECHA: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC), HORA: time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC), ESTADO_PAGO: "PAGADO", PK_ID_METODO_PAGO: &metodo}}
 		return fakeOrmer{queryAll: func(res interface{}, cols ...string) (int64, error) {
 			ptr := res.(*[]models.Pago)
 			*ptr = pagos
@@ -435,13 +436,15 @@ func TestPagoGetAllFilterFecha(t *testing.T) {
 func TestPagoGetAllFilterOthers(t *testing.T) {
 	orig := pagoNewOrm
 	pagoNewOrm = func() ormer {
+		metodo1 := int64(1)
+		metodo2 := int64(2)
 		pagos := []models.Pago{
-			{FECHA: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC), HORA: time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC), ESTADO_PAGO: "PAGADO", PK_ID_METODO_PAGO: int64(1)},
-			{FECHA: time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC), HORA: time.Date(2024, 1, 2, 10, 0, 0, 0, time.UTC), ESTADO_PAGO: "PAGADO", PK_ID_METODO_PAGO: int64(1)},
-			{FECHA: time.Date(2024, 2, 1, 0, 0, 0, 0, time.UTC), HORA: time.Date(2024, 2, 1, 10, 0, 0, 0, time.UTC), ESTADO_PAGO: "PAGADO", PK_ID_METODO_PAGO: int64(1)},
-			{FECHA: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC), HORA: time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC), ESTADO_PAGO: "PAGADO", PK_ID_METODO_PAGO: int64(1)},
-			{FECHA: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC), HORA: time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC), ESTADO_PAGO: "NO_PAGO", PK_ID_METODO_PAGO: int64(1)},
-			{FECHA: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC), HORA: time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC), ESTADO_PAGO: "PAGADO", PK_ID_METODO_PAGO: int64(2)},
+			{FECHA: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC), HORA: time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC), ESTADO_PAGO: "PAGADO", PK_ID_METODO_PAGO: &metodo1},
+			{FECHA: time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC), HORA: time.Date(2024, 1, 2, 10, 0, 0, 0, time.UTC), ESTADO_PAGO: "PAGADO", PK_ID_METODO_PAGO: &metodo1},
+			{FECHA: time.Date(2024, 2, 1, 0, 0, 0, 0, time.UTC), HORA: time.Date(2024, 2, 1, 10, 0, 0, 0, time.UTC), ESTADO_PAGO: "PAGADO", PK_ID_METODO_PAGO: &metodo1},
+			{FECHA: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC), HORA: time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC), ESTADO_PAGO: "PAGADO", PK_ID_METODO_PAGO: &metodo1},
+			{FECHA: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC), HORA: time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC), ESTADO_PAGO: "NO_PAGO", PK_ID_METODO_PAGO: &metodo1},
+			{FECHA: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC), HORA: time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC), ESTADO_PAGO: "PAGADO", PK_ID_METODO_PAGO: &metodo2},
 		}
 		return fakeOrmer{queryAll: func(res interface{}, cols ...string) (int64, error) {
 			ptr := res.(*[]models.Pago)
@@ -466,7 +469,8 @@ func TestPagoGetAllFilterOthers(t *testing.T) {
 func TestPagoGetAllNoResults(t *testing.T) {
 	orig := pagoNewOrm
 	pagoNewOrm = func() ormer {
-		pagos := []models.Pago{{FECHA: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC), HORA: time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC), ESTADO_PAGO: "PAGADO", PK_ID_METODO_PAGO: int64(1)}}
+		metodo := int64(1)
+		pagos := []models.Pago{{FECHA: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC), HORA: time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC), ESTADO_PAGO: "PAGADO", PK_ID_METODO_PAGO: &metodo}}
 		return fakeOrmer{queryAll: func(res interface{}, cols ...string) (int64, error) {
 			ptr := res.(*[]models.Pago)
 			*ptr = pagos

--- a/models/ControlNomina.go
+++ b/models/ControlNomina.go
@@ -7,9 +7,9 @@ import (
 )
 
 type ControlNomina struct {
-	PK_ID_CONTROL_NOMINA int64     `orm:"column(pk_id_control_nomina);pk;auto" json:"controlNominaId"`
-	Fecha                time.Time `orm:"column(fecha);type(date);unique" json:"fecha"`
-	Estado               string    `orm:"column(estado);type(text);default(NO GENERADA)" json:"estado"`
+	PK_ID_CONTROL_NOMINA int64               `orm:"column(pk_id_control_nomina);pk;auto" json:"controlNominaId"`
+	Fecha                time.Time           `orm:"column(fecha);type(date);unique" json:"fecha"`
+	Estado               EstadoControlNomina `orm:"column(estado);type(text);default(NO GENERADA)" json:"estado"`
 }
 
 func (c *ControlNomina) TableName() string {
@@ -18,4 +18,9 @@ func (c *ControlNomina) TableName() string {
 
 func init() {
 	orm.RegisterModel(new(ControlNomina))
+}
+
+// ValidEstado indica si el estado actual está permitido
+func (c *ControlNomina) ValidEstado() bool {
+	return c.Estado.IsValid()
 }

--- a/models/Domicilio.go
+++ b/models/Domicilio.go
@@ -8,18 +8,19 @@ import (
 )
 
 type Domicilio struct {
-	PK_ID_DOMICILIO         int64           `orm:"column(pk_id_domicilio);pk;auto" json:"domicilioId"`
-	DIRECCION               string          `orm:"column(direccion);type(text)" json:"direccion"`
-	TELEFONO                string          `orm:"column(telefono);type(text)" json:"telefono"`
-	ESTADO_DOMICILIO        EstadoDomicilio `orm:"column(estado_domicilio);type(text)" json:"estado"`
-	ENTREGADO               bool            `orm:"column(entregado);type(boolean)" json:"entregado"`
-	FECHA                   time.Time       `orm:"column(fecha);type(date)" json:"fechaDomicilio"`
-	OBSERVACIONES           string          `orm:"column(observaciones);type(text)" json:"observaciones"`
-	CREATED_AT              time.Time       `orm:"column(created_at);type(timestamp);auto_now_add" json:"createdAt"`
-	UPDATED_AT              time.Time       `orm:"column(updated_at);type(timestamp);auto_now" json:"updatedAt"`
-	CREATED_BY              *string         `orm:"column(created_by);type(text)" json:"createdBy,omitempty"`
-	UPDATED_BY              *string         `orm:"column(updated_by);type(text)" json:"updatedBy,omitempty"`
-	PK_DOCUMENTO_TRABAJADOR *int            `orm:"column(pk_documento_trabajador);null" json:"trabajadorAsignado,omitempty"`
+	PK_ID_DOMICILIO  int64           `orm:"column(pk_id_domicilio);pk;auto" json:"domicilioId"`
+	DIRECCION        string          `orm:"column(direccion);type(text)" json:"direccion"`
+	TELEFONO         string          `orm:"column(telefono);type(text)" json:"telefono"`
+	ESTADO_DOMICILIO EstadoDomicilio `orm:"column(estado_domicilio);type(text)" json:"estado"`
+	// ENTREGADO es una columna generada por la base de datos
+	ENTREGADO               bool      `orm:"column(entregado);type(boolean)" json:"entregado"`
+	FECHA                   time.Time `orm:"column(fecha);type(date)" json:"fechaDomicilio"`
+	OBSERVACIONES           *string   `orm:"column(observaciones);type(text);null" json:"observaciones,omitempty"`
+	CREATED_AT              time.Time `orm:"column(created_at);type(timestamp);auto_now_add" json:"createdAt"`
+	UPDATED_AT              time.Time `orm:"column(updated_at);type(timestamp);auto_now" json:"updatedAt"`
+	CREATED_BY              *string   `orm:"column(created_by);type(text)" json:"createdBy,omitempty"`
+	UPDATED_BY              *string   `orm:"column(updated_by);type(text)" json:"updatedBy,omitempty"`
+	PK_DOCUMENTO_TRABAJADOR *int64    `orm:"column(pk_documento_trabajador);null" json:"trabajadorAsignado,omitempty"`
 }
 
 func (d *Domicilio) TableName() string {

--- a/models/NominaTrabajador.go
+++ b/models/NominaTrabajador.go
@@ -40,3 +40,9 @@ func (n *NominaTrabajador) TableName() string {
 func init() {
 	orm.RegisterModel(new(NominaTrabajador))
 }
+
+func (n *NominaTrabajador) TableUnique() [][]string {
+	return [][]string{
+		{"PK_DOCUMENTO_TRABAJADOR", "PK_ID_NOMINA"},
+	}
+}

--- a/models/controlnomina_test.go
+++ b/models/controlnomina_test.go
@@ -1,0 +1,21 @@
+package models
+
+import "testing"
+
+func TestControlNominaValidEstado(t *testing.T) {
+	c := ControlNomina{Estado: EstadoControlNominaGenerada}
+	if !c.ValidEstado() {
+		t.Errorf("expected estado %s to be valid", c.Estado)
+	}
+	c.Estado = EstadoControlNomina("OTRO")
+	if c.ValidEstado() {
+		t.Errorf("expected estado %s to be invalid", c.Estado)
+	}
+}
+
+func TestControlNominaTableName(t *testing.T) {
+	c := ControlNomina{}
+	if c.TableName() != "control_nomina" {
+		t.Errorf("expected table name control_nomina, got %s", c.TableName())
+	}
+}

--- a/models/enums.go
+++ b/models/enums.go
@@ -66,3 +66,21 @@ const (
 	DiaSabado    DiaSemana = "SABADO"
 	DiaDomingo   DiaSemana = "DOMINGO"
 )
+
+// EstadoControlNomina represents valid values for control_nomina.estado
+type EstadoControlNomina string
+
+const (
+	EstadoControlNominaNoGenerada EstadoControlNomina = "NO GENERADA"
+	EstadoControlNominaGenerada   EstadoControlNomina = "GENERADA"
+	EstadoControlNominaReGenerada EstadoControlNomina = "REGENERADA"
+)
+
+// IsValid reports whether the estado is permitted for control_nomina
+func (e EstadoControlNomina) IsValid() bool {
+	switch e {
+	case EstadoControlNominaNoGenerada, EstadoControlNominaGenerada, EstadoControlNominaReGenerada:
+		return true
+	}
+	return false
+}

--- a/models/nominatrabajador_test.go
+++ b/models/nominatrabajador_test.go
@@ -1,0 +1,14 @@
+package models
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestNominaTrabajadorTableUnique(t *testing.T) {
+	n := NominaTrabajador{}
+	expected := [][]string{{"PK_DOCUMENTO_TRABAJADOR", "PK_ID_NOMINA"}}
+	if got := n.TableUnique(); !reflect.DeepEqual(got, expected) {
+		t.Errorf("expected %v, got %v", expected, got)
+	}
+}


### PR DESCRIPTION
## Summary
- make Domicilio observations and trabajador optional with correct types
- add ControlNomina enum validation and composite uniqueness for NominaTrabajador
- adjust controllers and tests for new fields

## Testing
- `go test ./...` *(fails: TestPedidoAssignDomicilioUpdateError, TestPedidoAssignDomicilioSuccess, TestPedidoAssignPagoUpdateError, TestPedidoAssignPagoSuccess, TestPedidoUpdateEstadoPedidoUpdateError, TestPedidoUpdateEstadoPedidoSuccess, TestProductoPostMissingNombre, TestPostMissingFields, TestPutInvalidDates, TestPutHashError, TestPutValidateDatesError, TestPutTelefonoUpdated, TestInitDBSuccess, TestCambiosHorarioMarshalJSON, TestDomicilioMarshalJSON, TestIncidenciaMarshalJSON, TestNominaMarshalJSON, TestReservaMarshalJSON, TestTrabajadorMarshalJSON, TestTrabajadorMarshalJSONNil, TestProductoPriceHistoryLifecycle, TestClienteMiddleware, ...)*

------
https://chatgpt.com/codex/tasks/task_e_68b5ff098ae8832586d497218b49ae66