### PR TITLE
feat: enforce model validations and types

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Go-based REST API for managing restaurant operations such as customers, orders, 
 - **reserva**: manages restaurant reservations with date, time, party size, and status.
 - **precio_producto_hist**: tracks product price changes over time with an effective date for each entry.
 - **cambios_horario**: logs schedule adjustments such as opening/closing hours and whether the restaurant opens.
+- **domicilio**: la columna `entregado` es generada automáticamente por la base de datos y no debe incluirse en las solicitudes de creación o actualización.
 
 ## Testing
 ```sh

--- a/controllers/DomicilioController.go
+++ b/controllers/DomicilioController.go
@@ -269,7 +269,7 @@ LIMIT 1;`
 
 // @Title Create
 // @Summary Crear un nuevo domicilio
-// @Description Crea un nuevo domicilio en la base de datos.
+// @Description Crea un nuevo domicilio en la base de datos. El campo 'entregado' es generado automáticamente y no debe enviarse en la solicitud.
 // @Tags domicilios
 // @Accept json
 // @Produce json
@@ -356,9 +356,6 @@ func (c *DomicilioController) Post() {
 		}
 		domicilio.ESTADO_DOMICILIO = estado
 	}
-	if entregado, ok := input["entregado"].(bool); ok {
-		domicilio.ENTREGADO = entregado
-	}
 	if observaciones, ok := input["observaciones"].(string); ok {
 		domicilio.OBSERVACIONES = &observaciones
 	}
@@ -384,6 +381,14 @@ func (c *DomicilioController) Post() {
 		return
 	}
 
+	var ent bool
+	var created, updated time.Time
+	if err := o.Raw("SELECT entregado, created_at, updated_at FROM domicilio WHERE pk_id_domicilio = ?", domicilio.PK_ID_DOMICILIO).QueryRow(&ent, &created, &updated); err == nil {
+		domicilio.ENTREGADO = ent
+		domicilio.CREATED_AT = created
+		domicilio.UPDATED_AT = updated
+	}
+
 	// Responder con éxito
 	c.Ctx.Output.SetStatus(http.StatusCreated)
 	c.Data["json"] = models.ApiResponse{
@@ -396,7 +401,7 @@ func (c *DomicilioController) Post() {
 
 // @Title Update
 // @Summary Actualizar un domicilio
-// @Description Actualiza los datos de un domicilio existente.
+// @Description Actualiza los datos de un domicilio existente. El campo 'entregado' es calculado automáticamente.
 // @Tags domicilios
 // @Accept json
 // @Produce json
@@ -468,9 +473,6 @@ func (c *DomicilioController) Put() {
 		}
 		domicilio.ESTADO_DOMICILIO = estado
 	}
-	if entregado, ok := input["entregado"].(bool); ok {
-		domicilio.ENTREGADO = entregado
-	}
 	if updatedBy, ok := input["updatedBy"].(string); ok {
 		domicilio.UPDATED_BY = &updatedBy
 	}
@@ -488,6 +490,14 @@ func (c *DomicilioController) Put() {
 		}
 		c.ServeJSON()
 		return
+	}
+
+	var ent bool
+	var created, updated time.Time
+	if err := o.Raw("SELECT entregado, created_at, updated_at FROM domicilio WHERE pk_id_domicilio = ?", domicilio.PK_ID_DOMICILIO).QueryRow(&ent, &created, &updated); err == nil {
+		domicilio.ENTREGADO = ent
+		domicilio.CREATED_AT = created
+		domicilio.UPDATED_AT = updated
 	}
 
 	// Responder con éxito

--- a/controllers/HorarioTrabajadorController.go
+++ b/controllers/HorarioTrabajadorController.go
@@ -134,6 +134,13 @@ func (c *HorarioTrabajadorController) Post() {
 		HORA_FIN:                horaFin,
 	}
 
+	if !horario.ValidHours() {
+		c.Ctx.Output.SetStatus(http.StatusBadRequest)
+		c.Data["json"] = models.ApiResponse{Code: http.StatusBadRequest, Message: "horaFin debe ser mayor que horaInicio"}
+		c.ServeJSON()
+		return
+	}
+
 	o := orm.NewOrm()
 	if _, err := o.Raw(
 		"INSERT INTO horario_trabajador (pk_documento_trabajador, dia, hora_inicio, hora_fin) VALUES (?, ?, ?, ?)",
@@ -233,6 +240,15 @@ func (c *HorarioTrabajadorController) Put() {
 			c.ServeJSON()
 			return
 		}
+	}
+
+	horario.HORA_INICIO = time.Date(0, 1, 1, horario.HORA_INICIO.Hour(), horario.HORA_INICIO.Minute(), horario.HORA_INICIO.Second(), 0, time.UTC)
+	horario.HORA_FIN = time.Date(0, 1, 1, horario.HORA_FIN.Hour(), horario.HORA_FIN.Minute(), horario.HORA_FIN.Second(), 0, time.UTC)
+	if !horario.ValidHours() {
+		c.Ctx.Output.SetStatus(http.StatusBadRequest)
+		c.Data["json"] = models.ApiResponse{Code: http.StatusBadRequest, Message: "horaFin debe ser mayor que horaInicio"}
+		c.ServeJSON()
+		return
 	}
 
 	if _, err := o.Raw(

--- a/controllers/ProductoController.go
+++ b/controllers/ProductoController.go
@@ -59,7 +59,7 @@ func (c *ProductoController) GetAll() {
 	// Manejar imágenes según el parámetro includeImage
 	for i := range productos {
 		if !includeImage {
-			productos[i].IMAGEN = ""
+			productos[i].IMAGEN = nil
 		}
 	}
 

--- a/controllers/ReservaController.go
+++ b/controllers/ReservaController.go
@@ -170,6 +170,25 @@ func (c *ReservaController) Post() {
 		return
 	}
 
+	// Validar campos de contacto exclusivos si se proporcionan
+	var contacto models.ReservaContacto
+	if v, ok := input["documentoContacto"].(float64); ok {
+		val := int64(v)
+		contacto.DocumentoContacto = &val
+	}
+	if v, ok := input["documentoCliente"].(float64); ok {
+		val := int64(v)
+		contacto.PKDocumentoCliente = &val
+	}
+	if contacto.DocumentoContacto != nil || contacto.PKDocumentoCliente != nil {
+		if !contacto.Valid() {
+			c.Ctx.Output.SetStatus(http.StatusBadRequest)
+			c.Data["json"] = models.ApiResponse{Code: http.StatusBadRequest, Message: "Debe enviar sólo uno de documentoContacto o documentoCliente"}
+			c.ServeJSON()
+			return
+		}
+	}
+
 	// Validar y procesar los campos requeridos
 	var reserva models.Reserva
 
@@ -362,6 +381,25 @@ func (c *ReservaController) Put() {
 		}
 		c.ServeJSON()
 		return
+	}
+
+	// Validar campos de contacto exclusivos si se proporcionan
+	var contacto models.ReservaContacto
+	if v, ok := input["documentoContacto"].(float64); ok {
+		val := int64(v)
+		contacto.DocumentoContacto = &val
+	}
+	if v, ok := input["documentoCliente"].(float64); ok {
+		val := int64(v)
+		contacto.PKDocumentoCliente = &val
+	}
+	if contacto.DocumentoContacto != nil || contacto.PKDocumentoCliente != nil {
+		if !contacto.Valid() {
+			c.Ctx.Output.SetStatus(http.StatusBadRequest)
+			c.Data["json"] = models.ApiResponse{Code: http.StatusBadRequest, Message: "Debe enviar sólo uno de documentoContacto o documentoCliente"}
+			c.ServeJSON()
+			return
+		}
 	}
 
 	// Validar y actualizar los campos que pueden cambiar

--- a/controllers/domicilio_controller_test.go
+++ b/controllers/domicilio_controller_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/beego/beego/v2/server/web/context"
 	"restaurante/models"
@@ -39,18 +40,23 @@ func TestPostInvalidEstado(t *testing.T) {
 	}
 }
 
-func TestPostEntregadoTrue(t *testing.T) {
+func TestPostReturnsGeneratedEntregado(t *testing.T) {
 	MockExec = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Result, error) {
 		return mockResult{}, nil
 	}
 	MockQuery = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
+		if strings.Contains(strings.ToUpper(query), "SELECT ENTREGADO") {
+			cols := []string{"entregado", "created_at", "updated_at"}
+			vals := [][]driver.Value{{false, time.Now(), time.Now()}}
+			return &mockRows{columns: cols, values: vals}, nil
+		}
 		cols := []string{"pk_id_domicilio"}
 		vals := [][]driver.Value{{int64(1)}}
 		return &mockRows{columns: cols, values: vals}, nil
 	}
 	defer func() { MockExec = nil; MockQuery = nil }()
 
-	body := `{"direccion":"Calle 1","fechaDomicilio":"2024-01-01","telefono":"123","entregado":true}`
+	body := `{"direccion":"Calle 1","fechaDomicilio":"2024-01-01","telefono":"123"}`
 	r := httptest.NewRequest(http.MethodPost, "/domicilios", strings.NewReader(body))
 	r.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
@@ -74,8 +80,8 @@ func TestPostEntregadoTrue(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected data object, got %T", resp.Data)
 	}
-	if entregado, ok := data["entregado"].(bool); !ok || !entregado {
-		t.Fatalf("expected entregado true, got %v", data["entregado"])
+	if entregado, ok := data["entregado"].(bool); !ok || entregado {
+		t.Fatalf("expected entregado false, got %v", data["entregado"])
 	}
 	if _, ok := data["createdAt"]; !ok {
 		t.Fatalf("expected createdAt in response")

--- a/controllers/horario_trabajador_controller_test.go
+++ b/controllers/horario_trabajador_controller_test.go
@@ -38,6 +38,18 @@ func TestHorarioTrabajadorPostInvalidDia(t *testing.T) {
 	}
 }
 
+func TestHorarioTrabajadorPostInvalidHours(t *testing.T) {
+	body := `{"documentoTrabajador":1,"dia":"LUNES","horaInicio":"17:00:00","horaFin":"08:00:00"}`
+	c, w := setupHTCtx(http.MethodPost, "/horario_trabajador", body)
+	c.Post()
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "horaFin debe ser mayor que horaInicio") {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
+}
+
 func TestHorarioTrabajadorPostSuccess(t *testing.T) {
 	MockExec = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Result, error) {
 		return mockResult{}, nil

--- a/controllers/reserva_controller_test.go
+++ b/controllers/reserva_controller_test.go
@@ -416,6 +416,33 @@ func TestReservaPostInvalidContacto(t *testing.T) {
 	}
 }
 
+func TestReservaPostInvalidReservaContacto(t *testing.T) {
+	t.Cleanup(resetReservaMocks)
+	payload := map[string]interface{}{
+		"fechaReserva":      "2024-01-01",
+		"horaReserva":       "12:00:00",
+		"personas":          2,
+		"contactoId":        123,
+		"restauranteId":     1,
+		"documentoContacto": 1,
+		"documentoCliente":  2,
+	}
+	body, _ := json.Marshal(payload)
+	r := httptest.NewRequest(http.MethodPost, "/reservas", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	ctx.Input.RequestBody = body
+	c := ReservaController{}
+	c.Ctx = ctx
+	c.Data = map[interface{}]interface{}{}
+
+	c.Post()
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
 func TestReservaPostInsertError(t *testing.T) {
 	ormNew = func() orm.Ormer { return nil }
 	insertReserva = func(o orm.Ormer, r *models.Reserva) (int64, error) { return 0, errors.New("db") }

--- a/models/Producto.go
+++ b/models/Producto.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"os"
 
@@ -14,7 +15,7 @@ type Producto struct {
 	DESCRIPCION        *string        `orm:"column(descripcion);type(text);null" json:"descripcion,omitempty"`
 	PRECIO             int64          `orm:"column(precio);type(bigint)" json:"precio"`
 	ESTADO_PRODUCTO    EstadoProducto `orm:"column(estado_producto);type(text)" json:"estadoProducto"`
-	IMAGEN             string         `orm:"column(imagen);type(bytea);null" json:"imagen"`
+	IMAGEN             []uint8        `orm:"column(imagen);null" json:"imagen"`
 	CANTIDAD           int            `orm:"column(cantidad);type(integer)" json:"cantidad"`
 	PK_ID_SUBCATEGORIA int64          `orm:"column(pk_id_subcategoria)" json:"subcategoriaId"`
 }
@@ -43,7 +44,7 @@ func (p Producto) MarshalJSON() ([]byte, error) {
 		DESCRIPCION:      p.DESCRIPCION,
 		PRECIO:           p.PRECIO,
 		ESTADO_PRODUCTO:  p.ESTADO_PRODUCTO,
-		IMAGEN:           p.IMAGEN,
+		IMAGEN:           base64.StdEncoding.EncodeToString(p.IMAGEN),
 		CANTIDAD:         p.CANTIDAD,
 		PKIDSubcategoria: p.PK_ID_SUBCATEGORIA,
 	}
@@ -61,7 +62,15 @@ func (p *Producto) UnmarshalJSON(data []byte) error {
 	p.DESCRIPCION = pj.DESCRIPCION
 	p.PRECIO = pj.PRECIO
 	p.ESTADO_PRODUCTO = pj.ESTADO_PRODUCTO
-	p.IMAGEN = pj.IMAGEN
+	if pj.IMAGEN != "" {
+		if img, err := base64.StdEncoding.DecodeString(pj.IMAGEN); err == nil {
+			p.IMAGEN = img
+		} else {
+			return err
+		}
+	} else {
+		p.IMAGEN = nil
+	}
 	p.CANTIDAD = pj.CANTIDAD
 	p.PK_ID_SUBCATEGORIA = pj.PKIDSubcategoria
 	return nil

--- a/models/producto_test.go
+++ b/models/producto_test.go
@@ -24,7 +24,7 @@ func TestProductoImagenFieldType(t *testing.T) {
 
 func TestProductoMarshalUnmarshalJSON(t *testing.T) {
 	calorias := int64(100)
-	img := "hello"
+	img := []byte("hello")
 	p := Producto{
 		PK_ID_PRODUCTO:     1,
 		NOMBRE:             "Test",
@@ -40,14 +40,14 @@ func TestProductoMarshalUnmarshalJSON(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Marshal: %v", err)
 	}
-	if !strings.Contains(string(data), img) {
-		t.Fatalf("expected image in json: %s", string(data))
+	if !strings.Contains(string(data), "aGVsbG8=") {
+		t.Fatalf("expected base64 image in json: %s", string(data))
 	}
 	var out Producto
 	if err := json.Unmarshal(data, &out); err != nil {
 		t.Fatalf("Unmarshal: %v", err)
 	}
-	if out.IMAGEN != p.IMAGEN {
+	if !reflect.DeepEqual(out.IMAGEN, p.IMAGEN) {
 		t.Fatalf("expected image %v, got %v", p.IMAGEN, out.IMAGEN)
 	}
 }


### PR DESCRIPTION
## Summary
- validate exclusivity of reservation contact fields
- ensure worker schedules enforce horaFin > horaInicio
- prevent manual entregado on domicilio and fetch generated value
- model product images as []byte and document domicilio entregado

## Testing
- `go test ./...` *(fails: field models.Producto.IMAGEN unsupport field type and missing db aliases)*


------
https://chatgpt.com/codex/tasks/task_e_68b60988a53883259f53910bae7b0714