### PR TITLE
test: expand horario trabajador controller coverage

### DIFF
--- a/controllers/horario_trabajador_controller_test.go
+++ b/controllers/horario_trabajador_controller_test.go
@@ -3,12 +3,14 @@ package controllers
 import (
 	stdctx "context"
 	"database/sql/driver"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/beego/beego/v2/client/orm"
 	"github.com/beego/beego/v2/server/web/context"
 )
 
@@ -97,6 +99,127 @@ func TestHorarioTrabajadorPutSuccess(t *testing.T) {
 		t.Fatalf("expected 200, got %d", w.Code)
 	}
 	if !strings.Contains(w.Body.String(), "Horario actualizado correctamente") {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
+}
+
+func TestIsValidDia(t *testing.T) {
+	valid := []string{"LUNES", "martes", "Miercoles", "JUEVES", "viernes", "sabado", "DOMINGO"}
+	for _, d := range valid {
+		if !isValidDia(d) {
+			t.Errorf("expected %s to be valid", d)
+		}
+	}
+	invalid := []string{"", "FUNDAY", "luness"}
+	for _, d := range invalid {
+		if isValidDia(d) {
+			t.Errorf("expected %s to be invalid", d)
+		}
+	}
+}
+
+func TestDiaToDB(t *testing.T) {
+	cases := map[string]string{
+		"LUNES": "Lunes",
+		"lunes": "Lunes",
+		"l":     "L",
+		"":      "",
+	}
+	for in, exp := range cases {
+		if got := diaToDB(in); got != exp {
+			t.Errorf("diaToDB(%s) = %s, want %s", in, got, exp)
+		}
+	}
+}
+
+func TestHorarioTrabajadorGetAllSuccess(t *testing.T) {
+	var capturedQuery string
+	var capturedArgs []driver.NamedValue
+	MockQuery = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
+		capturedQuery = query
+		capturedArgs = args
+		cols := []string{"pk_documento_trabajador", "dia", "hora_inicio", "hora_fin"}
+		vals := [][]driver.Value{{int64(1), "Lunes", time.Date(2024, 1, 1, 8, 0, 0, 0, time.UTC), time.Date(2024, 1, 1, 17, 0, 0, 0, time.UTC)}}
+		return &mockRows{columns: cols, values: vals}, nil
+	}
+	defer func() { MockQuery = nil }()
+
+	c, w := setupHTCtx(http.MethodGet, "/horario_trabajador?documento=1&dia=LUNES", "")
+	c.GetAll()
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "Horarios obtenidos correctamente") {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
+	if !strings.Contains(capturedQuery, "WHERE pk_documento_trabajador") || !strings.Contains(capturedQuery, "AND dia") {
+		t.Errorf("unexpected query: %s", capturedQuery)
+	}
+	if len(capturedArgs) != 2 || capturedArgs[0].Value.(int64) != 1 || capturedArgs[1].Value.(string) != "Lunes" {
+		t.Errorf("unexpected args: %#v", capturedArgs)
+	}
+}
+
+func TestHorarioTrabajadorGetAllDBError(t *testing.T) {
+	MockQuery = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
+		return nil, errors.New("db error")
+	}
+	defer func() { MockQuery = nil }()
+
+	c, w := setupHTCtx(http.MethodGet, "/horario_trabajador", "")
+	c.GetAll()
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "Error al obtener horarios") {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
+}
+
+func TestHorarioTrabajadorDeleteInvalidDia(t *testing.T) {
+	c, w := setupHTCtx(http.MethodDelete, "/horario_trabajador?documento=1&dia=foo", "")
+	c.Delete()
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "Parámetro 'dia' inválido") {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
+}
+
+func TestHorarioTrabajadorDeleteNotFound(t *testing.T) {
+	MockQuery = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
+		return nil, orm.ErrNoRows
+	}
+	defer func() { MockQuery = nil }()
+
+	c, w := setupHTCtx(http.MethodDelete, "/horario_trabajador?documento=1&dia=LUNES", "")
+	c.Delete()
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "Horario no encontrado") {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
+}
+
+func TestHorarioTrabajadorDeleteSuccess(t *testing.T) {
+	MockQuery = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
+		cols := []string{"pk_documento_trabajador", "dia"}
+		vals := [][]driver.Value{{int64(1), "Lunes"}}
+		return &mockRows{columns: cols, values: vals}, nil
+	}
+	MockExec = func(ctx stdctx.Context, query string, args []driver.NamedValue) (driver.Result, error) {
+		return mockResult{}, nil
+	}
+	defer func() { MockQuery = nil; MockExec = nil }()
+
+	c, w := setupHTCtx(http.MethodDelete, "/horario_trabajador?documento=1&dia=LUNES", "")
+	c.Delete()
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "Horario eliminado correctamente") {
 		t.Errorf("unexpected body: %s", w.Body.String())
 	}
 }


### PR DESCRIPTION
## Summary
- add day validation helpers tests
- cover GetAll and Delete scenarios for HorarioTrabajadorController

## Testing
- `go test ./controllers -run HorarioTrabajador -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68b7984b13488325bfbb89ac999bf7ab