### PR TITLE
Add Incidencia controller tests

### DIFF
--- a/controllers/incidencia_controller_test.go
+++ b/controllers/incidencia_controller_test.go
@@ -73,6 +73,25 @@ func TestIncidenciaGetByDocumentAndDateInvalidYear(t *testing.T) {
 	}
 }
 
+func TestIncidenciaGetByDocumentAndDateNoResults(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/incidencias/search?documento=1&mes=1&anio=2024", nil)
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	c := IncidenciaController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	c.GetByDocumentAndDate()
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "No se encontraron incidencias") {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
+}
+
 func TestIncidenciaPostInvalidJSON(t *testing.T) {
 	r := httptest.NewRequest(http.MethodPost, "/incidencias", strings.NewReader("notjson"))
 	w := httptest.NewRecorder()
@@ -156,6 +175,41 @@ func TestIncidenciaPostMissingDocumentoTrabajador(t *testing.T) {
 		t.Fatalf("expected status 400, got %d", w.Code)
 	}
 }
+func TestIncidenciaPostMissingResta(t *testing.T) {
+	body := `{"fechaIncidencia":"2024-01-01","monto":100,"motivo":"test","documentoTrabajador":1}`
+	r := httptest.NewRequest(http.MethodPost, "/incidencias", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	c := IncidenciaController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	ctx.Input.CopyBody(1 << 20)
+	c.Post()
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d", w.Code)
+	}
+}
+
+func TestIncidenciaPostMissingMotivo(t *testing.T) {
+	body := `{"fechaIncidencia":"2024-01-01","monto":100,"resta":false,"documentoTrabajador":1}`
+	r := httptest.NewRequest(http.MethodPost, "/incidencias", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	c := IncidenciaController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	ctx.Input.CopyBody(1 << 20)
+	c.Post()
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d", w.Code)
+	}
+}
 
 func TestIncidenciaPutInvalidID(t *testing.T) {
 	r := httptest.NewRequest(http.MethodPut, "/incidencias?id=abc", strings.NewReader("{}"))
@@ -206,6 +260,23 @@ func TestIncidenciaPutInvalidFecha(t *testing.T) {
 	}
 }
 
+func TestIncidenciaPutUpdateError(t *testing.T) {
+	body := `{"fechaIncidencia":"2024-01-01","monto":100,"resta":false,"motivo":"test","documentoTrabajador":1}`
+	r := httptest.NewRequest(http.MethodPut, "/incidencias?id=1", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	c := IncidenciaController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	ctx.Input.CopyBody(1 << 20)
+	c.Put()
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected status 500, got %d", w.Code)
+	}
+}
+
 func TestIncidenciaDeleteInvalidID(t *testing.T) {
 	r := httptest.NewRequest(http.MethodDelete, "/incidencias?id=abc", nil)
 	w := httptest.NewRecorder()
@@ -219,5 +290,21 @@ func TestIncidenciaDeleteInvalidID(t *testing.T) {
 
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("expected status 400, got %d", w.Code)
+	}
+}
+
+func TestIncidenciaDeleteError(t *testing.T) {
+	r := httptest.NewRequest(http.MethodDelete, "/incidencias?id=1", nil)
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	c := IncidenciaController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	c.Delete()
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected status 500, got %d", w.Code)
 	}
 }


### PR DESCRIPTION
## Summary
- expand Incidencia controller unit tests to cover missing fields and database errors

## Testing
- `go test ./controllers -run Incidencia`


------
https://chatgpt.com/codex/tasks/task_e_68b799f6ee6c832593630681ac585de3