### PR TITLE
test: cover all branches in LoginController

### DIFF
--- a/controllers/login_controller_test.go
+++ b/controllers/login_controller_test.go
@@ -12,6 +12,7 @@ import (
 	"restaurante/models"
 
 	"github.com/beego/beego/v2/client/orm"
+	"github.com/beego/beego/v2/server/web"
 	"github.com/beego/beego/v2/server/web/context"
 	"github.com/dgrijalva/jwt-go"
 )
@@ -21,12 +22,12 @@ import (
 // promoted from the embedded orm.Ormer and will panic if used since the field
 // is nil, but our tests only rely on Read.
 type mockLoginOrmer struct {
-        orm.Ormer
-        ReadFunc func(interface{}, ...string) error
+	orm.Ormer
+	ReadFunc func(interface{}, ...string) error
 }
 
 func (m mockLoginOrmer) Read(v interface{}, cols ...string) error {
-        return m.ReadFunc(v, cols...)
+	return m.ReadFunc(v, cols...)
 }
 
 func TestGenerateJWT(t *testing.T) {
@@ -88,8 +89,8 @@ func TestLoginTrabajadorSuccess(t *testing.T) {
 
 	origNewOrm := newOrm
 	defer func() { newOrm = origNewOrm }()
-        newOrm = func() orm.Ormer {
-                return &mockLoginOrmer{ReadFunc: func(v interface{}, cols ...string) error {
+	newOrm = func() orm.Ormer {
+		return &mockLoginOrmer{ReadFunc: func(v interface{}, cols ...string) error {
 			if trab, ok := v.(*models.Trabajador); ok {
 				trab.NOMBRE = "Foo"
 				trab.APELLIDO = "Bar"
@@ -143,8 +144,8 @@ func TestLoginClienteSuccess(t *testing.T) {
 
 	origNewOrm := newOrm
 	defer func() { newOrm = origNewOrm }()
-        newOrm = func() orm.Ormer {
-                return &mockLoginOrmer{ReadFunc: func(v interface{}, cols ...string) error {
+	newOrm = func() orm.Ormer {
+		return &mockLoginOrmer{ReadFunc: func(v interface{}, cols ...string) error {
 			switch val := v.(type) {
 			case *models.Trabajador:
 				return errors.New("not found")
@@ -196,8 +197,8 @@ func TestLoginClienteSuccess(t *testing.T) {
 func TestLoginTrabajadorInvalidPassword(t *testing.T) {
 	origNewOrm := newOrm
 	defer func() { newOrm = origNewOrm }()
-        newOrm = func() orm.Ormer {
-                return &mockLoginOrmer{ReadFunc: func(v interface{}, cols ...string) error {
+	newOrm = func() orm.Ormer {
+		return &mockLoginOrmer{ReadFunc: func(v interface{}, cols ...string) error {
 			if trab, ok := v.(*models.Trabajador); ok {
 				trab.PASSWORD = "hashed"
 				return nil
@@ -230,8 +231,8 @@ func TestLoginTrabajadorInvalidPassword(t *testing.T) {
 func TestLoginClienteInvalidPassword(t *testing.T) {
 	origNewOrm := newOrm
 	defer func() { newOrm = origNewOrm }()
-        newOrm = func() orm.Ormer {
-                return &mockLoginOrmer{ReadFunc: func(v interface{}, cols ...string) error {
+	newOrm = func() orm.Ormer {
+		return &mockLoginOrmer{ReadFunc: func(v interface{}, cols ...string) error {
 			switch val := v.(type) {
 			case *models.Trabajador:
 				return errors.New("not found")
@@ -267,8 +268,8 @@ func TestLoginClienteInvalidPassword(t *testing.T) {
 func TestLoginUserNotFound(t *testing.T) {
 	origNewOrm := newOrm
 	defer func() { newOrm = origNewOrm }()
-        newOrm = func() orm.Ormer {
-                return &mockLoginOrmer{ReadFunc: func(v interface{}, cols ...string) error {
+	newOrm = func() orm.Ormer {
+		return &mockLoginOrmer{ReadFunc: func(v interface{}, cols ...string) error {
 			return errors.New("not found")
 		}}
 	}
@@ -382,6 +383,41 @@ func TestValidateTokenOptions(t *testing.T) {
 
 func TestValidateTokenPublicCliente(t *testing.T) {
 	r := httptest.NewRequest(http.MethodPost, "/restaurante/v1/clientes", nil)
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+
+	ValidateToken(ctx)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+}
+
+func TestValidateTokenSwaggerRefererDev(t *testing.T) {
+	orig := web.BConfig.RunMode
+	web.BConfig.RunMode = "dev"
+	t.Cleanup(func() { web.BConfig.RunMode = orig })
+
+	r := httptest.NewRequest(http.MethodGet, "/any", nil)
+	r.Header.Set("Referer", "http://localhost/swagger/")
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+
+	ValidateToken(ctx)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+}
+
+func TestValidateTokenSwaggerURLDev(t *testing.T) {
+	orig := web.BConfig.RunMode
+	web.BConfig.RunMode = "dev"
+	t.Cleanup(func() { web.BConfig.RunMode = orig })
+
+	r := httptest.NewRequest(http.MethodGet, "/swagger/index.html", nil)
 	w := httptest.NewRecorder()
 	ctx := context.NewContext()
 	ctx.Reset(w, r)

--- a/controllers/login_generatejwt_error_test.go
+++ b/controllers/login_generatejwt_error_test.go
@@ -1,35 +1,39 @@
 package controllers
 
 import (
+	"crypto"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
 	beegoCtx "github.com/beego/beego/v2/server/web/context"
+	"github.com/dgrijalva/jwt-go"
 )
 
 func TestGenerateJWT_ErrorWhenSigning(t *testing.T) {
-    // Forzar error estable cambiando la clave a nil temporalmente
-    orig := jwtSecret
-    jwtSecret = nil
-    t.Cleanup(func(){ jwtSecret = orig })
+	origSecret := jwtSecret
+	jwtSecret = []byte("testsecret")
+	t.Cleanup(func() { jwtSecret = origSecret })
 
-    r := httptest.NewRequest(http.MethodPost, "/login", nil)
-    w := httptest.NewRecorder()
-    ctx := beegoCtx.NewContext(); ctx.Reset(w, r)
-    c := &LoginController{}
-    c.Ctx = ctx
-    c.Data = make(map[interface{}]interface{})
+	origHash := jwt.SigningMethodHS256.Hash
+	jwt.SigningMethodHS256.Hash = crypto.Hash(0)
+	t.Cleanup(func() { jwt.SigningMethodHS256.Hash = origHash })
 
-    generateJWT(c, 1, "Admin", "Tester")
+	r := httptest.NewRequest(http.MethodPost, "/login", nil)
+	w := httptest.NewRecorder()
+	ctx := beegoCtx.NewContext()
+	ctx.Reset(w, r)
+	c := &LoginController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
 
-    if w.Code != http.StatusInternalServerError && w.Code != http.StatusOK {
-        t.Fatalf("expected 500 or 200 depending on env, got %d", w.Code)
-    }
-    if w.Code == http.StatusInternalServerError && !strings.Contains(w.Body.String(), "Error al generar el token") {
-        t.Fatalf("expected signing error message, got: %s", w.Body.String())
-    }
+	generateJWT(c, 1, "Admin", "Tester")
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected status 500, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "Error al generar el token") {
+		t.Fatalf("expected signing error message, got: %s", w.Body.String())
+	}
 }
-
-


### PR DESCRIPTION
## Summary
- force signing failure to test JWT error handling
- add dev-mode Swagger bypass tests for ValidateToken

## Testing
- `go test ./controllers -coverprofile=coverage.out`
- `go tool cover -func=coverage.out | grep LoginController.go`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68be26c0a0b883259d3e88bc3a4d0f25