### PR TITLE
refactor: use struct pointers for foreign keys

### DIFF
--- a/controllers/DomicilioController.go
+++ b/controllers/DomicilioController.go
@@ -600,7 +600,7 @@ func (c *DomicilioController) AsignarDomiciliario() {
 	}
 
 	// Asignar el domiciliario
-	domicilio.PK_DOCUMENTO_TRABAJADOR = &trabajadorID
+	domicilio.PK_DOCUMENTO_TRABAJADOR = &models.Trabajador{PK_DOCUMENTO_TRABAJADOR: trabajadorID}
 
 	if _, err := o.Update(&domicilio, "PK_DOCUMENTO_TRABAJADOR"); err != nil {
 		c.Ctx.Output.SetStatus(http.StatusInternalServerError)

--- a/controllers/HorarioTrabajadorController.go
+++ b/controllers/HorarioTrabajadorController.go
@@ -128,7 +128,7 @@ func (c *HorarioTrabajadorController) Post() {
 	}
 
 	horario := models.HorarioTrabajador{
-		PK_DOCUMENTO_TRABAJADOR: &input.PK_DOCUMENTO_TRABAJADOR,
+		PK_DOCUMENTO_TRABAJADOR: &models.Trabajador{PK_DOCUMENTO_TRABAJADOR: input.PK_DOCUMENTO_TRABAJADOR},
 		DIA:                     dia,
 		HORA_INICIO:             horaInicio,
 		HORA_FIN:                horaFin,
@@ -144,7 +144,7 @@ func (c *HorarioTrabajadorController) Post() {
 	o := orm.NewOrm()
 	if _, err := o.Raw(
 		"INSERT INTO horario_trabajador (pk_documento_trabajador, dia, hora_inicio, hora_fin) VALUES (?, ?, ?, ?)",
-		horario.PK_DOCUMENTO_TRABAJADOR, horario.DIA, horario.HORA_INICIO, horario.HORA_FIN,
+		horario.PK_DOCUMENTO_TRABAJADOR.PK_DOCUMENTO_TRABAJADOR, horario.DIA, horario.HORA_INICIO, horario.HORA_FIN,
 	).Exec(); err != nil {
 		c.Ctx.Output.SetStatus(http.StatusInternalServerError)
 		c.Data["json"] = models.ApiResponse{

--- a/controllers/IncidenciaController.go
+++ b/controllers/IncidenciaController.go
@@ -238,7 +238,7 @@ func (c *IncidenciaController) Post() {
 	// Procesar documentoTrabajador (obligatorio)
 	if documento, ok := input["documentoTrabajador"].(float64); ok && documento != 0 {
 		doc := int64(documento)
-		incidencia.PK_DOCUMENTO_TRABAJADOR = &doc
+		incidencia.PK_DOCUMENTO_TRABAJADOR = &models.Trabajador{PK_DOCUMENTO_TRABAJADOR: doc}
 	} else {
 		c.Ctx.Output.SetStatus(http.StatusBadRequest)
 		c.Data["json"] = models.ApiResponse{
@@ -264,12 +264,17 @@ func (c *IncidenciaController) Post() {
 
 	// Preparar la respuesta con el formato deseado
 	response := map[string]interface{}{
-		"incidenciaId":        incidencia.PK_ID_INCIDENCIA,
-		"fechaIncidencia":     incidencia.FECHA.Format("2006-01-02"),
-		"monto":               incidencia.MONTO,
-		"resta":               incidencia.RESTA,
-		"motivo":              incidencia.MOTIVO,
-		"documentoTrabajador": incidencia.PK_DOCUMENTO_TRABAJADOR,
+		"incidenciaId":    incidencia.PK_ID_INCIDENCIA,
+		"fechaIncidencia": incidencia.FECHA.Format("2006-01-02"),
+		"monto":           incidencia.MONTO,
+		"resta":           incidencia.RESTA,
+		"motivo":          incidencia.MOTIVO,
+		"documentoTrabajador": func() int64 {
+			if incidencia.PK_DOCUMENTO_TRABAJADOR != nil {
+				return incidencia.PK_DOCUMENTO_TRABAJADOR.PK_DOCUMENTO_TRABAJADOR
+			}
+			return 0
+		}(),
 	}
 
 	// Responder con éxito
@@ -367,7 +372,7 @@ func (c *IncidenciaController) Put() {
 
 	if documento, ok := input["documentoTrabajador"].(float64); ok && documento != 0 {
 		doc := int64(documento)
-		incidencia.PK_DOCUMENTO_TRABAJADOR = &doc
+		incidencia.PK_DOCUMENTO_TRABAJADOR = &models.Trabajador{PK_DOCUMENTO_TRABAJADOR: doc}
 	}
 
 	// Guardar los cambios en la base de datos
@@ -384,12 +389,17 @@ func (c *IncidenciaController) Put() {
 
 	// Preparar la respuesta con el formato deseado
 	response := map[string]interface{}{
-		"incidenciaId":        incidencia.PK_ID_INCIDENCIA,
-		"fechaIncidencia":     incidencia.FECHA.Format("2006-01-02"),
-		"monto":               incidencia.MONTO,
-		"resta":               incidencia.RESTA,
-		"motivo":              incidencia.MOTIVO,
-		"documentoTrabajador": incidencia.PK_DOCUMENTO_TRABAJADOR,
+		"incidenciaId":    incidencia.PK_ID_INCIDENCIA,
+		"fechaIncidencia": incidencia.FECHA.Format("2006-01-02"),
+		"monto":           incidencia.MONTO,
+		"resta":           incidencia.RESTA,
+		"motivo":          incidencia.MOTIVO,
+		"documentoTrabajador": func() int64 {
+			if incidencia.PK_DOCUMENTO_TRABAJADOR != nil {
+				return incidencia.PK_DOCUMENTO_TRABAJADOR.PK_DOCUMENTO_TRABAJADOR
+			}
+			return 0
+		}(),
 	}
 
 	// Responder con éxito

--- a/controllers/NominaTrabajadorController.go
+++ b/controllers/NominaTrabajadorController.go
@@ -91,7 +91,7 @@ func (c *NominaTrabajadorController) Post() {
 		c.ServeJSON()
 		return
 	}
-	nominaTrabajador.PK_DOCUMENTO_TRABAJADOR = &input.PK_DOCUMENTO_TRABAJADOR
+	nominaTrabajador.PK_DOCUMENTO_TRABAJADOR = &models.Trabajador{PK_DOCUMENTO_TRABAJADOR: input.PK_DOCUMENTO_TRABAJADOR}
 
 	// Calcular el rango de fechas
 	now := time.Now()

--- a/controllers/PagoController.go
+++ b/controllers/PagoController.go
@@ -99,7 +99,7 @@ func (c *PagoController) GetAll() {
 		if estado != "" && pago.ESTADO_PAGO != estado {
 			continue
 		}
-		if metodo_pago > 0 && (pago.PK_ID_METODO_PAGO == nil || *pago.PK_ID_METODO_PAGO != int64(metodo_pago)) {
+		if metodo_pago > 0 && (pago.PK_ID_METODO_PAGO == nil || pago.PK_ID_METODO_PAGO.PK_ID_METODO_PAGO != int64(metodo_pago)) {
 			continue
 		}
 
@@ -288,9 +288,9 @@ func (c *PagoController) Post() {
 		FECHA:             fecha,
 		HORA:              hora,
 		MONTO:             in.Monto,
-		ESTADO_PAGO:       in.EstadoPago,    // e.g. "PAGADO"
-		PK_ID_METODO_PAGO: &in.MetodoPagoId, // FK obligatorio
-		UPDATED_BY:        updatedBy,        // opcional
+		ESTADO_PAGO:       in.EstadoPago,                                          // e.g. "PAGADO"
+		PK_ID_METODO_PAGO: &models.MetodoPago{PK_ID_METODO_PAGO: in.MetodoPagoId}, // FK obligatorio
+		UPDATED_BY:        updatedBy,                                              // opcional
 		// UPDATED_AT se maneja con auto_now en el modelo
 	}
 
@@ -433,7 +433,7 @@ func (c *PagoController) Put() {
 
 	if pkMetodoPago, ok := input["PK_ID_METODO_PAGO"].(float64); ok && pkMetodoPago != 0 {
 		val := int64(pkMetodoPago)
-		pago.PK_ID_METODO_PAGO = &val
+		pago.PK_ID_METODO_PAGO = &models.MetodoPago{PK_ID_METODO_PAGO: val}
 	} else {
 		c.Ctx.Output.SetStatus(http.StatusBadRequest)
 		c.Data["json"] = models.ApiResponse{

--- a/controllers/PedidoController.go
+++ b/controllers/PedidoController.go
@@ -173,7 +173,7 @@ func (c *PedidoController) Post() {
 		pedido.DELIVERY = false
 	}
 	if in.PKIDDomicilio != nil {
-		pedido.PK_ID_DOMICILIO = in.PKIDDomicilio
+		pedido.PK_ID_DOMICILIO = &models.Domicilio{PK_ID_DOMICILIO: *in.PKIDDomicilio}
 	}
 	if in.RestauranteId == 0 {
 		c.Ctx.Output.SetStatus(400)
@@ -181,7 +181,7 @@ func (c *PedidoController) Post() {
 		c.ServeJSON()
 		return
 	}
-	pedido.PK_ID_RESTAURANTE = &in.RestauranteId
+	pedido.PK_ID_RESTAURANTE = &models.Restaurante{PK_ID_RESTAURANTE: in.RestauranteId}
 
 	if pedido.DELIVERY && pedido.PK_ID_DOMICILIO == nil {
 		c.Ctx.Output.SetStatus(400)
@@ -242,7 +242,7 @@ func (c *PedidoController) AssignDomicilio() {
 	}
 
 	// Sólo actualizamos la FK al domicilio (por contrato actual)
-	pedido.PK_ID_DOMICILIO = &domicilioID
+	pedido.PK_ID_DOMICILIO = &models.Domicilio{PK_ID_DOMICILIO: domicilioID}
 	if _, err := o.Update(&pedido, "PK_ID_DOMICILIO"); err != nil {
 		c.Ctx.Output.SetStatus(500)
 		c.Data["json"] = models.ApiResponse{Code: 500, Message: "Error al asignar domicilio", Cause: err.Error()}
@@ -282,7 +282,7 @@ func (c *PedidoController) AssignPago() {
 	}
 
 	// Actualizamos la FK al pago y marcamos la orden como terminada
-	pedido.PK_ID_PAGO = &pagoID
+	pedido.PK_ID_PAGO = &models.Pago{PK_ID_PAGO: pagoID}
 	pedido.ESTADO_PEDIDO = models.EstadoPedidoTerminado
 	if _, err := o.Update(&pedido, "PK_ID_PAGO", "ESTADO_PEDIDO"); err != nil {
 		c.Ctx.Output.SetStatus(500)

--- a/controllers/ProductoController.go
+++ b/controllers/ProductoController.go
@@ -154,7 +154,7 @@ func (c *ProductoController) Post() {
 		return
 	}
 
-	hist := models.PrecioProductoHist{PKIDProducto: &producto.PK_ID_PRODUCTO, Precio: producto.PRECIO, FechaVigencia: time.Now()}
+	hist := models.PrecioProductoHist{PKIDProducto: &producto, Precio: producto.PRECIO, FechaVigencia: time.Now()}
 	if _, err := o.Insert(&hist); err != nil {
 		c.Ctx.Output.SetStatus(http.StatusInternalServerError)
 		c.Data["json"] = models.ApiResponse{Code: http.StatusInternalServerError, Message: "Error al registrar historial de precios", Cause: err.Error()}
@@ -236,7 +236,7 @@ func (c *ProductoController) Put() {
 		}
 
 		if producto.PRECIO != original.PRECIO {
-			hist := models.PrecioProductoHist{PKIDProducto: &producto.PK_ID_PRODUCTO, Precio: producto.PRECIO, FechaVigencia: time.Now()}
+			hist := models.PrecioProductoHist{PKIDProducto: &producto, Precio: producto.PRECIO, FechaVigencia: time.Now()}
 			if _, err := o.Insert(&hist); err != nil {
 				c.Ctx.Output.SetStatus(http.StatusInternalServerError)
 				c.Data["json"] = models.ApiResponse{Code: http.StatusInternalServerError, Message: "Error al registrar historial de precios", Cause: err.Error()}

--- a/controllers/ProductoPedidoController.go
+++ b/controllers/ProductoPedidoController.go
@@ -135,8 +135,8 @@ func (c *ProductoPedidoController) Post() {
 		pedidoID := input.PedidoId
 		productoID := d.PKIDProducto
 		detalle := models.DetallePedido{
-			PKIDPedido:   &pedidoID,
-			PKIDProducto: &productoID,
+			PKIDPedido:   &models.Pedido{PK_ID_PEDIDO: pedidoID},
+			PKIDProducto: &models.Producto{PK_ID_PRODUCTO: productoID},
 			Cantidad:     d.Cantidad,
 		}
 		if _, err := o.Insert(&detalle); err != nil {
@@ -254,8 +254,8 @@ func (c *ProductoPedidoController) Update() {
 		pid := pedidoID
 		prodID := d.PKIDProducto
 		detalle := models.DetallePedido{
-			PKIDPedido:   &pid,
-			PKIDProducto: &prodID,
+			PKIDPedido:   &models.Pedido{PK_ID_PEDIDO: pid},
+			PKIDProducto: &models.Producto{PK_ID_PRODUCTO: prodID},
 			Cantidad:     d.Cantidad,
 		}
 		if _, err := o.Insert(&detalle); err != nil {

--- a/controllers/ReservaController.go
+++ b/controllers/ReservaController.go
@@ -178,7 +178,7 @@ func (c *ReservaController) Post() {
 	}
 	if v, ok := input["documentoCliente"].(float64); ok {
 		val := int64(v)
-		contacto.PKDocumentoCliente = &val
+		contacto.PKDocumentoCliente = &models.Cliente{PK_DOCUMENTO_CLIENTE: val}
 	}
 	if contacto.DocumentoContacto != nil || contacto.PKDocumentoCliente != nil {
 		if !contacto.Valid() {
@@ -283,19 +283,19 @@ func (c *ReservaController) Post() {
 
 	if contactoID, ok := input["contactoId"].(float64); ok {
 		val := int64(contactoID)
-		reserva.PK_ID_CONTACTO = &val
+		reserva.PK_ID_CONTACTO = &models.ReservaContacto{PKIDContacto: val}
 	} else {
-			c.Ctx.Output.SetStatus(http.StatusBadRequest)
-			c.Data["json"] = models.ApiResponse{
-				Code:    http.StatusBadRequest,
-				Message: "El campo PK_ID_CONTACTO debe ser un número",
-			}
-			c.ServeJSON()
-			return
+		c.Ctx.Output.SetStatus(http.StatusBadRequest)
+		c.Data["json"] = models.ApiResponse{
+			Code:    http.StatusBadRequest,
+			Message: "El campo PK_ID_CONTACTO debe ser un número",
+		}
+		c.ServeJSON()
+		return
 	}
 	if restauranteID, ok := input["restauranteId"].(float64); ok {
 		val := int64(restauranteID)
-		reserva.PK_ID_RESTAURANTE = &val
+		reserva.PK_ID_RESTAURANTE = &models.Restaurante{PK_ID_RESTAURANTE: val}
 	} else {
 		c.Ctx.Output.SetStatus(http.StatusBadRequest)
 		c.Data["json"] = models.ApiResponse{
@@ -393,7 +393,7 @@ func (c *ReservaController) Put() {
 	}
 	if v, ok := input["documentoCliente"].(float64); ok {
 		val := int64(v)
-		contacto.PKDocumentoCliente = &val
+		contacto.PKDocumentoCliente = &models.Cliente{PK_DOCUMENTO_CLIENTE: val}
 	}
 	if contacto.DocumentoContacto != nil || contacto.PKDocumentoCliente != nil {
 		if !contacto.Valid() {
@@ -456,7 +456,7 @@ func (c *ReservaController) Put() {
 
 	if contactoID, ok := input["contactoId"].(float64); ok {
 		val := int64(contactoID)
-		reserva.PK_ID_CONTACTO = &val
+		reserva.PK_ID_CONTACTO = &models.ReservaContacto{PKIDContacto: val}
 	} else {
 		c.Ctx.Output.SetStatus(http.StatusBadRequest)
 		c.Data["json"] = models.ApiResponse{
@@ -468,7 +468,7 @@ func (c *ReservaController) Put() {
 	}
 	if restauranteID, ok := input["restauranteId"].(float64); ok {
 		val := int64(restauranteID)
-		reserva.PK_ID_RESTAURANTE = &val
+		reserva.PK_ID_RESTAURANTE = &models.Restaurante{PK_ID_RESTAURANTE: val}
 	} else {
 		c.Ctx.Output.SetStatus(http.StatusBadRequest)
 		c.Data["json"] = models.ApiResponse{

--- a/controllers/TrabajadorController.go
+++ b/controllers/TrabajadorController.go
@@ -347,7 +347,7 @@ func (c *TrabajadorController) Post() {
 	// Procesar PK_ID_RESTAURANTE
 	if pkRestaurante, ok := input["restauranteId"].(float64); ok {
 		valor := int64(pkRestaurante)
-		trabajador.PK_ID_RESTAURANTE = &valor
+		trabajador.PK_ID_RESTAURANTE = &models.Restaurante{PK_ID_RESTAURANTE: valor}
 	}
 
 	// Procesar FECHA_NACIMIENTO

--- a/controllers/pago_controller_test.go
+++ b/controllers/pago_controller_test.go
@@ -384,7 +384,7 @@ func TestPagoDeleteNotFound(t *testing.T) {
 func TestPagoGetAllSuccess(t *testing.T) {
 	orig := pagoNewOrm
 	pagoNewOrm = func() ormer {
-		pagos := []models.Pago{{PK_ID_PAGO: int64(1), FECHA: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC), HORA: time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC), ESTADO_PAGO: "PAGADO", PK_ID_METODO_PAGO: 1}}
+		pagos := []models.Pago{{PK_ID_PAGO: int64(1), FECHA: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC), HORA: time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC), ESTADO_PAGO: "PAGADO", PK_ID_METODO_PAGO: &models.MetodoPago{PK_ID_METODO_PAGO: 1}}}
 		return fakeOrmer{queryAll: func(res interface{}, cols ...string) (int64, error) {
 			ptr := res.(*[]models.Pago)
 			*ptr = pagos
@@ -436,12 +436,12 @@ func TestPagoGetAllFilterOthers(t *testing.T) {
 	orig := pagoNewOrm
 	pagoNewOrm = func() ormer {
 		pagos := []models.Pago{
-			{FECHA: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC), HORA: time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC), ESTADO_PAGO: "PAGADO", PK_ID_METODO_PAGO: 1},
-			{FECHA: time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC), HORA: time.Date(2024, 1, 2, 10, 0, 0, 0, time.UTC), ESTADO_PAGO: "PAGADO", PK_ID_METODO_PAGO: 1},
-			{FECHA: time.Date(2024, 2, 1, 0, 0, 0, 0, time.UTC), HORA: time.Date(2024, 2, 1, 10, 0, 0, 0, time.UTC), ESTADO_PAGO: "PAGADO", PK_ID_METODO_PAGO: 1},
-			{FECHA: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC), HORA: time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC), ESTADO_PAGO: "PAGADO", PK_ID_METODO_PAGO: 1},
-			{FECHA: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC), HORA: time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC), ESTADO_PAGO: "NO_PAGO", PK_ID_METODO_PAGO: 1},
-			{FECHA: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC), HORA: time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC), ESTADO_PAGO: "PAGADO", PK_ID_METODO_PAGO: 2},
+			{FECHA: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC), HORA: time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC), ESTADO_PAGO: "PAGADO", PK_ID_METODO_PAGO: &models.MetodoPago{PK_ID_METODO_PAGO: 1}},
+			{FECHA: time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC), HORA: time.Date(2024, 1, 2, 10, 0, 0, 0, time.UTC), ESTADO_PAGO: "PAGADO", PK_ID_METODO_PAGO: &models.MetodoPago{PK_ID_METODO_PAGO: 1}},
+			{FECHA: time.Date(2024, 2, 1, 0, 0, 0, 0, time.UTC), HORA: time.Date(2024, 2, 1, 10, 0, 0, 0, time.UTC), ESTADO_PAGO: "PAGADO", PK_ID_METODO_PAGO: &models.MetodoPago{PK_ID_METODO_PAGO: 1}},
+			{FECHA: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC), HORA: time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC), ESTADO_PAGO: "PAGADO", PK_ID_METODO_PAGO: &models.MetodoPago{PK_ID_METODO_PAGO: 1}},
+			{FECHA: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC), HORA: time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC), ESTADO_PAGO: "NO_PAGO", PK_ID_METODO_PAGO: &models.MetodoPago{PK_ID_METODO_PAGO: 1}},
+			{FECHA: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC), HORA: time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC), ESTADO_PAGO: "PAGADO", PK_ID_METODO_PAGO: &models.MetodoPago{PK_ID_METODO_PAGO: 2}},
 		}
 		return fakeOrmer{queryAll: func(res interface{}, cols ...string) (int64, error) {
 			ptr := res.(*[]models.Pago)
@@ -466,7 +466,7 @@ func TestPagoGetAllFilterOthers(t *testing.T) {
 func TestPagoGetAllNoResults(t *testing.T) {
 	orig := pagoNewOrm
 	pagoNewOrm = func() ormer {
-		pagos := []models.Pago{{FECHA: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC), HORA: time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC), ESTADO_PAGO: "PAGADO", PK_ID_METODO_PAGO: 1}}
+		pagos := []models.Pago{{FECHA: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC), HORA: time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC), ESTADO_PAGO: "PAGADO", PK_ID_METODO_PAGO: &models.MetodoPago{PK_ID_METODO_PAGO: 1}}}
 		return fakeOrmer{queryAll: func(res interface{}, cols ...string) (int64, error) {
 			ptr := res.(*[]models.Pago)
 			*ptr = pagos

--- a/controllers/producto_pedido_controller_test.go
+++ b/controllers/producto_pedido_controller_test.go
@@ -255,8 +255,8 @@ func TestProductoPedidoGetAllSuccess(t *testing.T) {
 					*detalles = append(
 						*detalles,
 						models.DetallePedido{
-							PKIDPedido:   &pedidoID,
-							PKIDProducto: &productoID,
+							PKIDPedido:   &models.Pedido{PK_ID_PEDIDO: pedidoID},
+							PKIDProducto: &models.Producto{PK_ID_PRODUCTO: productoID},
 							Cantidad:     1,
 							Precio:       1000,
 						},
@@ -303,8 +303,8 @@ func TestProductoPedidoPostSuccess(t *testing.T) {
 						pedidoID := int64(1)
 						productoID := int64(1)
 						*d = models.DetallePedido{
-							PKIDPedido:   &pedidoID,
-							PKIDProducto: &productoID,
+							PKIDPedido:   &models.Pedido{PK_ID_PEDIDO: pedidoID},
+							PKIDProducto: &models.Producto{PK_ID_PRODUCTO: productoID},
 							Cantidad:     1,
 							Precio:       1000,
 						}
@@ -355,8 +355,8 @@ func TestProductoPedidoUpdateSuccess(t *testing.T) {
 						pedidoID := int64(1)
 						productoID := int64(1)
 						*d = models.DetallePedido{
-							PKIDPedido:   &pedidoID,
-							PKIDProducto: &productoID,
+							PKIDPedido:   &models.Pedido{PK_ID_PEDIDO: pedidoID},
+							PKIDProducto: &models.Producto{PK_ID_PRODUCTO: productoID},
 							Cantidad:     1,
 							Precio:       1000,
 						}

--- a/controllers/reserva_controller_test.go
+++ b/controllers/reserva_controller_test.go
@@ -670,7 +670,7 @@ func TestReservaGetByParameterSuccess(t *testing.T) {
 	hora, _ := time.Parse(time.RFC3339, "2024-01-01T12:00:00Z")
 	db := []models.Reserva{{
 		PK_ID_RESERVA:  int64(1),
-		PK_ID_CONTACTO: 123,
+		PK_ID_CONTACTO: &models.ReservaContacto{PKIDContacto: 123},
 		FECHA:          time.Now(),
 		CREATED_AT:     time.Now(),
 		UPDATED_AT:     time.Now(),

--- a/models/DetallePedido.go
+++ b/models/DetallePedido.go
@@ -4,11 +4,11 @@ import "github.com/beego/beego/v2/client/orm"
 
 // DetallePedido represents a product within un pedido.
 type DetallePedido struct {
-	PK_ID_DETALLE int64  `orm:"column(pk_id_detalle);pk;auto" json:"detalleId"`
-	PKIDPedido    *int64 `orm:"column(pk_id_pedido);rel(fk)" json:"pedidoId"`
-	PKIDProducto  *int64 `orm:"column(pk_id_producto);rel(fk)" json:"productoId"`
-	Precio        int64  `orm:"column(precio);type(bigint)" json:"precio"`
-	Cantidad      int    `orm:"column(cantidad)" json:"cantidad"`
+	PK_ID_DETALLE int64     `orm:"column(pk_id_detalle);pk;auto" json:"detalleId"`
+	PKIDPedido    *Pedido   `orm:"column(pk_id_pedido);rel(fk)" json:"pedidoId"`
+	PKIDProducto  *Producto `orm:"column(pk_id_producto);rel(fk)" json:"productoId"`
+	Precio        int64     `orm:"column(precio);type(bigint)" json:"precio"`
+	Cantidad      int       `orm:"column(cantidad)" json:"cantidad"`
 }
 
 func (d *DetallePedido) TableName() string {

--- a/models/Domicilio.go
+++ b/models/Domicilio.go
@@ -13,14 +13,14 @@ type Domicilio struct {
 	TELEFONO         string          `orm:"column(telefono);type(text)" json:"telefono"`
 	ESTADO_DOMICILIO EstadoDomicilio `orm:"column(estado_domicilio);type(estado_domicilio)" json:"estado"`
 	// ENTREGADO es una columna generada por la base de datos
-	ENTREGADO               bool      `orm:"column(entregado);type(boolean)" json:"entregado"`
-	FECHA                   time.Time `orm:"column(fecha);type(date)" json:"fechaDomicilio"`
-	OBSERVACIONES           *string   `orm:"column(observaciones);type(text);null" json:"observaciones,omitempty"`
-	CREATED_AT              time.Time `orm:"column(created_at);type(timestamptz);auto_now_add" json:"createdAt"`
-	UPDATED_AT              time.Time `orm:"column(updated_at);type(timestamptz);auto_now" json:"updatedAt"`
-	CREATED_BY              *string   `orm:"column(created_by);type(text);null" json:"createdBy,omitempty"`
-	UPDATED_BY              *string   `orm:"column(updated_by);type(text);null" json:"updatedBy,omitempty"`
-	PK_DOCUMENTO_TRABAJADOR *int64    `orm:"column(pk_documento_trabajador);rel(fk);null" json:"trabajadorAsignado,omitempty"`
+	ENTREGADO               bool        `orm:"column(entregado);type(boolean)" json:"entregado"`
+	FECHA                   time.Time   `orm:"column(fecha);type(date)" json:"fechaDomicilio"`
+	OBSERVACIONES           *string     `orm:"column(observaciones);type(text);null" json:"observaciones,omitempty"`
+	CREATED_AT              time.Time   `orm:"column(created_at);type(timestamptz);auto_now_add" json:"createdAt"`
+	UPDATED_AT              time.Time   `orm:"column(updated_at);type(timestamptz);auto_now" json:"updatedAt"`
+	CREATED_BY              *string     `orm:"column(created_by);type(text);null" json:"createdBy,omitempty"`
+	UPDATED_BY              *string     `orm:"column(updated_by);type(text);null" json:"updatedBy,omitempty"`
+	PK_DOCUMENTO_TRABAJADOR *Trabajador `orm:"column(pk_documento_trabajador);rel(fk);null" json:"trabajadorAsignado,omitempty"`
 }
 
 func (d *Domicilio) TableName() string {

--- a/models/HorarioTrabajador.go
+++ b/models/HorarioTrabajador.go
@@ -8,11 +8,11 @@ import (
 )
 
 type HorarioTrabajador struct {
-	PK_ID_HORARIO_TRABAJADOR int64     `orm:"column(pk_id_horario_trabajador);pk;auto" json:"horarioTrabajadorId"`
-	PK_DOCUMENTO_TRABAJADOR  *int64    `orm:"column(pk_documento_trabajador);rel(fk)" json:"documentoTrabajador"`
-	DIA                      DiaSemana `orm:"column(dia);type(dia_semana)" json:"dia"`
-	HORA_INICIO              time.Time `orm:"column(hora_inicio);type(time)" json:"horaInicio"`
-	HORA_FIN                 time.Time `orm:"column(hora_fin);type(time)" json:"horaFin"`
+	PK_ID_HORARIO_TRABAJADOR int64       `orm:"column(pk_id_horario_trabajador);pk;auto" json:"horarioTrabajadorId"`
+	PK_DOCUMENTO_TRABAJADOR  *Trabajador `orm:"column(pk_documento_trabajador);rel(fk)" json:"documentoTrabajador"`
+	DIA                      DiaSemana   `orm:"column(dia);type(dia_semana)" json:"dia"`
+	HORA_INICIO              time.Time   `orm:"column(hora_inicio);type(time)" json:"horaInicio"`
+	HORA_FIN                 time.Time   `orm:"column(hora_fin);type(time)" json:"horaFin"`
 }
 
 func (h *HorarioTrabajador) TableName() string {
@@ -40,9 +40,14 @@ func (h HorarioTrabajador) MarshalJSON() ([]byte, error) {
 		HORA_INICIO             string `json:"horaInicio"`
 		HORA_FIN                string `json:"horaFin"`
 	}{
-		PK_DOCUMENTO_TRABAJADOR: h.PK_DOCUMENTO_TRABAJADOR,
-		DIA:                     string(h.DIA),
-		HORA_INICIO:             h.HORA_INICIO.Format("15:04:05"),
-		HORA_FIN:                h.HORA_FIN.Format("15:04:05"),
+		PK_DOCUMENTO_TRABAJADOR: func() *int64 {
+			if h.PK_DOCUMENTO_TRABAJADOR != nil {
+				return &h.PK_DOCUMENTO_TRABAJADOR.PK_DOCUMENTO_TRABAJADOR
+			}
+			return nil
+		}(),
+		DIA:         string(h.DIA),
+		HORA_INICIO: h.HORA_INICIO.Format("15:04:05"),
+		HORA_FIN:    h.HORA_FIN.Format("15:04:05"),
 	})
 }

--- a/models/Incidencia.go
+++ b/models/Incidencia.go
@@ -8,12 +8,12 @@ import (
 )
 
 type Incidencia struct {
-	PK_ID_INCIDENCIA        int64     `orm:"column(pk_id_incidencia);pk;auto" json:"incidenciaId"`
-	FECHA                   time.Time `orm:"column(fecha);type(date)" json:"fechaIncidencia"`
-	MONTO                   int64     `orm:"column(monto)" json:"monto"`
-	RESTA                   bool      `orm:"column(resta);type(boolean)" json:"resta"`
-	MOTIVO                  string    `orm:"column(motivo);type(text)" json:"motivo"`
-	PK_DOCUMENTO_TRABAJADOR *int64    `orm:"column(pk_documento_trabajador);rel(fk)" json:"documentoTrabajador"`
+	PK_ID_INCIDENCIA        int64       `orm:"column(pk_id_incidencia);pk;auto" json:"incidenciaId"`
+	FECHA                   time.Time   `orm:"column(fecha);type(date)" json:"fechaIncidencia"`
+	MONTO                   int64       `orm:"column(monto)" json:"monto"`
+	RESTA                   bool        `orm:"column(resta);type(boolean)" json:"resta"`
+	MOTIVO                  string      `orm:"column(motivo);type(text)" json:"motivo"`
+	PK_DOCUMENTO_TRABAJADOR *Trabajador `orm:"column(pk_documento_trabajador);rel(fk)" json:"documentoTrabajador"`
 }
 
 func (i *Incidencia) TableName() string {

--- a/models/NominaTrabajador.go
+++ b/models/NominaTrabajador.go
@@ -3,12 +3,12 @@ package models
 import "github.com/beego/beego/v2/client/orm"
 
 type NominaTrabajador struct {
-	PK_ID_NOMINA_TRABAJADOR int64   `orm:"column(pk_id_nomina_trabajador);pk;auto" json:"nominaTrabajadorId"`
-	SUELDO_BASE             int64   `orm:"column(sueldo_base)" json:"sueldoBase"`
-	MONTO_INCIDENCIAS       *int64  `orm:"column(monto_incidencias);null" json:"montoIncidencias,omitempty"`
-	DETALLES                *string `orm:"column(detalles);type(text);null" json:"detalles,omitempty"`
-	PK_DOCUMENTO_TRABAJADOR *int64  `orm:"column(pk_documento_trabajador);rel(fk)" json:"documentoTrabajador"`
-	PK_ID_NOMINA            *int64  `orm:"column(pk_id_nomina);rel(fk)" json:"nominaId"`
+	PK_ID_NOMINA_TRABAJADOR int64       `orm:"column(pk_id_nomina_trabajador);pk;auto" json:"nominaTrabajadorId"`
+	SUELDO_BASE             int64       `orm:"column(sueldo_base)" json:"sueldoBase"`
+	MONTO_INCIDENCIAS       *int64      `orm:"column(monto_incidencias);null" json:"montoIncidencias,omitempty"`
+	DETALLES                *string     `orm:"column(detalles);type(text);null" json:"detalles,omitempty"`
+	PK_DOCUMENTO_TRABAJADOR *Trabajador `orm:"column(pk_documento_trabajador);rel(fk)" json:"documentoTrabajador"`
+	PK_ID_NOMINA            *Nomina     `orm:"column(pk_id_nomina);rel(fk)" json:"nominaId"`
 }
 
 type NominaTrabajadorRequest struct {

--- a/models/Pago.go
+++ b/models/Pago.go
@@ -8,14 +8,14 @@ import (
 )
 
 type Pago struct {
-	PK_ID_PAGO        int64      `orm:"column(pk_id_pago);pk;auto" json:"pagoId"`
-	FECHA             time.Time  `orm:"column(fecha);type(date)" json:"fechaPago"`
-	HORA              time.Time  `orm:"column(hora);type(time)" json:"horaPago"`
-	MONTO             int64      `orm:"column(monto)" json:"monto"`
-	ESTADO_PAGO       EstadoPago `orm:"column(estado_pago);type(estado_pago)" json:"estadoPago"`
-	PK_ID_METODO_PAGO *int64     `orm:"column(pk_id_metodo_pago);rel(fk)" json:"metodoPagoId"`
-	UPDATED_AT        time.Time  `orm:"column(updated_at);type(timestamptz);auto_now" json:"updatedAt"`
-	UPDATED_BY        *string    `orm:"column(updated_by);type(text);null" json:"updatedBy,omitempty"`
+	PK_ID_PAGO        int64       `orm:"column(pk_id_pago);pk;auto" json:"pagoId"`
+	FECHA             time.Time   `orm:"column(fecha);type(date)" json:"fechaPago"`
+	HORA              time.Time   `orm:"column(hora);type(time)" json:"horaPago"`
+	MONTO             int64       `orm:"column(monto)" json:"monto"`
+	ESTADO_PAGO       EstadoPago  `orm:"column(estado_pago);type(estado_pago)" json:"estadoPago"`
+	PK_ID_METODO_PAGO *MetodoPago `orm:"column(pk_id_metodo_pago);rel(fk)" json:"metodoPagoId"`
+	UPDATED_AT        time.Time   `orm:"column(updated_at);type(timestamptz);auto_now" json:"updatedAt"`
+	UPDATED_BY        *string     `orm:"column(updated_by);type(text);null" json:"updatedBy,omitempty"`
 }
 
 func (p *Pago) TableName() string {

--- a/models/Pedido.go
+++ b/models/Pedido.go
@@ -13,10 +13,10 @@ type Pedido struct {
 	HORA                 time.Time    `orm:"column(hora);type(time)" json:"horaPedido"`
 	DELIVERY             bool         `orm:"column(delivery);type(boolean)" json:"delivery"`
 	ESTADO_PEDIDO        EstadoPedido `orm:"column(estado_pedido);type(estado_pedido)" json:"estadoPedido"`
-	PK_ID_DOMICILIO      *int64       `orm:"column(pk_id_domicilio);rel(fk);null" json:"domicilioId,omitempty"`
-	PK_ID_PAGO           *int64       `orm:"column(pk_id_pago);rel(fk);null" json:"pagoId"`
-	PK_ID_RESTAURANTE    *int64       `orm:"column(pk_id_restaurante);rel(fk)" json:"restauranteId"`
-	PK_DOCUMENTO_CLIENTE *int64       `orm:"column(pk_documento_cliente);rel(fk)" json:"documentoCliente"`
+	PK_ID_DOMICILIO      *Domicilio   `orm:"column(pk_id_domicilio);rel(fk);null" json:"domicilioId,omitempty"`
+	PK_ID_PAGO           *Pago        `orm:"column(pk_id_pago);rel(fk);null" json:"pagoId"`
+	PK_ID_RESTAURANTE    *Restaurante `orm:"column(pk_id_restaurante);rel(fk)" json:"restauranteId"`
+	PK_DOCUMENTO_CLIENTE *Cliente     `orm:"column(pk_documento_cliente);rel(fk)" json:"documentoCliente"`
 	UPDATED_AT           time.Time    `orm:"column(updated_at);type(timestamptz);auto_now" json:"updatedAt"`
 	UPDATED_BY           *string      `orm:"column(updated_by);type(text);null" json:"updatedBy,omitempty"`
 }

--- a/models/PrecioProductoHist.go
+++ b/models/PrecioProductoHist.go
@@ -10,7 +10,7 @@ import (
 // It no longer maintains its own primary key or audit timestamps.
 type PrecioProductoHist struct {
 	PK_ID_PRECIO_HIST int64     `orm:"column(pk_id_precio_hist);pk;auto" json:"precioHistId"`
-	PKIDProducto      *int64    `orm:"column(pk_id_producto);rel(fk)" json:"productoId"`
+	PKIDProducto      *Producto `orm:"column(pk_id_producto);rel(fk)" json:"productoId"`
 	Precio            int64     `orm:"column(precio);type(bigint)" json:"precio"`
 	FechaVigencia     time.Time `orm:"column(fecha_vigencia);type(date)" json:"fechaVigencia"`
 }

--- a/models/Reserva.go
+++ b/models/Reserva.go
@@ -8,18 +8,18 @@ import (
 )
 
 type Reserva struct {
-	PK_ID_RESERVA     int64          `orm:"column(pk_id_reserva);pk;auto" json:"reservaId"`
-	FECHA             time.Time      `orm:"column(fecha);type(date)" json:"fechaReserva"`
-	HORA              time.Time      `orm:"column(hora);type(time);size(8)" json:"horaReserva"`
-	PERSONAS          int            `orm:"column(personas)" json:"personas"`
-	PK_ID_CONTACTO    *int64         `orm:"column(pk_id_contacto);rel(fk)" json:"contactoId"`
-	PK_ID_RESTAURANTE *int64         `orm:"column(pk_id_restaurante);rel(fk)" json:"restauranteId"`
-	ESTADO_RESERVA    *EstadoReserva `orm:"column(estado_reserva);type(estado_reserva);null" json:"estadoReserva,omitempty"`
-	INDICACIONES      *string        `orm:"column(indicaciones);null" json:"indicaciones,omitempty"`
-	CREATED_AT        time.Time      `orm:"column(created_at);type(timestamptz);auto_now_add" json:"createdAt"`
-	UPDATED_AT        time.Time      `orm:"column(updated_at);type(timestamptz);auto_now" json:"updatedAt"`
-	CREATED_BY        *string        `orm:"column(created_by);type(text);null" json:"createdBy,omitempty"`
-	UPDATED_BY        *string        `orm:"column(updated_by);type(text);null" json:"updatedBy,omitempty"`
+	PK_ID_RESERVA     int64            `orm:"column(pk_id_reserva);pk;auto" json:"reservaId"`
+	FECHA             time.Time        `orm:"column(fecha);type(date)" json:"fechaReserva"`
+	HORA              time.Time        `orm:"column(hora);type(time);size(8)" json:"horaReserva"`
+	PERSONAS          int              `orm:"column(personas)" json:"personas"`
+	PK_ID_CONTACTO    *ReservaContacto `orm:"column(pk_id_contacto);rel(fk)" json:"contactoId"`
+	PK_ID_RESTAURANTE *Restaurante     `orm:"column(pk_id_restaurante);rel(fk)" json:"restauranteId"`
+	ESTADO_RESERVA    *EstadoReserva   `orm:"column(estado_reserva);type(estado_reserva);null" json:"estadoReserva,omitempty"`
+	INDICACIONES      *string          `orm:"column(indicaciones);null" json:"indicaciones,omitempty"`
+	CREATED_AT        time.Time        `orm:"column(created_at);type(timestamptz);auto_now_add" json:"createdAt"`
+	UPDATED_AT        time.Time        `orm:"column(updated_at);type(timestamptz);auto_now" json:"updatedAt"`
+	CREATED_BY        *string          `orm:"column(created_by);type(text);null" json:"createdBy,omitempty"`
+	UPDATED_BY        *string          `orm:"column(updated_by);type(text);null" json:"updatedBy,omitempty"`
 }
 
 func (r *Reserva) TableName() string {

--- a/models/ReservaContacto.go
+++ b/models/ReservaContacto.go
@@ -3,11 +3,11 @@ package models
 import "github.com/beego/beego/v2/client/orm"
 
 type ReservaContacto struct {
-	PKIDContacto       int64   `orm:"column(pk_id_contacto);pk;auto" json:"contactoId"`
-	NombreCompleto     string  `orm:"column(nombre_completo);type(text)" json:"nombreCompleto"`
-	Telefono           *string `orm:"column(telefono);type(text);null" json:"telefono,omitempty"`
-	DocumentoContacto  *int64  `orm:"column(documento_contacto);null" json:"documentoContacto,omitempty"`
-	PKDocumentoCliente *int64  `orm:"column(pk_documento_cliente);rel(fk);null" json:"documentoCliente,omitempty"`
+	PKIDContacto       int64    `orm:"column(pk_id_contacto);pk;auto" json:"contactoId"`
+	NombreCompleto     string   `orm:"column(nombre_completo);type(text)" json:"nombreCompleto"`
+	Telefono           *string  `orm:"column(telefono);type(text);null" json:"telefono,omitempty"`
+	DocumentoContacto  *int64   `orm:"column(documento_contacto);null" json:"documentoContacto,omitempty"`
+	PKDocumentoCliente *Cliente `orm:"column(pk_documento_cliente);rel(fk);null" json:"documentoCliente,omitempty"`
 }
 
 func (r *ReservaContacto) TableName() string {

--- a/models/Restaurante.go
+++ b/models/Restaurante.go
@@ -7,10 +7,10 @@ import (
 )
 
 type Restaurante struct {
-	PK_ID_RESTAURANTE    int64     `orm:"column(pk_id_restaurante);pk;auto" json:"restauranteId"`
-	NOMBRE_RESTAURANTE   string    `orm:"column(nombre_restaurante);type(text)" json:"nombreRestaurante"`
-	HORA_APERTURA        time.Time `orm:"column(hora_apertura);type(time)" json:"horaApertura"`
-	PK_ID_CAMBIO_HORARIO *int64    `orm:"column(pk_id_cambio_horario);rel(fk);null" json:"cambioHorarioId,omitempty"`
+	PK_ID_RESTAURANTE    int64           `orm:"column(pk_id_restaurante);pk;auto" json:"restauranteId"`
+	NOMBRE_RESTAURANTE   string          `orm:"column(nombre_restaurante);type(text)" json:"nombreRestaurante"`
+	HORA_APERTURA        time.Time       `orm:"column(hora_apertura);type(time)" json:"horaApertura"`
+	PK_ID_CAMBIO_HORARIO *CambiosHorario `orm:"column(pk_id_cambio_horario);rel(fk);null" json:"cambioHorarioId,omitempty"`
 }
 
 func (t *Restaurante) TableName() string {

--- a/models/RestauranteDia.go
+++ b/models/RestauranteDia.go
@@ -3,9 +3,9 @@ package models
 import "github.com/beego/beego/v2/client/orm"
 
 type RestauranteDia struct {
-	PK_ID_RESTAURANTE_DIA int64     `orm:"column(pk_id_restaurante_dia);pk;auto" json:"restauranteDiaId"`
-	PKIDRestaurante       *int64    `orm:"column(pk_id_restaurante);rel(fk)" json:"restauranteId"`
-	Dia                   DiaSemana `orm:"column(dia);type(dia_semana)" json:"dia"`
+	PK_ID_RESTAURANTE_DIA int64        `orm:"column(pk_id_restaurante_dia);pk;auto" json:"restauranteDiaId"`
+	PKIDRestaurante       *Restaurante `orm:"column(pk_id_restaurante);rel(fk)" json:"restauranteId"`
+	Dia                   DiaSemana    `orm:"column(dia);type(dia_semana)" json:"dia"`
 }
 
 func (r *RestauranteDia) TableName() string {

--- a/models/Subcategoria.go
+++ b/models/Subcategoria.go
@@ -5,9 +5,9 @@ import (
 )
 
 type Subcategoria struct {
-	PK_ID_SUBCATEGORIA int64  `orm:"column(pk_id_subcategoria);pk;auto" json:"subcategoriaId"`
-	PK_ID_CATEGORIA    *int64 `orm:"column(pk_id_categoria);rel(fk)" json:"categoriaId"`
-	NOMBRE             string `orm:"column(nombre);type(text)" json:"nombre"`
+	PK_ID_SUBCATEGORIA int64      `orm:"column(pk_id_subcategoria);pk;auto" json:"subcategoriaId"`
+	PK_ID_CATEGORIA    *Categoria `orm:"column(pk_id_categoria);rel(fk)" json:"categoriaId"`
+	NOMBRE             string     `orm:"column(nombre);type(text)" json:"nombre"`
 }
 
 func (s *Subcategoria) TableName() string {

--- a/models/Trabajador.go
+++ b/models/Trabajador.go
@@ -20,7 +20,7 @@ type Trabajador struct {
 	FECHA_RETIRO            *time.Time          `orm:"column(fecha_retiro);type(date);null" json:"fechaRetiro,omitempty"`
 	PASSWORD                string              `orm:"column(password)" json:"password"`
 	HORARIOS                []HorarioTrabajador `orm:"-" json:"horarios,omitempty"`
-	PK_ID_RESTAURANTE       *int64              `orm:"column(pk_id_restaurante);rel(fk);null" json:"restauranteId,omitempty"`
+	PK_ID_RESTAURANTE       *Restaurante        `orm:"column(pk_id_restaurante);rel(fk);null" json:"restauranteId,omitempty"`
 }
 
 func (t *Trabajador) TableName() string {

--- a/models/pedido_test.go
+++ b/models/pedido_test.go
@@ -52,8 +52,8 @@ func TestDetallePedidoPrecioAuto(t *testing.T) {
 	pedidoID := int64(1)
 	productoID := int64(1)
 	detalle := DetallePedido{
-		PKIDPedido:   &pedidoID,
-		PKIDProducto: &productoID,
+		PKIDPedido:   &Pedido{PK_ID_PEDIDO: pedidoID},
+		PKIDProducto: &Producto{PK_ID_PRODUCTO: productoID},
 		Cantidad:     1,
 	}
 	if _, err := o.Insert(&detalle); err != nil {

--- a/models/producto_test.go
+++ b/models/producto_test.go
@@ -24,7 +24,7 @@ func TestProductoImagenFieldType(t *testing.T) {
 
 func TestProductoMarshalUnmarshalJSON(t *testing.T) {
 	calorias := int64(100)
-	img := []byte("hello")
+	img := "hello"
 	p := Producto{
 		PK_ID_PRODUCTO:     1,
 		NOMBRE:             "Test",
@@ -34,7 +34,7 @@ func TestProductoMarshalUnmarshalJSON(t *testing.T) {
 		ESTADO_PRODUCTO:    EstadoProductoDisponible,
 		IMAGEN:             img,
 		CANTIDAD:           2,
-		PK_ID_SUBCATEGORIA: 3,
+		PK_ID_SUBCATEGORIA: &Subcategoria{PK_ID_SUBCATEGORIA: 3},
 	}
 	data, err := json.Marshal(p)
 	if err != nil {

--- a/models/reserva_contacto_test.go
+++ b/models/reserva_contacto_test.go
@@ -7,7 +7,7 @@ func TestReservaContactoValid(t *testing.T) {
 	if !r.Valid() {
 		t.Fatalf("expected valid when only DocumentoContacto is set")
 	}
-	r = ReservaContacto{PKDocumentoCliente: new(int64)}
+	r = ReservaContacto{PKDocumentoCliente: &Cliente{PK_DOCUMENTO_CLIENTE: 1}}
 	if !r.Valid() {
 		t.Fatalf("expected valid when only PKDocumentoCliente is set")
 	}
@@ -16,7 +16,7 @@ func TestReservaContactoValid(t *testing.T) {
 		t.Fatalf("expected invalid when both nil")
 	}
 	doc := int64(1)
-	cli := int64(2)
+	cli := Cliente{PK_DOCUMENTO_CLIENTE: 2}
 	r = ReservaContacto{DocumentoContacto: &doc, PKDocumentoCliente: &cli}
 	if r.Valid() {
 		t.Fatalf("expected invalid when both set")

--- a/tests/detalle_pedido_trigger_test.go
+++ b/tests/detalle_pedido_trigger_test.go
@@ -47,8 +47,8 @@ func TestDetallePedidoTriggerOnInsert(t *testing.T) {
 	pid := int64(9999)
 	prodID := prod.PK_ID_PRODUCTO
 	det := models.DetallePedido{
-		PKIDPedido:   &pid,
-		PKIDProducto: &prodID,
+		PKIDPedido:   &models.Pedido{PK_ID_PEDIDO: pid},
+		PKIDProducto: &models.Producto{PK_ID_PRODUCTO: prodID},
 		Cantidad:     1,
 	}
 	if _, err := o.Insert(&det); err != nil {

--- a/tests/seed_data.go
+++ b/tests/seed_data.go
@@ -20,7 +20,7 @@ func SeedTestData() {
 		log.Println("seed categoria:", err)
 	}
 
-	if _, err := o.Insert(&models.Subcategoria{PK_ID_SUBCATEGORIA: 1, PK_ID_CATEGORIA: 1, NOMBRE: "Subgeneral"}); err != nil {
+	if _, err := o.Insert(&models.Subcategoria{PK_ID_SUBCATEGORIA: 1, PK_ID_CATEGORIA: &models.Categoria{PK_ID_CATEGORIA: 1}, NOMBRE: "Subgeneral"}); err != nil {
 		log.Println("seed subcategoria:", err)
 	}
 
@@ -34,7 +34,7 @@ func SeedTestData() {
 			PRECIO:             1000,
 			ESTADO_PRODUCTO:    models.EstadoProductoDisponible,
 			CANTIDAD:           1,
-			PK_ID_SUBCATEGORIA: 1,
+			PK_ID_SUBCATEGORIA: &models.Subcategoria{PK_ID_SUBCATEGORIA: 1},
 		}
 		if _, err := o.Insert(&prod); err != nil {
 			log.Println("seed producto:", err)
@@ -46,8 +46,8 @@ func SeedTestData() {
 	pedidoID := int64(1)
 	productoID := int64(1)
 	if _, err := o.Insert(&models.DetallePedido{
-		PKIDPedido:   &pedidoID,
-		PKIDProducto: &productoID,
+		PKIDPedido:   &models.Pedido{PK_ID_PEDIDO: pedidoID},
+		PKIDProducto: &models.Producto{PK_ID_PRODUCTO: productoID},
 		Cantidad:     1,
 	}); err != nil {
 		log.Println("seed detalle_pedido:", err)


### PR DESCRIPTION
## Summary
- replace int64 foreign key fields with struct pointers
- update controllers and tests to use model pointers

## Testing
- `go test ./controllers ./models ./tests` *(fails: PedidoController and model marshalling tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b7524b6a0483258a6fd7fc98aa71f4