### PR TITLE
Use raw SQL for domicilio assignment

### DIFF
--- a/controllers/DomicilioController.go
+++ b/controllers/DomicilioController.go
@@ -520,29 +520,11 @@ func (c *DomicilioController) AsignarDomiciliario() {
 	trabajadorID, _ := c.GetInt64("trabajador_id")
 
 	o := orm.NewOrm()
-	domicilio := models.Domicilio{ID: domicilioID}
-	if err := o.Read(&domicilio); err != nil {
-		c.Ctx.Output.SetStatus(http.StatusNotFound)
-		c.Data["json"] = models.ApiResponse{
-			Code:    http.StatusNotFound,
-			Message: "Domicilio no encontrado",
-		}
-		c.ServeJSON()
-		return
-	}
-
-	if domicilio.Trabajador != nil {
-		c.Ctx.Output.SetStatus(http.StatusConflict)
-		c.Data["json"] = models.ApiResponse{
-			Code:    http.StatusConflict,
-			Message: "Este domicilio ya ha sido asignado",
-		}
-		c.ServeJSON()
-		return
-	}
-
-	domicilio.Trabajador = &models.Trabajador{PK_DOCUMENTO_TRABAJADOR: trabajadorID}
-	if _, err := o.Update(&domicilio, "Trabajador"); err != nil {
+	res, err := o.Raw(
+		"UPDATE domicilio SET estado_domicilio='EN_CAMINO', pk_documento_trabajador=? WHERE pk_id_domicilio=? AND pk_documento_trabajador IS NULL",
+		trabajadorID, domicilioID,
+	).Exec()
+	if err != nil {
 		c.Ctx.Output.SetStatus(http.StatusInternalServerError)
 		c.Data["json"] = models.ApiResponse{
 			Code:    http.StatusInternalServerError,
@@ -551,6 +533,45 @@ func (c *DomicilioController) AsignarDomiciliario() {
 		}
 		c.ServeJSON()
 		return
+	}
+
+	affected, err := res.RowsAffected()
+	if err != nil {
+		c.Ctx.Output.SetStatus(http.StatusInternalServerError)
+		c.Data["json"] = models.ApiResponse{
+			Code:    http.StatusInternalServerError,
+			Message: "Error al asignar domicilio",
+			Cause:   err.Error(),
+		}
+		c.ServeJSON()
+		return
+	}
+
+	if affected != 1 {
+		var exists int
+		if err := o.Raw("SELECT COUNT(1) FROM domicilio WHERE pk_id_domicilio = ?", domicilioID).QueryRow(&exists); err != nil || exists == 0 {
+			c.Ctx.Output.SetStatus(http.StatusNotFound)
+			c.Data["json"] = models.ApiResponse{
+				Code:    http.StatusNotFound,
+				Message: "Domicilio no encontrado",
+			}
+		} else {
+			c.Ctx.Output.SetStatus(http.StatusConflict)
+			c.Data["json"] = models.ApiResponse{
+				Code:    http.StatusConflict,
+				Message: "Este domicilio ya ha sido asignado",
+			}
+		}
+		c.ServeJSON()
+		return
+	}
+
+	domicilio := models.Domicilio{
+		ID:     domicilioID,
+		Estado: models.EstadoDomicilioEnCamino,
+		Trabajador: &models.Trabajador{
+			PK_DOCUMENTO_TRABAJADOR: trabajadorID,
+		},
 	}
 
 	c.Ctx.Output.SetStatus(http.StatusOK)

--- a/controllers/domicilio_controller_test.go
+++ b/controllers/domicilio_controller_test.go
@@ -90,3 +90,38 @@ func TestPostReturnsGeneratedEntregado(t *testing.T) {
 		t.Fatalf("expected updatedAt in response")
 	}
 }
+
+func TestAsignarDomiciliarioSuccess(t *testing.T) {
+	MockExec = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Result, error) {
+		if !strings.Contains(strings.ToUpper(query), "ESTADO_DOMICILIO='EN_CAMINO'") {
+			t.Errorf("unexpected query: %s", query)
+		}
+		return mockResult{}, nil
+	}
+	defer func() { MockExec = nil }()
+
+	r := httptest.NewRequest(http.MethodPost, "/domicilios/asignar?domicilio_id=1&trabajador_id=2", nil)
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	c := DomicilioController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	c.AsignarDomiciliario()
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+	var resp models.ApiResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+	data, ok := resp.Data.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected map data, got %T", resp.Data)
+	}
+	if estado, ok := data["estadoDomicilio"].(string); !ok || estado != string(models.EstadoDomicilioEnCamino) {
+		t.Fatalf("expected estadoDomicilio %s, got %v", models.EstadoDomicilioEnCamino, data["estadoDomicilio"])
+	}
+}


### PR DESCRIPTION
## Summary
- update domicilio assignment to use raw SQL update and check row count
- test domicilio assignment using raw update and ensure state is EN_CAMINO

## Testing
- `go test ./...` *(fails: unknown db alias name `default` and other test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68b78fdd3dc8832586991272200ee0a3