### PR TITLE
Mark optional fields as nullable

### DIFF
--- a/models/Cliente.go
+++ b/models/Cliente.go
@@ -11,7 +11,7 @@ type Cliente struct {
 	CORREO               *string `orm:"column(correo);type(text);unique;null"        json:"correo" valid:"email"`
 	DIRECCION            string  `orm:"column(direccion);type(text)"     json:"direccion"`
 	TELEFONO             string  `orm:"column(telefono);type(text);unique"      json:"telefono"`
-	OBSERVACIONES        *string `orm:"column(observaciones);type(text)" json:"observaciones"`
+	OBSERVACIONES        *string `orm:"column(observaciones);type(text);null" json:"observaciones"`
 	PASSWORD             string  `orm:"column(password);type(text)"      json:"password"`
 }
 

--- a/models/Domicilio.go
+++ b/models/Domicilio.go
@@ -18,8 +18,8 @@ type Domicilio struct {
 	OBSERVACIONES           *string   `orm:"column(observaciones);type(text);null" json:"observaciones,omitempty"`
 	CREATED_AT              time.Time `orm:"column(created_at);type(timestamptz);auto_now_add" json:"createdAt"`
 	UPDATED_AT              time.Time `orm:"column(updated_at);type(timestamptz);auto_now" json:"updatedAt"`
-	CREATED_BY              *string   `orm:"column(created_by);type(text)" json:"createdBy,omitempty"`
-	UPDATED_BY              *string   `orm:"column(updated_by);type(text)" json:"updatedBy,omitempty"`
+	CREATED_BY              *string   `orm:"column(created_by);type(text);null" json:"createdBy,omitempty"`
+	UPDATED_BY              *string   `orm:"column(updated_by);type(text);null" json:"updatedBy,omitempty"`
 	PK_DOCUMENTO_TRABAJADOR *int64    `orm:"column(pk_documento_trabajador);null" json:"trabajadorAsignado,omitempty"`
 }
 

--- a/models/Producto.go
+++ b/models/Producto.go
@@ -11,7 +11,7 @@ import (
 type Producto struct {
 	PK_ID_PRODUCTO     int64          `orm:"column(pk_id_producto);pk;auto" json:"productoId"`
 	NOMBRE             string         `orm:"column(nombre);type(text)" json:"nombre"`
-	CALORIAS           *int64         `orm:"column(calorias);type(bigint)" json:"calorias"`
+	CALORIAS           *int64         `orm:"column(calorias);type(bigint);null" json:"calorias"`
 	DESCRIPCION        *string        `orm:"column(descripcion);type(text);null" json:"descripcion,omitempty"`
 	PRECIO             int64          `orm:"column(precio);type(bigint)" json:"precio"`
 	ESTADO_PRODUCTO    EstadoProducto `orm:"column(estado_producto);type(text)" json:"estadoProducto"`

--- a/models/Trabajador.go
+++ b/models/Trabajador.go
@@ -13,7 +13,7 @@ type Trabajador struct {
 	APELLIDO                string              `orm:"column(apellido);type(text)" json:"apellido"`
 	SUELDO                  int64               `orm:"column(sueldo)" json:"sueldo"`
 	TELEFONO                *string             `orm:"column(telefono);type(text);unique;null" json:"telefono,omitempty"`
-	FECHA_NACIMIENTO        *time.Time          `orm:"column(fecha_nacimiento);type(date)" json:"fechaNacimiento,omitempty"`
+	FECHA_NACIMIENTO        *time.Time          `orm:"column(fecha_nacimiento);type(date);null" json:"fechaNacimiento,omitempty"`
 	NUEVO                   bool                `orm:"column(nuevo);type(boolean)" json:"nuevo"`
 	ROL                     RolTrabajador       `orm:"column(rol);type(text)" json:"rol"`
 	FECHA_INGRESO           time.Time           `orm:"column(fecha_ingreso);type(date)" json:"fechaIngreso"`


### PR DESCRIPTION
## Summary
- allow null in Cliente.OBSERVACIONES
- mark Trabajador.FECHA_NACIMIENTO as nullable
- permit null for Producto.CALORIAS
- allow null in Domicilio.CREATED_BY and UPDATED_BY

## Testing
- `SKIP_ORM_REGISTRATION=1 go test ./models -run TestDomicilioTableName -count=1 -v`
- `SKIP_ORM_REGISTRATION=1 go test ./models -run TestTrabajadorTableName -count=1 -v`
- `SKIP_ORM_REGISTRATION=1 go test ./models -run TestProductoImagenFieldType -count=1 -v`


------
https://chatgpt.com/codex/tasks/task_e_68b6136f0dbc8325a203dd26aade93a8