### PR TITLE
test: cover IncidenciaController fully

### DIFF
--- a/controllers/incidencia_controller_test.go
+++ b/controllers/incidencia_controller_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/beego/beego/v2/client/orm"
 	"github.com/beego/beego/v2/server/web/context"
 )
 
@@ -117,6 +118,7 @@ func TestIncidenciaPostMissingFecha(t *testing.T) {
 	w := httptest.NewRecorder()
 	ctx := context.NewContext()
 	ctx.Reset(w, r)
+	ctx.Input.RequestBody = []byte(body)
 	c := IncidenciaController{}
 	c.Ctx = ctx
 	c.Data = make(map[interface{}]interface{})
@@ -134,6 +136,7 @@ func TestIncidenciaPostInvalidFecha(t *testing.T) {
 	w := httptest.NewRecorder()
 	ctx := context.NewContext()
 	ctx.Reset(w, r)
+	ctx.Input.RequestBody = []byte(body)
 	c := IncidenciaController{}
 	c.Ctx = ctx
 	c.Data = make(map[interface{}]interface{})
@@ -151,6 +154,7 @@ func TestIncidenciaPostMissingMonto(t *testing.T) {
 	w := httptest.NewRecorder()
 	ctx := context.NewContext()
 	ctx.Reset(w, r)
+	ctx.Input.RequestBody = []byte(body)
 	c := IncidenciaController{}
 	c.Ctx = ctx
 	c.Data = make(map[interface{}]interface{})
@@ -168,6 +172,7 @@ func TestIncidenciaPostMissingDocumentoTrabajador(t *testing.T) {
 	w := httptest.NewRecorder()
 	ctx := context.NewContext()
 	ctx.Reset(w, r)
+	ctx.Input.RequestBody = []byte(body)
 	c := IncidenciaController{}
 	c.Ctx = ctx
 	c.Data = make(map[interface{}]interface{})
@@ -215,18 +220,26 @@ func TestIncidenciaPostMissingMotivo(t *testing.T) {
 }
 
 func TestIncidenciaPostInsertError(t *testing.T) {
-    body := `{"fechaIncidencia":"2024-01-01","monto":100,"resta":false,"motivo":"x","documentoTrabajador":1}`
-    r := httptest.NewRequest(http.MethodPost, "/incidencias", strings.NewReader(body))
-    w := httptest.NewRecorder()
-    ctx := context.NewContext(); ctx.Reset(w, r); ctx.Input.RequestBody = []byte(body)
-    c := IncidenciaController{}; c.Ctx = ctx; c.Data = make(map[interface{}]interface{})
+	body := `{"fechaIncidencia":"2024-01-01","monto":100,"resta":false,"motivo":"x","documentoTrabajador":1}`
+	r := httptest.NewRequest(http.MethodPost, "/incidencias", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	ctx.Input.RequestBody = []byte(body)
+	c := IncidenciaController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
 
-    // Forzar error de inserción
-    MockExec = func(_ stdctx.Context, _ string, _ []driver.NamedValue) (driver.Result, error) { return nil, errors.New("db") }
-    t.Cleanup(func(){ MockExec = nil })
+	// Forzar error de inserción
+	MockExec = func(_ stdctx.Context, _ string, _ []driver.NamedValue) (driver.Result, error) {
+		return nil, errors.New("db")
+	}
+	t.Cleanup(func() { MockExec = nil })
 
-    c.Post()
-    if w.Code != http.StatusInternalServerError { t.Fatalf("expected 500, got %d", w.Code) }
+	c.Post()
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", w.Code)
+	}
 }
 
 func TestIncidenciaPutInvalidID(t *testing.T) {
@@ -267,6 +280,7 @@ func TestIncidenciaPutInvalidFecha(t *testing.T) {
 	w := httptest.NewRecorder()
 	ctx := context.NewContext()
 	ctx.Reset(w, r)
+	ctx.Input.RequestBody = []byte(body)
 	c := IncidenciaController{}
 	c.Ctx = ctx
 	c.Data = make(map[interface{}]interface{})
@@ -296,17 +310,35 @@ func TestIncidenciaPutUpdateError(t *testing.T) {
 }
 
 func TestIncidenciaPutNotFound(t *testing.T) {
-    r := httptest.NewRequest(http.MethodPut, "/incidencias?id=1", strings.NewReader(`{}`))
-    w := httptest.NewRecorder()
-    ctx := context.NewContext(); ctx.Reset(w, r)
-    c := IncidenciaController{}; c.Ctx = ctx; c.Data = make(map[interface{}]interface{})
+	body := `{}`
+	r := httptest.NewRequest(http.MethodPut, "/incidencias?id=1", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	ctx.Input.RequestBody = []byte(body)
+	c := IncidenciaController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
 
-    // No configurar MockQuery: devolverá 0 filas por defecto en este entorno, simulando no encontrado
-    c.Put()
-    if w.Code != http.StatusOK && w.Code != http.StatusBadRequest {
-        t.Fatalf("expected 200 or 400, got %d", w.Code)
-    }
+	// Forzar que Read devuelva orm.ErrNoRows
+	orig := incidenciaOrmNew
+	incidenciaOrmNew = func() incidenciaOrmer { return fakeIncidOrmReadNotFound{} }
+	t.Cleanup(func() { incidenciaOrmNew = orig })
+
+	c.Put()
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
 }
+
+// fakeIncidOrmReadNotFound devuelve orm.ErrNoRows en Read para simular no encontrado
+type fakeIncidOrmReadNotFound struct{}
+
+func (fakeIncidOrmReadNotFound) QueryTable(interface{}) orm.QuerySeter        { return nil }
+func (fakeIncidOrmReadNotFound) Insert(interface{}) (int64, error)            { return 0, nil }
+func (fakeIncidOrmReadNotFound) Read(interface{}, ...string) error            { return orm.ErrNoRows }
+func (fakeIncidOrmReadNotFound) Update(interface{}, ...string) (int64, error) { return 0, nil }
+func (fakeIncidOrmReadNotFound) Delete(interface{}, ...string) (int64, error) { return 0, nil }
 
 func TestIncidenciaDeleteInvalidID(t *testing.T) {
 	r := httptest.NewRequest(http.MethodDelete, "/incidencias?id=abc", nil)

--- a/controllers/incidencia_getby_hook_error_results_test.go
+++ b/controllers/incidencia_getby_hook_error_results_test.go
@@ -1,0 +1,51 @@
+package controllers
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"restaurante/models"
+
+	"github.com/beego/beego/v2/client/orm"
+	"github.com/beego/beego/v2/server/web/context"
+)
+
+type fakeIncidQSErrorRes struct{ orm.QuerySeter }
+
+func (fakeIncidQSErrorRes) Filter(string, ...interface{}) orm.QuerySeter {
+	return fakeIncidQSErrorRes{}
+}
+func (fakeIncidQSErrorRes) All(res interface{}, _ ...string) (int64, error) {
+	dst := res.(*[]models.Incidencia)
+	*dst = append(*dst, models.Incidencia{MOTIVO: "x"})
+	return 1, errors.New("db")
+}
+
+type fakeIncidOrmErrRes struct{}
+
+func (fakeIncidOrmErrRes) QueryTable(interface{}) orm.QuerySeter        { return fakeIncidQSErrorRes{} }
+func (fakeIncidOrmErrRes) Insert(interface{}) (int64, error)            { return 0, nil }
+func (fakeIncidOrmErrRes) Read(interface{}, ...string) error            { return nil }
+func (fakeIncidOrmErrRes) Update(interface{}, ...string) (int64, error) { return 0, nil }
+func (fakeIncidOrmErrRes) Delete(interface{}, ...string) (int64, error) { return 0, nil }
+
+func TestIncidenciaGetByDocumentAndDate_HookErrWithResults(t *testing.T) {
+	orig := incidenciaOrmNew
+	incidenciaOrmNew = func() incidenciaOrmer { return fakeIncidOrmErrRes{} }
+	t.Cleanup(func() { incidenciaOrmNew = orig })
+
+	r := httptest.NewRequest(http.MethodGet, "/incidencias/search?documento=1&mes=1&anio=2024", nil)
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	c := IncidenciaController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	c.GetByDocumentAndDate()
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", w.Code)
+	}
+}

--- a/controllers/incidencia_post_nil_doc_response_test.go
+++ b/controllers/incidencia_post_nil_doc_response_test.go
@@ -1,0 +1,56 @@
+package controllers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"restaurante/models"
+
+	"github.com/beego/beego/v2/client/orm"
+	"github.com/beego/beego/v2/server/web/context"
+)
+
+type fakeIncidOrmNilDoc struct{}
+
+func (fakeIncidOrmNilDoc) QueryTable(interface{}) orm.QuerySeter { return nil }
+func (fakeIncidOrmNilDoc) Insert(v interface{}) (int64, error) {
+	if inc, ok := v.(*models.Incidencia); ok {
+		inc.PK_DOCUMENTO_TRABAJADOR = nil
+	}
+	return 1, nil
+}
+func (fakeIncidOrmNilDoc) Read(interface{}, ...string) error            { return nil }
+func (fakeIncidOrmNilDoc) Update(interface{}, ...string) (int64, error) { return 1, nil }
+func (fakeIncidOrmNilDoc) Delete(interface{}, ...string) (int64, error) { return 1, nil }
+
+func TestIncidenciaPost_ResponseDocumentoZeroWhenNil(t *testing.T) {
+	orig := incidenciaOrmNew
+	incidenciaOrmNew = func() incidenciaOrmer { return fakeIncidOrmNilDoc{} }
+	t.Cleanup(func() { incidenciaOrmNew = orig })
+
+	body := `{"fechaIncidencia":"2024-01-01","monto":10,"resta":false,"motivo":"m","documentoTrabajador":5}`
+	r := httptest.NewRequest(http.MethodPost, "/incidencias", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	ctx.Input.RequestBody = []byte(body)
+	c := IncidenciaController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	c.Post()
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d", w.Code)
+	}
+	var resp models.ApiResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	m := resp.Data.(map[string]interface{})
+	if m["documentoTrabajador"].(float64) != 0 {
+		t.Fatalf("expected 0, got %v", m["documentoTrabajador"])
+	}
+}


### PR DESCRIPTION
## Summary
- ensure POST validation branches run by supplying request bodies
- add tests for ORM error cases and nil documents in Incidencia controller

## Testing
- `go test ./controllers -run Incidencia -coverprofile=/tmp/coverage.out`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68be26b944308325944c5965a35cedaa