### PR TITLE
test: ensure CategoriaController Put handles invalid JSON

### DIFF
--- a/controllers/categoria_put_invalid_json_test.go
+++ b/controllers/categoria_put_invalid_json_test.go
@@ -1,28 +1,38 @@
 package controllers
 
 import (
-	"net/http"
-	"net/http/httptest"
-	"strings"
-	"testing"
+        "net/http"
+        "net/http/httptest"
+        "strings"
+        "testing"
 
-	"github.com/beego/beego/v2/server/web/context"
+        "restaurante/models"
+
+        "github.com/beego/beego/v2/server/web/context"
 )
 
 func TestCategoriaController_Put_InvalidJSON(t *testing.T) {
-	r := httptest.NewRequest(http.MethodPut, "/categorias?id=1", strings.NewReader("{"))
-	w := httptest.NewRecorder()
-	ctx := context.NewContext()
-	ctx.Reset(w, r)
-	ctx.Input.RequestBody = []byte("{")
-	c := &CategoriaController{}
-	c.Ctx = ctx
-	c.Data = make(map[interface{}]interface{})
+        // Mock ormer to avoid hitting real database and ensure Read succeeds
+        m := newCatMockOrm()
+        // Insert a dummy category with ID=1 so that Read returns nil error
+        _, _ = m.Insert(&models.Categoria{NOMBRE: "test"})
+        orig := catOrmNew
+        catOrmNew = func() categoriaOrmer { return m }
+        defer func() { catOrmNew = orig }()
 
-	c.Put()
-	if w.Code != http.StatusBadRequest && w.Code != http.StatusOK {
-		t.Fatalf("expected 400 or 200, got %d", w.Code)
-	}
+        r := httptest.NewRequest(http.MethodPut, "/categorias?id=1", strings.NewReader("{"))
+        w := httptest.NewRecorder()
+        ctx := context.NewContext()
+        ctx.Reset(w, r)
+        ctx.Input.RequestBody = []byte("{")
+        c := &CategoriaController{}
+        c.Ctx = ctx
+        c.Data = make(map[interface{}]interface{})
+
+        c.Put()
+        if w.Code != http.StatusBadRequest {
+                t.Fatalf("expected 400, got %d", w.Code)
+        }
 }
 
 


### PR DESCRIPTION
## Summary
- mock CategoriaController's Ormer in invalid JSON test to hit unmarshal error path
- ensure categoria Put controller handles malformed payloads

## Testing
- `go test ./controllers -run Cat -coverprofile=coverage.out`
- `go tool cover -func=coverage.out | grep CategoriaController.go`


------
https://chatgpt.com/codex/tasks/task_e_68be268c6c948325ade9a7f240a2cd2d