### PR TITLE
test: cover restaurante controller

### DIFF
--- a/controllers/restaurante_adapters_cover_test.go
+++ b/controllers/restaurante_adapters_cover_test.go
@@ -2,10 +2,31 @@ package controllers
 
 import "testing"
 
-func TestRestOrmAdapter_Update_Coverage(t *testing.T) {
-    a := restOrmAdapter{}
-    defer func() { _ = recover() }()
-    _, _ = a.Update(nil)
+func TestRestauranteOrmAdapterCoverage(t *testing.T) {
+	a := restOrmAdapter{}
+	func() {
+		defer func() { _ = recover() }()
+		a.QueryTable(nil)
+	}()
+	func() {
+		defer func() { _ = recover() }()
+		_ = a.Read(nil)
+	}()
+	func() {
+		defer func() { _ = recover() }()
+		_, _ = a.Insert(nil)
+	}()
+	func() {
+		defer func() { _ = recover() }()
+		_, _ = a.Update(nil)
+	}()
+	func() {
+		defer func() { _ = recover() }()
+		_, _ = a.Delete(nil)
+	}()
+	func() {
+		defer func() { _ = recover() }()
+		qs := restQSAdapter{}
+		_, _ = qs.All(nil)
+	}()
 }
-
-

--- a/controllers/restaurante_controller_test.go
+++ b/controllers/restaurante_controller_test.go
@@ -1,15 +1,21 @@
 package controllers
 
 import (
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
+	"github.com/beego/beego/v2/client/orm"
 	"github.com/beego/beego/v2/server/web/context"
 )
 
 func TestRestauranteGetAllWithoutDB(t *testing.T) {
+	orig := restOrmNew
+	restOrmNew = func() restOrmer { return restFakeOrm{qsErr: errors.New("db")} }
+	defer func() { restOrmNew = orig }()
+
 	r := httptest.NewRequest(http.MethodGet, "/restaurante/v1/restaurantes", nil)
 	w := httptest.NewRecorder()
 	ctx := context.NewContext()
@@ -30,41 +36,67 @@ func TestRestauranteGetAllWithoutDB(t *testing.T) {
 
 // Mocks para RestauranteController
 type restFakeQS struct{ err error }
+
 func (f restFakeQS) All(res interface{}, _ ...string) (int64, error) { return 0, f.err }
 
-type restFakeOrm struct{ qsErr error; readErr error; updated int; deleted int }
+type restFakeOrm struct {
+	qsErr     error
+	readErr   error
+	insertErr error
+	updateErr error
+	deleteErr error
+	updated   int
+	deleted   int
+}
+
 func (f restFakeOrm) QueryTable(i interface{}) restQuerySeter { return restFakeQS{err: f.qsErr} }
-func (f restFakeOrm) Read(v interface{}, _ ...string) error { return f.readErr }
-func (f restFakeOrm) Insert(v interface{}) (int64, error) { return 1, nil }
-func (f restFakeOrm) Update(v interface{}, _ ...string) (int64, error) { f.updated++; return 1, nil }
-func (f restFakeOrm) Delete(v interface{}, _ ...string) (int64, error) { f.deleted++; return 1, nil }
+func (f restFakeOrm) Read(v interface{}, _ ...string) error   { return f.readErr }
+func (f restFakeOrm) Insert(v interface{}) (int64, error)     { return 1, f.insertErr }
+func (f restFakeOrm) Update(v interface{}, _ ...string) (int64, error) {
+	f.updated++
+	return 1, f.updateErr
+}
+func (f restFakeOrm) Delete(v interface{}, _ ...string) (int64, error) {
+	f.deleted++
+	return 1, f.deleteErr
+}
 
 func TestRestauranteGetAllSuccess(t *testing.T) {
-    orig := restOrmNew
-    restOrmNew = func() restOrmer { return restFakeOrm{qsErr: nil} }
-    defer func() { restOrmNew = orig }()
+	orig := restOrmNew
+	restOrmNew = func() restOrmer { return restFakeOrm{qsErr: nil} }
+	defer func() { restOrmNew = orig }()
 
-    r := httptest.NewRequest(http.MethodGet, "/restaurante/v1/restaurantes", nil)
-    w := httptest.NewRecorder()
-    ctx := context.NewContext(); ctx.Reset(w, r)
-    c := RestauranteController{}; c.Ctx = ctx; c.Data = make(map[interface{}]interface{})
-    c.GetAll()
-    if w.Code != http.StatusOK { t.Fatalf("expected 200, got %d", w.Code) }
+	r := httptest.NewRequest(http.MethodGet, "/restaurante/v1/restaurantes", nil)
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	c := RestauranteController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+	c.GetAll()
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
 }
 
 func TestRestaurantePutSuccess(t *testing.T) {
-    orig := restOrmNew
-    restOrmNew = func() restOrmer { return restFakeOrm{readErr: nil} }
-    defer func() { restOrmNew = orig }()
+	orig := restOrmNew
+	restOrmNew = func() restOrmer { return restFakeOrm{readErr: nil} }
+	defer func() { restOrmNew = orig }()
 
-    body := `{"nombre":"X"}`
-    r := httptest.NewRequest(http.MethodPut, "/restaurante/v1/restaurantes?id=1", strings.NewReader(body))
-    w := httptest.NewRecorder()
-    ctx := context.NewContext(); ctx.Reset(w, r)
-    ctx.Input.RequestBody = []byte(body)
-    c := RestauranteController{}; c.Ctx = ctx; c.Data = make(map[interface{}]interface{})
-    c.Put()
-    if w.Code != http.StatusOK { t.Fatalf("expected 200, got %d", w.Code) }
+	body := `{"nombre":"X"}`
+	r := httptest.NewRequest(http.MethodPut, "/restaurante/v1/restaurantes?id=1", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	ctx.Input.RequestBody = []byte(body)
+	c := RestauranteController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+	c.Put()
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
 }
 
 func TestRestauranteGetByIdInvalidID(t *testing.T) {
@@ -87,6 +119,10 @@ func TestRestauranteGetByIdInvalidID(t *testing.T) {
 }
 
 func TestRestauranteGetByIdDBError(t *testing.T) {
+	orig := restOrmNew
+	restOrmNew = func() restOrmer { return restFakeOrm{readErr: errors.New("db")} }
+	defer func() { restOrmNew = orig }()
+
 	r := httptest.NewRequest(http.MethodGet, "/restaurante/v1/restaurantes/search?id=1", nil)
 	w := httptest.NewRecorder()
 	ctx := context.NewContext()
@@ -105,35 +141,42 @@ func TestRestauranteGetByIdDBError(t *testing.T) {
 	}
 }
 
-type okOrmForRead struct{ restFakeOrm }
-func (ok okOrmForRead) Read(v interface{}, _ ...string) error { return nil }
-
-type okOrmForInsert struct{ restFakeOrm }
-func (ok okOrmForInsert) Insert(v interface{}) (int64, error) { return 1, nil }
-
 func TestRestauranteGetByIdSuccess(t *testing.T) {
-    orig := restOrmNew
-    restOrmNew = func() restOrmer { return okOrmForRead{} }
-    defer func() { restOrmNew = orig }()
+	orig := restOrmNew
+	restOrmNew = func() restOrmer { return restFakeOrm{} }
+	defer func() { restOrmNew = orig }()
 
-    r := httptest.NewRequest(http.MethodGet, "/restaurante/v1/restaurantes/search?id=1", nil)
-    w := httptest.NewRecorder(); ctx := context.NewContext(); ctx.Reset(w, r)
-    c := RestauranteController{}; c.Ctx = ctx; c.Data = make(map[interface{}]interface{})
-    c.GetById()
-    if w.Code != http.StatusOK { t.Fatalf("expected 200, got %d", w.Code) }
+	r := httptest.NewRequest(http.MethodGet, "/restaurante/v1/restaurantes/search?id=1", nil)
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	c := RestauranteController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+	c.GetById()
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
 }
 
 func TestRestaurantePostSuccess(t *testing.T) {
-    orig := restOrmNew
-    restOrmNew = func() restOrmer { return okOrmForInsert{} }
-    defer func() { restOrmNew = orig }()
+	orig := restOrmNew
+	restOrmNew = func() restOrmer { return restFakeOrm{} }
+	defer func() { restOrmNew = orig }()
 
-    body := `{"nombre":"X"}`
-    r := httptest.NewRequest(http.MethodPost, "/restaurante/v1/restaurantes", strings.NewReader(body))
-    w := httptest.NewRecorder(); ctx := context.NewContext(); ctx.Reset(w, r); ctx.Input.RequestBody = []byte(body)
-    c := RestauranteController{}; c.Ctx = ctx; c.Data = make(map[interface{}]interface{})
-    c.Post()
-    if w.Code != http.StatusCreated { t.Fatalf("expected 201, got %d", w.Code) }
+	body := `{"nombre":"X"}`
+	r := httptest.NewRequest(http.MethodPost, "/restaurante/v1/restaurantes", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	ctx.Input.RequestBody = []byte(body)
+	c := RestauranteController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+	c.Post()
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d", w.Code)
+	}
 }
 
 func TestRestaurantePostInvalidJSON(t *testing.T) {
@@ -157,6 +200,10 @@ func TestRestaurantePostInvalidJSON(t *testing.T) {
 }
 
 func TestRestaurantePostWithoutDB(t *testing.T) {
+	orig := restOrmNew
+	restOrmNew = func() restOrmer { return restFakeOrm{insertErr: errors.New("db")} }
+	defer func() { restOrmNew = orig }()
+
 	body := `{"restauranteId":1}`
 	r := httptest.NewRequest(http.MethodPost, "/restaurante/v1/restaurantes", strings.NewReader(body))
 	w := httptest.NewRecorder()
@@ -197,6 +244,10 @@ func TestRestaurantePutInvalidID(t *testing.T) {
 }
 
 func TestRestaurantePutNotFoundWithoutDB(t *testing.T) {
+	orig := restOrmNew
+	restOrmNew = func() restOrmer { return restFakeOrm{readErr: errors.New("db")} }
+	defer func() { restOrmNew = orig }()
+
 	r := httptest.NewRequest(http.MethodPut, "/restaurante/v1/restaurantes?id=1", strings.NewReader("{}"))
 	w := httptest.NewRecorder()
 	ctx := context.NewContext()
@@ -235,6 +286,10 @@ func TestRestauranteDeleteInvalidID(t *testing.T) {
 }
 
 func TestRestauranteDeleteNotFoundWithoutDB(t *testing.T) {
+	orig := restOrmNew
+	restOrmNew = func() restOrmer { return restFakeOrm{deleteErr: errors.New("db")} }
+	defer func() { restOrmNew = orig }()
+
 	r := httptest.NewRequest(http.MethodDelete, "/restaurante/v1/restaurantes?id=1", nil)
 	w := httptest.NewRecorder()
 	ctx := context.NewContext()
@@ -249,6 +304,102 @@ func TestRestauranteDeleteNotFoundWithoutDB(t *testing.T) {
 		t.Fatalf("expected status 200, got %d", w.Code)
 	}
 	if !strings.Contains(w.Body.String(), "Restaurante no encontrado") {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
+}
+
+func TestRestauranteGetByIdNotFound(t *testing.T) {
+	orig := restOrmNew
+	restOrmNew = func() restOrmer { return restFakeOrm{readErr: orm.ErrNoRows} }
+	defer func() { restOrmNew = orig }()
+
+	r := httptest.NewRequest(http.MethodGet, "/restaurante/v1/restaurantes/search?id=1", nil)
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	c := RestauranteController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	c.GetById()
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "Restaurante no encontrado") {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
+}
+
+func TestRestaurantePutInvalidJSON(t *testing.T) {
+	orig := restOrmNew
+	restOrmNew = func() restOrmer { return restFakeOrm{readErr: nil} }
+	defer func() { restOrmNew = orig }()
+
+	body := "badjson"
+	r := httptest.NewRequest(http.MethodPut, "/restaurante/v1/restaurantes?id=1", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	ctx.Input.RequestBody = []byte(body)
+	c := RestauranteController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	c.Put()
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "Error en la solicitud") {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
+}
+
+func TestRestaurantePutUpdateError(t *testing.T) {
+	orig := restOrmNew
+	restOrmNew = func() restOrmer { return restFakeOrm{readErr: nil, updateErr: errors.New("db")} }
+	defer func() { restOrmNew = orig }()
+
+	body := `{"nombre":"X"}`
+	r := httptest.NewRequest(http.MethodPut, "/restaurante/v1/restaurantes?id=1", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	ctx.Input.RequestBody = []byte(body)
+	c := RestauranteController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	c.Put()
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected status 500, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "Error al actualizar el restaurante") {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
+}
+
+func TestRestauranteDeleteSuccess(t *testing.T) {
+	orig := restOrmNew
+	restOrmNew = func() restOrmer { return restFakeOrm{} }
+	defer func() { restOrmNew = orig }()
+
+	r := httptest.NewRequest(http.MethodDelete, "/restaurante/v1/restaurantes?id=1", nil)
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	c := RestauranteController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	c.Delete()
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "Restaurante eliminado") {
 		t.Errorf("unexpected body: %s", w.Body.String())
 	}
 }


### PR DESCRIPTION
## Summary
- expand REST fake ORM to simulate failures
- add comprehensive Restaurante controller tests and adapter coverage
- reach 100% coverage for RestauranteController

## Testing
- `go test ./controllers -run Restaurante -coverprofile=coverage.out`
- `go tool cover -func=coverage.out | grep controllers/RestauranteController.go`


------
https://chatgpt.com/codex/tasks/task_e_68be2b1433988325aa8a96e988702542