### PR TITLE
Add database constraints and validation

### DIFF
--- a/controllers/LoginController.go
+++ b/controllers/LoginController.go
@@ -80,7 +80,7 @@ func (c *LoginController) Login() {
 		}
 		nombre := trabajador.NOMBRE + " " + trabajador.APELLIDO
 		// Generar JWT con el rol específico del trabajador (admin, mesero, mensajero, etc.)
-		generateJWT(c, trabajador.PK_DOCUMENTO_TRABAJADOR, trabajador.ROL, nombre)
+		generateJWT(c, trabajador.PK_DOCUMENTO_TRABAJADOR, string(trabajador.ROL), nombre)
 		return
 	}
 

--- a/controllers/PedidoController.go
+++ b/controllers/PedidoController.go
@@ -140,7 +140,8 @@ func (c *PedidoController) GetAll() {
 func (c *PedidoController) Post() {
 	// Estructura mínima para leer el JSON de entrada sin acoplarse al modelo
 	var in struct {
-		Delivery *bool `json:"delivery"`
+		Delivery      *bool  `json:"delivery"`
+		PKIDDomicilio *int64 `json:"pk_id_domicilio"`
 		// Ignoramos 'pagoId', 'estadoPedido', etc. por contrato actual
 	}
 
@@ -169,6 +170,18 @@ func (c *PedidoController) Post() {
 		pedido.DELIVERY = *in.Delivery
 	} else {
 		pedido.DELIVERY = false
+	}
+	if in.PKIDDomicilio != nil {
+		pedido.PK_ID_DOMICILIO = in.PKIDDomicilio
+	}
+	if pedido.DELIVERY && pedido.PK_ID_DOMICILIO == nil {
+		c.Ctx.Output.SetStatus(400)
+		c.Data["json"] = models.ApiResponse{
+			Code:    400,
+			Message: "El domicilio es obligatorio cuando delivery es true",
+		}
+		c.ServeJSON()
+		return
 	}
 
 	o := orm.NewOrm()

--- a/controllers/TrabajadorController.go
+++ b/controllers/TrabajadorController.go
@@ -258,7 +258,16 @@ func (c *TrabajadorController) Post() {
 
 	// Procesar ROL
 	if rol, ok := input["rol"].(string); ok && rol != "" {
-		trabajador.ROL = rol
+		trabajador.ROL = models.RolTrabajador(rol)
+		if !trabajador.ROL.IsValid() {
+			c.Ctx.Output.SetStatus(http.StatusBadRequest)
+			c.Data["json"] = models.ApiResponse{
+				Code:    http.StatusBadRequest,
+				Message: "Rol inválido",
+			}
+			c.ServeJSON()
+			return
+		}
 	} else {
 		c.Ctx.Output.SetStatus(http.StatusBadRequest)
 		c.Data["json"] = models.ApiResponse{
@@ -443,7 +452,14 @@ func (c *TrabajadorController) Put() {
 	}
 
 	if rol, ok := input["ROL"].(string); ok && rol != "" {
-		trabajador.ROL = rol
+		r := models.RolTrabajador(rol)
+		if !r.IsValid() {
+			c.Ctx.Output.SetStatus(http.StatusBadRequest)
+			c.Data["json"] = models.ApiResponse{Code: http.StatusBadRequest, Message: "Rol inválido"}
+			c.ServeJSON()
+			return
+		}
+		trabajador.ROL = r
 	}
 
 	if sueldo, ok := input["SUELDO"].(float64); ok {

--- a/controllers/pedido_controller_test.go
+++ b/controllers/pedido_controller_test.go
@@ -188,6 +188,28 @@ func TestPedidoPostParseError(t *testing.T) {
 	}
 }
 
+func TestPedidoPostDeliveryWithoutDomicilio(t *testing.T) {
+	body := `{"delivery":true}`
+	r := httptest.NewRequest(http.MethodPost, "/pedidos", strings.NewReader(body))
+	r.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	ctx := beegoCtx.NewContext()
+	ctx.Reset(w, r)
+	c := PedidoController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+	c.Ctx.Input.RequestBody = []byte(body)
+
+	c.Post()
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "domicilio es obligatorio") {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
+}
+
 func TestPedidoPostSuccess(t *testing.T) {
 	MockExec = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Result, error) {
 		return mockResult{}, nil

--- a/controllers/trabajador_controller_test.go
+++ b/controllers/trabajador_controller_test.go
@@ -204,9 +204,9 @@ func TestPostMissingFields(t *testing.T) {
 		{`{"documentoTrabajador":1}`, "nombre"},
 		{`{"documentoTrabajador":1,"nombre":"a"}`, "apellido"},
 		{`{"documentoTrabajador":1,"nombre":"a","apellido":"b"}`, "rol"},
-		{`{"documentoTrabajador":1,"nombre":"a","apellido":"b","rol":"c"}`, "fechaIngreso"},
-		{`{"documentoTrabajador":1,"nombre":"a","apellido":"b","rol":"c","fechaIngreso":"2023-01-01"}`, "sueldo"},
-		{`{"documentoTrabajador":1,"nombre":"a","apellido":"b","rol":"c","fechaIngreso":"2023-01-01","sueldo":1}`, "password"},
+		{`{"documentoTrabajador":1,"nombre":"a","apellido":"b","rol":"Administrador"}`, "fechaIngreso"},
+		{`{"documentoTrabajador":1,"nombre":"a","apellido":"b","rol":"Administrador","fechaIngreso":"2023-01-01"}`, "sueldo"},
+		{`{"documentoTrabajador":1,"nombre":"a","apellido":"b","rol":"Administrador","fechaIngreso":"2023-01-01","sueldo":1}`, "password"},
 	}
 	for _, tc := range cases {
 		c, w := buildContext(http.MethodPost, "/trabajadores", tc.body)
@@ -221,14 +221,14 @@ func TestPostMissingFields(t *testing.T) {
 }
 
 func TestPostInvalidDates(t *testing.T) {
-	body := `{"documentoTrabajador":1,"nombre":"a","apellido":"b","rol":"c","fechaIngreso":"bad","sueldo":1,"password":"p"}`
+	body := `{"documentoTrabajador":1,"nombre":"a","apellido":"b","rol":"Administrador","fechaIngreso":"bad","sueldo":1,"password":"p"}`
 	c, w := buildContext(http.MethodPost, "/trabajadores", body)
 	c.Post()
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("%d", w.Code)
 	}
 
-	body2 := `{"documentoTrabajador":1,"nombre":"a","apellido":"b","rol":"c","fechaIngreso":"2023-01-01","sueldo":1,"password":"p","fechaNacimiento":"bad"}`
+	body2 := `{"documentoTrabajador":1,"nombre":"a","apellido":"b","rol":"Administrador","fechaIngreso":"2023-01-01","sueldo":1,"password":"p","fechaNacimiento":"bad"}`
 	c2, w2 := buildContext(http.MethodPost, "/trabajadores", body2)
 	c2.Post()
 	if w2.Code != http.StatusBadRequest {
@@ -240,7 +240,7 @@ func TestPostHashError(t *testing.T) {
 	originalHash := hashPassword
 	hashPassword = func(string) (string, error) { return "", errors.New("hash") }
 	defer func() { hashPassword = originalHash }()
-	body := `{"documentoTrabajador":1,"nombre":"a","apellido":"b","rol":"c","fechaIngreso":"2023-01-01","sueldo":1,"password":"p"}`
+	body := `{"documentoTrabajador":1,"nombre":"a","apellido":"b","rol":"Administrador","fechaIngreso":"2023-01-01","sueldo":1,"password":"p"}`
 	c, w := buildContext(http.MethodPost, "/trabajadores", body)
 	c.Post()
 	if w.Code != http.StatusInternalServerError {
@@ -252,7 +252,7 @@ func TestPostInsertError(t *testing.T) {
 	original := newTrabajadorOrm
 	newTrabajadorOrm = func() orm.Ormer { return &mockOrm{insertErr: errors.New("db")} }
 	defer func() { newTrabajadorOrm = original }()
-	body := `{"documentoTrabajador":1,"nombre":"a","apellido":"b","rol":"c","fechaIngreso":"2023-01-01","sueldo":1,"password":"p"}`
+	body := `{"documentoTrabajador":1,"nombre":"a","apellido":"b","rol":"Administrador","fechaIngreso":"2023-01-01","sueldo":1,"password":"p"}`
 	c, w := buildContext(http.MethodPost, "/trabajadores", body)
 	c.Post()
 	if w.Code != http.StatusInternalServerError {

--- a/models/ControlNomina.go
+++ b/models/ControlNomina.go
@@ -3,6 +3,7 @@ package models
 import (
 	"time"
 
+	"fmt"
 	"github.com/beego/beego/v2/client/orm"
 )
 
@@ -23,4 +24,25 @@ func init() {
 // ValidEstado indica si el estado actual está permitido
 func (c *ControlNomina) ValidEstado() bool {
 	return c.Estado.IsValid()
+}
+
+// Insert validates Estado before inserting
+type simpleOrmer interface {
+	Insert(interface{}) (int64, error)
+	Update(interface{}, ...string) (int64, error)
+}
+
+func (c *ControlNomina) Insert(o simpleOrmer) (int64, error) {
+	if !c.ValidEstado() {
+		return 0, fmt.Errorf("estado inválido: %s", c.Estado)
+	}
+	return o.Insert(c)
+}
+
+// Update validates Estado before updating
+func (c *ControlNomina) Update(o simpleOrmer, cols ...string) (int64, error) {
+	if !c.ValidEstado() {
+		return 0, fmt.Errorf("estado inválido: %s", c.Estado)
+	}
+	return o.Update(c, cols...)
 }

--- a/models/DetallePedido.go
+++ b/models/DetallePedido.go
@@ -15,6 +15,11 @@ func (d *DetallePedido) TableName() string {
 	return "detalle_pedido"
 }
 
+// TableUnique enforces UNIQUE(pk_id_pedido, pk_id_producto)
+func (d *DetallePedido) TableUnique() [][]string {
+	return [][]string{{"PKIDPedido", "PKIDProducto"}}
+}
+
 func init() {
 	orm.RegisterModel(new(DetallePedido))
 }

--- a/models/HorarioTrabajador.go
+++ b/models/HorarioTrabajador.go
@@ -19,6 +19,16 @@ func (h *HorarioTrabajador) TableName() string {
 	return "horario_trabajador"
 }
 
+// TableUnique enforces UNIQUE(pk_documento_trabajador, dia)
+func (h *HorarioTrabajador) TableUnique() [][]string {
+	return [][]string{{"PK_DOCUMENTO_TRABAJADOR", "DIA"}}
+}
+
+// ValidHours checks that HORA_FIN > HORA_INICIO
+func (h *HorarioTrabajador) ValidHours() bool {
+	return h.HORA_FIN.After(h.HORA_INICIO)
+}
+
 func init() {
 	orm.RegisterModel(new(HorarioTrabajador))
 }

--- a/models/PrecioProductoHist.go
+++ b/models/PrecioProductoHist.go
@@ -19,6 +19,11 @@ func (p *PrecioProductoHist) TableName() string {
 	return "precio_producto_hist"
 }
 
+// TableUnique enforces UNIQUE(pk_id_producto, fecha_vigencia)
+func (p *PrecioProductoHist) TableUnique() [][]string {
+	return [][]string{{"PKIDProducto", "FechaVigencia"}}
+}
+
 func init() {
 	orm.RegisterModel(new(PrecioProductoHist))
 }

--- a/models/Producto.go
+++ b/models/Producto.go
@@ -14,7 +14,7 @@ type Producto struct {
 	DESCRIPCION        *string        `orm:"column(descripcion);type(text);null" json:"descripcion,omitempty"`
 	PRECIO             int64          `orm:"column(precio);type(bigint)" json:"precio"`
 	ESTADO_PRODUCTO    EstadoProducto `orm:"column(estado_producto);type(text)" json:"estadoProducto"`
-	IMAGEN             string         `orm:"column(imagen);type(text);null" json:"imagen"`
+	IMAGEN             string         `orm:"column(imagen);type(bytea);null" json:"imagen"`
 	CANTIDAD           int            `orm:"column(cantidad);type(integer)" json:"cantidad"`
 	PK_ID_SUBCATEGORIA int64          `orm:"column(pk_id_subcategoria)" json:"subcategoriaId"`
 }

--- a/models/ReservaContacto.go
+++ b/models/ReservaContacto.go
@@ -14,6 +14,14 @@ func (r *ReservaContacto) TableName() string {
 	return "reserva_contacto"
 }
 
+// Valid ensures only one of DocumentoContacto or PKDocumentoCliente is set
+func (r *ReservaContacto) Valid() bool {
+	if (r.DocumentoContacto == nil) == (r.PKDocumentoCliente == nil) {
+		return false
+	}
+	return true
+}
+
 func init() {
 	orm.RegisterModel(new(ReservaContacto))
 }

--- a/models/RestauranteDia.go
+++ b/models/RestauranteDia.go
@@ -12,6 +12,11 @@ func (r *RestauranteDia) TableName() string {
 	return "restaurante_dia"
 }
 
+// TableUnique enforces UNIQUE(pk_id_restaurante, dia)
+func (r *RestauranteDia) TableUnique() [][]string {
+	return [][]string{{"PKIDRestaurante", "Dia"}}
+}
+
 func init() {
 	orm.RegisterModel(new(RestauranteDia))
 }

--- a/models/Trabajador.go
+++ b/models/Trabajador.go
@@ -15,7 +15,7 @@ type Trabajador struct {
 	TELEFONO                *string             `orm:"column(telefono);type(text);unique;null" json:"telefono,omitempty"`
 	FECHA_NACIMIENTO        *time.Time          `orm:"column(fecha_nacimiento);type(date)" json:"fechaNacimiento,omitempty"`
 	NUEVO                   bool                `orm:"column(nuevo);type(boolean)" json:"nuevo"`
-	ROL                     string              `orm:"column(rol);type(text)" json:"rol"`
+	ROL                     RolTrabajador       `orm:"column(rol);type(text)" json:"rol"`
 	FECHA_INGRESO           time.Time           `orm:"column(fecha_ingreso);type(date)" json:"fechaIngreso"`
 	FECHA_RETIRO            *time.Time          `orm:"column(fecha_retiro);type(date);null" json:"fechaRetiro,omitempty"`
 	PASSWORD                string              `orm:"column(password)" json:"password"`

--- a/models/controlnomina_test.go
+++ b/models/controlnomina_test.go
@@ -19,3 +19,28 @@ func TestControlNominaTableName(t *testing.T) {
 		t.Errorf("expected table name control_nomina, got %s", c.TableName())
 	}
 }
+
+type dummyOrmer struct{}
+
+func (d dummyOrmer) Insert(interface{}) (int64, error)            { return 1, nil }
+func (d dummyOrmer) Update(interface{}, ...string) (int64, error) { return 1, nil }
+
+func TestControlNominaInsertUpdateValidation(t *testing.T) {
+	o := dummyOrmer{}
+	c := ControlNomina{Estado: EstadoControlNominaGenerada}
+	if _, err := c.Insert(o); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	c.Estado = EstadoControlNomina("BAD")
+	if _, err := c.Insert(o); err == nil {
+		t.Fatalf("expected error for invalid estado")
+	}
+	c.Estado = EstadoControlNominaGenerada
+	if _, err := c.Update(o); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	c.Estado = EstadoControlNomina("BAD")
+	if _, err := c.Update(o); err == nil {
+		t.Fatalf("expected error for invalid estado on update")
+	}
+}

--- a/models/detalle_pedido_test.go
+++ b/models/detalle_pedido_test.go
@@ -1,0 +1,11 @@
+package models
+
+import "testing"
+
+func TestDetallePedidoTableUnique(t *testing.T) {
+	d := DetallePedido{}
+	u := d.TableUnique()
+	if len(u) != 1 || len(u[0]) != 2 || u[0][0] != "PKIDPedido" || u[0][1] != "PKIDProducto" {
+		t.Fatalf("unexpected unique constraints: %#v", u)
+	}
+}

--- a/models/enums.go
+++ b/models/enums.go
@@ -67,6 +67,26 @@ const (
 	DiaDomingo   DiaSemana = "DOMINGO"
 )
 
+// RolTrabajador represents valid roles for trabajador. Values are case-sensitive.
+type RolTrabajador string
+
+const (
+	RolAdministrador RolTrabajador = "Administrador"
+	RolMesero        RolTrabajador = "Mesero"
+	RolCocinero      RolTrabajador = "Cocinero"
+	RolDomiciliario  RolTrabajador = "Domiciliario"
+	RolOficiosVarios RolTrabajador = "Oficios_varios"
+)
+
+// IsValid reports whether the role is permitted for trabajador
+func (r RolTrabajador) IsValid() bool {
+	switch r {
+	case RolAdministrador, RolMesero, RolCocinero, RolDomiciliario, RolOficiosVarios:
+		return true
+	}
+	return false
+}
+
 // EstadoControlNomina represents valid values for control_nomina.estado
 type EstadoControlNomina string
 

--- a/models/horario_trabajador_test.go
+++ b/models/horario_trabajador_test.go
@@ -1,0 +1,28 @@
+package models
+
+import (
+	"testing"
+	"time"
+)
+
+func TestHorarioTrabajadorTableUnique(t *testing.T) {
+	h := HorarioTrabajador{}
+	u := h.TableUnique()
+	if len(u) != 1 || len(u[0]) != 2 || u[0][0] != "PK_DOCUMENTO_TRABAJADOR" || u[0][1] != "DIA" {
+		t.Fatalf("unexpected unique constraints: %#v", u)
+	}
+}
+
+func TestHorarioTrabajadorValidHours(t *testing.T) {
+	h := HorarioTrabajador{
+		HORA_INICIO: time.Date(0, 1, 1, 9, 0, 0, 0, time.UTC),
+		HORA_FIN:    time.Date(0, 1, 1, 10, 0, 0, 0, time.UTC),
+	}
+	if !h.ValidHours() {
+		t.Fatalf("expected valid hours")
+	}
+	h.HORA_FIN = time.Date(0, 1, 1, 8, 0, 0, 0, time.UTC)
+	if h.ValidHours() {
+		t.Fatalf("expected invalid hours")
+	}
+}

--- a/models/precio_producto_hist_test.go
+++ b/models/precio_producto_hist_test.go
@@ -1,0 +1,11 @@
+package models
+
+import "testing"
+
+func TestPrecioProductoHistTableUnique(t *testing.T) {
+	p := PrecioProductoHist{}
+	uniques := p.TableUnique()
+	if len(uniques) != 1 || len(uniques[0]) != 2 || uniques[0][0] != "PKIDProducto" || uniques[0][1] != "FechaVigencia" {
+		t.Fatalf("unexpected unique constraints: %#v", uniques)
+	}
+}

--- a/models/producto_test.go
+++ b/models/producto_test.go
@@ -9,7 +9,7 @@ import (
 	_ "github.com/lib/pq"
 )
 
-// TestProductoImagenFieldType ensures IMAGEN column is declared as text.
+// TestProductoImagenFieldType ensures IMAGEN column is declared as bytea.
 func TestProductoImagenFieldType(t *testing.T) {
 	typ := reflect.TypeOf(Producto{})
 	field, ok := typ.FieldByName("IMAGEN")
@@ -17,8 +17,8 @@ func TestProductoImagenFieldType(t *testing.T) {
 		t.Fatal("IMAGEN field not found")
 	}
 	tag := field.Tag.Get("orm")
-	if !strings.Contains(tag, "type(text)") {
-		t.Fatalf("expected orm tag to contain type(text), got %q", tag)
+	if !strings.Contains(tag, "type(bytea)") {
+		t.Fatalf("expected orm tag to contain type(bytea), got %q", tag)
 	}
 }
 

--- a/models/reserva_contacto_test.go
+++ b/models/reserva_contacto_test.go
@@ -1,0 +1,24 @@
+package models
+
+import "testing"
+
+func TestReservaContactoValid(t *testing.T) {
+	r := ReservaContacto{DocumentoContacto: new(int64)}
+	if !r.Valid() {
+		t.Fatalf("expected valid when only DocumentoContacto is set")
+	}
+	r = ReservaContacto{PKDocumentoCliente: new(int64)}
+	if !r.Valid() {
+		t.Fatalf("expected valid when only PKDocumentoCliente is set")
+	}
+	r = ReservaContacto{}
+	if r.Valid() {
+		t.Fatalf("expected invalid when both nil")
+	}
+	doc := int64(1)
+	cli := int64(2)
+	r = ReservaContacto{DocumentoContacto: &doc, PKDocumentoCliente: &cli}
+	if r.Valid() {
+		t.Fatalf("expected invalid when both set")
+	}
+}

--- a/models/restaurante_dia_test.go
+++ b/models/restaurante_dia_test.go
@@ -1,0 +1,11 @@
+package models
+
+import "testing"
+
+func TestRestauranteDiaTableUnique(t *testing.T) {
+	r := RestauranteDia{}
+	u := r.TableUnique()
+	if len(u) != 1 || len(u[0]) != 2 || u[0][0] != "PKIDRestaurante" || u[0][1] != "Dia" {
+		t.Fatalf("unexpected unique constraints: %#v", u)
+	}
+}

--- a/models/trabajador_test.go
+++ b/models/trabajador_test.go
@@ -44,6 +44,16 @@ func TestTrabajadorTableName(t *testing.T) {
 	}
 }
 
+func TestRolTrabajadorIsValid(t *testing.T) {
+	if !RolAdministrador.IsValid() {
+		t.Fatalf("RolAdministrador should be valid")
+	}
+	invalid := RolTrabajador("Chef")
+	if invalid.IsValid() {
+		t.Fatalf("unexpected valid role for %s", invalid)
+	}
+}
+
 func TestTrabajadorMarshalJSONNil(t *testing.T) {
 	ingreso := time.Date(2023, time.February, 10, 9, 15, 30, 0, time.UTC)
 	tr := Trabajador{FECHA_INGRESO: ingreso}


### PR DESCRIPTION
## Summary
- enforce composite uniqueness in price history, order detail, and restaurant day tables
- add schedule hour validation, role checks, and domicilio requirement for delivery orders
- map product images to bytea and validate control_nomina states

## Testing
- `go test ./...` *(fails: expected 500 got 404, database unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68b605e39b608325a5e796db6d469bf2