### PR TITLE
Declare FK relations and enforce delivery check

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Go-based REST API for managing restaurant operations such as customers, orders, 
 - **precio_producto_hist**: tracks product price changes over time with an effective date for each entry.
 - **cambios_horario**: logs schedule adjustments such as opening/closing hours and whether the restaurant opens.
 - **domicilio**: la columna `entregado` es generada automáticamente por la base de datos y no debe incluirse en las solicitudes de creación o actualización.
+- **pedido**: la base de datos valida que `delivery` sea `false` o que `pk_id_domicilio` tenga un valor.
 
 ## Testing
 ```sh

--- a/database/migrations/001_add_pedido_delivery_check.sql
+++ b/database/migrations/001_add_pedido_delivery_check.sql
@@ -1,0 +1,11 @@
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint WHERE conname = 'pedido_delivery_requires_domicilio'
+    ) THEN
+        ALTER TABLE pedido
+            ADD CONSTRAINT pedido_delivery_requires_domicilio
+            CHECK (delivery = false OR pk_id_domicilio IS NOT NULL);
+    END IF;
+END;
+$$;

--- a/models/DetallePedido.go
+++ b/models/DetallePedido.go
@@ -5,8 +5,8 @@ import "github.com/beego/beego/v2/client/orm"
 // DetallePedido represents a product within un pedido.
 type DetallePedido struct {
 	PK_ID_DETALLE int64 `orm:"column(pk_id_detalle);pk;auto" json:"detalleId"`
-	PKIDPedido    int64 `orm:"column(pk_id_pedido)" json:"pedidoId"`
-	PKIDProducto  int64 `orm:"column(pk_id_producto)" json:"productoId"`
+	PKIDPedido    int64 `orm:"column(pk_id_pedido);rel(fk)" json:"pedidoId"`
+	PKIDProducto  int64 `orm:"column(pk_id_producto);rel(fk)" json:"productoId"`
 	Precio        int64 `orm:"column(precio);type(bigint)" json:"precio"`
 	Cantidad      int   `orm:"column(cantidad)" json:"cantidad"`
 }

--- a/models/Domicilio.go
+++ b/models/Domicilio.go
@@ -20,7 +20,7 @@ type Domicilio struct {
 	UPDATED_AT              time.Time `orm:"column(updated_at);type(timestamptz);auto_now" json:"updatedAt"`
 	CREATED_BY              *string   `orm:"column(created_by);type(text);null" json:"createdBy,omitempty"`
 	UPDATED_BY              *string   `orm:"column(updated_by);type(text);null" json:"updatedBy,omitempty"`
-	PK_DOCUMENTO_TRABAJADOR *int64    `orm:"column(pk_documento_trabajador);null" json:"trabajadorAsignado,omitempty"`
+	PK_DOCUMENTO_TRABAJADOR *int64    `orm:"column(pk_documento_trabajador);rel(fk);null" json:"trabajadorAsignado,omitempty"`
 }
 
 func (d *Domicilio) TableName() string {

--- a/models/HorarioTrabajador.go
+++ b/models/HorarioTrabajador.go
@@ -9,7 +9,7 @@ import (
 
 type HorarioTrabajador struct {
 	PK_ID_HORARIO_TRABAJADOR int64     `orm:"column(pk_id_horario_trabajador);pk;auto" json:"horarioTrabajadorId"`
-	PK_DOCUMENTO_TRABAJADOR  int64     `orm:"column(pk_documento_trabajador)" json:"documentoTrabajador"`
+	PK_DOCUMENTO_TRABAJADOR  int64     `orm:"column(pk_documento_trabajador);rel(fk)" json:"documentoTrabajador"`
 	DIA                      DiaSemana `orm:"column(dia);type(text)" json:"dia"`
 	HORA_INICIO              time.Time `orm:"column(hora_inicio);type(time)" json:"horaInicio"`
 	HORA_FIN                 time.Time `orm:"column(hora_fin);type(time)" json:"horaFin"`

--- a/models/Incidencia.go
+++ b/models/Incidencia.go
@@ -13,7 +13,7 @@ type Incidencia struct {
 	MONTO                   int64     `orm:"column(monto)" json:"monto"`
 	RESTA                   bool      `orm:"column(resta);type(boolean)" json:"resta"`
 	MOTIVO                  string    `orm:"column(motivo);type(text)" json:"motivo"`
-	PK_DOCUMENTO_TRABAJADOR *int64    `orm:"column(pk_documento_trabajador);null" json:"documentoTrabajador,omitempty"`
+	PK_DOCUMENTO_TRABAJADOR *int64    `orm:"column(pk_documento_trabajador);rel(fk);null" json:"documentoTrabajador,omitempty"`
 }
 
 func (i *Incidencia) TableName() string {

--- a/models/NominaTrabajador.go
+++ b/models/NominaTrabajador.go
@@ -7,8 +7,8 @@ type NominaTrabajador struct {
 	SUELDO_BASE             int64   `orm:"column(sueldo_base)" json:"sueldoBase"`
 	MONTO_INCIDENCIAS       *int64  `orm:"column(monto_incidencias);null" json:"montoIncidencias,omitempty"`
 	DETALLES                *string `orm:"column(detalles);type(text);null" json:"detalles,omitempty"`
-	PK_DOCUMENTO_TRABAJADOR int64   `orm:"column(pk_documento_trabajador)" json:"documentoTrabajador"`
-	PK_ID_NOMINA            int64   `orm:"column(pk_id_nomina)" json:"nominaId"`
+	PK_DOCUMENTO_TRABAJADOR int64   `orm:"column(pk_documento_trabajador);rel(fk)" json:"documentoTrabajador"`
+	PK_ID_NOMINA            int64   `orm:"column(pk_id_nomina);rel(fk)" json:"nominaId"`
 }
 
 type NominaTrabajadorRequest struct {

--- a/models/Pago.go
+++ b/models/Pago.go
@@ -13,7 +13,7 @@ type Pago struct {
 	HORA              time.Time  `orm:"column(hora);type(time)" json:"horaPago"`
 	MONTO             int64      `orm:"column(monto)" json:"monto"`
 	ESTADO_PAGO       EstadoPago `orm:"column(estado_pago);type(text)" json:"estadoPago"`
-	PK_ID_METODO_PAGO *int64     `orm:"column(pk_id_metodo_pago);null" json:"metodoPagoId,omitempty"`
+	PK_ID_METODO_PAGO *int64     `orm:"column(pk_id_metodo_pago);rel(fk);null" json:"metodoPagoId,omitempty"`
 	UPDATED_AT        time.Time  `orm:"column(updated_at);type(timestamptz);auto_now" json:"updatedAt"`
 	UPDATED_BY        *string    `orm:"column(updated_by);type(text);null" json:"updatedBy,omitempty"`
 }

--- a/models/Pedido.go
+++ b/models/Pedido.go
@@ -13,10 +13,10 @@ type Pedido struct {
 	HORA                 time.Time    `orm:"column(hora);type(time)" json:"horaPedido"`
 	DELIVERY             bool         `orm:"column(delivery);type(boolean)" json:"delivery"`
 	ESTADO_PEDIDO        EstadoPedido `orm:"column(estado_pedido)" json:"estadoPedido"`
-	PK_ID_DOMICILIO      *int64       `orm:"column(pk_id_domicilio);null" json:"domicilioId,omitempty"`
-	PK_ID_PAGO           *int64       `orm:"column(pk_id_pago);null" json:"pagoId"`
-	PK_ID_RESTAURANTE    int64        `orm:"column(pk_id_restaurante)" json:"restauranteId"`
-	PK_DOCUMENTO_CLIENTE int64        `orm:"column(pk_documento_cliente)" json:"documentoCliente"`
+	PK_ID_DOMICILIO      *int64       `orm:"column(pk_id_domicilio);rel(fk);null" json:"domicilioId,omitempty"`
+	PK_ID_PAGO           *int64       `orm:"column(pk_id_pago);rel(fk);null" json:"pagoId"`
+	PK_ID_RESTAURANTE    int64        `orm:"column(pk_id_restaurante);rel(fk)" json:"restauranteId"`
+	PK_DOCUMENTO_CLIENTE int64        `orm:"column(pk_documento_cliente);rel(fk)" json:"documentoCliente"`
 	UPDATED_AT           time.Time    `orm:"column(updated_at);type(timestamptz);auto_now" json:"updatedAt"`
 	UPDATED_BY           *string      `orm:"column(updated_by);type(text);null" json:"updatedBy,omitempty"`
 }

--- a/models/PrecioProductoHist.go
+++ b/models/PrecioProductoHist.go
@@ -10,7 +10,7 @@ import (
 // It no longer maintains its own primary key or audit timestamps.
 type PrecioProductoHist struct {
 	PK_ID_PRECIO_HIST int64     `orm:"column(pk_id_precio_hist);pk;auto" json:"precioHistId"`
-	PKIDProducto      int64     `orm:"column(pk_id_producto)" json:"productoId"`
+	PKIDProducto      int64     `orm:"column(pk_id_producto);rel(fk)" json:"productoId"`
 	Precio            int64     `orm:"column(precio);type(bigint)" json:"precio"`
 	FechaVigencia     time.Time `orm:"column(fecha_vigencia);type(date)" json:"fechaVigencia"`
 }

--- a/models/Producto.go
+++ b/models/Producto.go
@@ -17,7 +17,7 @@ type Producto struct {
 	ESTADO_PRODUCTO    EstadoProducto `orm:"column(estado_producto);type(text)" json:"estadoProducto"`
 	IMAGEN             []byte         `orm:"column(imagen);type(bytea);null" json:"imagen"`
 	CANTIDAD           int            `orm:"column(cantidad);type(integer)" json:"cantidad"`
-	PK_ID_SUBCATEGORIA int64          `orm:"column(pk_id_subcategoria)" json:"subcategoriaId"`
+	PK_ID_SUBCATEGORIA int64          `orm:"column(pk_id_subcategoria);rel(fk)" json:"subcategoriaId"`
 }
 
 func (p *Producto) TableName() string {

--- a/models/Reserva.go
+++ b/models/Reserva.go
@@ -12,8 +12,8 @@ type Reserva struct {
 	FECHA             time.Time      `orm:"column(fecha);type(date)" json:"fechaReserva"`
 	HORA              time.Time      `orm:"column(hora);type(time);size(8)" json:"horaReserva"`
 	PERSONAS          int            `orm:"column(personas)" json:"personas"`
-	PK_ID_CONTACTO    int64          `orm:"column(pk_id_contacto)" json:"contactoId"`
-	PK_ID_RESTAURANTE int64          `orm:"column(pk_id_restaurante)" json:"restauranteId"`
+	PK_ID_CONTACTO    int64          `orm:"column(pk_id_contacto);rel(fk)" json:"contactoId"`
+	PK_ID_RESTAURANTE int64          `orm:"column(pk_id_restaurante);rel(fk)" json:"restauranteId"`
 	ESTADO_RESERVA    *EstadoReserva `orm:"column(estado_reserva);null" json:"estadoReserva,omitempty"`
 	INDICACIONES      *string        `orm:"column(indicaciones);null" json:"indicaciones,omitempty"`
 	CREATED_AT        time.Time      `orm:"column(created_at);type(timestamptz);auto_now_add" json:"createdAt"`

--- a/models/ReservaContacto.go
+++ b/models/ReservaContacto.go
@@ -7,7 +7,7 @@ type ReservaContacto struct {
 	NombreCompleto     string  `orm:"column(nombre_completo);type(text)" json:"nombreCompleto"`
 	Telefono           *string `orm:"column(telefono);type(text);null" json:"telefono,omitempty"`
 	DocumentoContacto  *int64  `orm:"column(documento_contacto);null" json:"documentoContacto,omitempty"`
-	PKDocumentoCliente *int64  `orm:"column(pk_documento_cliente);null" json:"documentoCliente,omitempty"`
+	PKDocumentoCliente *int64  `orm:"column(pk_documento_cliente);rel(fk);null" json:"documentoCliente,omitempty"`
 }
 
 func (r *ReservaContacto) TableName() string {

--- a/models/Restaurante.go
+++ b/models/Restaurante.go
@@ -10,7 +10,7 @@ type Restaurante struct {
 	PK_ID_RESTAURANTE    int64     `orm:"column(pk_id_restaurante);pk;auto" json:"restauranteId"`
 	NOMBRE_RESTAURANTE   string    `orm:"column(nombre_restaurante);type(text)" json:"nombreRestaurante"`
 	HORA_APERTURA        time.Time `orm:"column(hora_apertura);type(time)" json:"horaApertura"`
-	PK_ID_CAMBIO_HORARIO *int64    `orm:"column(pk_id_cambio_horario);null" json:"cambioHorarioId,omitempty"`
+	PK_ID_CAMBIO_HORARIO *int64    `orm:"column(pk_id_cambio_horario);rel(fk);null" json:"cambioHorarioId,omitempty"`
 }
 
 func (t *Restaurante) TableName() string {

--- a/models/RestauranteDia.go
+++ b/models/RestauranteDia.go
@@ -4,7 +4,7 @@ import "github.com/beego/beego/v2/client/orm"
 
 type RestauranteDia struct {
 	PK_ID_RESTAURANTE_DIA int64     `orm:"column(pk_id_restaurante_dia);pk;auto" json:"restauranteDiaId"`
-	PKIDRestaurante       int64     `orm:"column(pk_id_restaurante)" json:"restauranteId"`
+	PKIDRestaurante       int64     `orm:"column(pk_id_restaurante);rel(fk)" json:"restauranteId"`
 	Dia                   DiaSemana `orm:"column(dia);type(text)" json:"dia"`
 }
 

--- a/models/Subcategoria.go
+++ b/models/Subcategoria.go
@@ -6,7 +6,7 @@ import (
 
 type Subcategoria struct {
 	PK_ID_SUBCATEGORIA int64  `orm:"column(pk_id_subcategoria);pk;auto" json:"subcategoriaId"`
-	PK_ID_CATEGORIA    int64  `orm:"column(pk_id_categoria)" json:"categoriaId"`
+	PK_ID_CATEGORIA    int64  `orm:"column(pk_id_categoria);rel(fk)" json:"categoriaId"`
 	NOMBRE             string `orm:"column(nombre);type(text)" json:"nombre"`
 }
 

--- a/models/Trabajador.go
+++ b/models/Trabajador.go
@@ -20,7 +20,7 @@ type Trabajador struct {
 	FECHA_RETIRO            *time.Time          `orm:"column(fecha_retiro);type(date);null" json:"fechaRetiro,omitempty"`
 	PASSWORD                string              `orm:"column(password)" json:"password"`
 	HORARIOS                []HorarioTrabajador `orm:"-" json:"horarios,omitempty"`
-	PK_ID_RESTAURANTE       *int64              `orm:"column(pk_id_restaurante);null" json:"restauranteId,omitempty"`
+	PK_ID_RESTAURANTE       *int64              `orm:"column(pk_id_restaurante);rel(fk);null" json:"restauranteId,omitempty"`
 }
 
 func (t *Trabajador) TableName() string {


### PR DESCRIPTION
## Summary
- mark foreign key fields with `rel(fk)` across models for clearer Beego relationships
- add SQL migration enforcing that delivery orders include a domicilio
- document the delivery check in README

## Testing
- `go test ./...` *(failed: process hung, likely awaiting database connection)*

------
https://chatgpt.com/codex/tasks/task_e_68b616897cbc83258ec5a26f218e6a86