### PR TITLE
test: cover invalid JSON case for Producto

### DIFF
--- a/models/producto_test.go
+++ b/models/producto_test.go
@@ -74,6 +74,13 @@ func TestProductoUnmarshalJSON_InvalidBase64(t *testing.T) {
 	}
 }
 
+func TestProductoUnmarshalJSON_InvalidJSON(t *testing.T) {
+        var p Producto
+        if err := p.UnmarshalJSON([]byte("{invalid")); err == nil {
+                t.Fatalf("expected error for invalid JSON")
+        }
+}
+
 func TestProductoMarshalJSON_SubcategoriaNil(t *testing.T) {
 	p := Producto{PK_ID_PRODUCTO: 10, NOMBRE: "Z", PRECIO: 1, ESTADO_PRODUCTO: EstadoProductoDisponible, CANTIDAD: 1}
 	data, err := json.Marshal(p)


### PR DESCRIPTION
## Summary
- test: add coverage for invalid JSON in Producto.UnmarshalJSON

## Testing
- `go test ./models -coverprofile=coverage.out`
- `go tool cover -func=coverage.out | grep Producto.go`
- `go test ./...` *(fails: dial tcp [::1]:5432: connect: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68bcadb9f79c8325b661aa53afaf9e56