### PR TITLE
test: improve producto controller coverage

### DIFF
--- a/controllers/producto_controller_test.go
+++ b/controllers/producto_controller_test.go
@@ -44,6 +44,7 @@ func TestProductoGetAllWithoutDB(t *testing.T) {
 	w := httptest.NewRecorder()
 	ctx := context.NewContext()
 	ctx.Reset(w, r)
+	ctx.Request.ParseMultipartForm(32 << 20)
 	c := ProductoController{}
 	c.Ctx = ctx
 	c.Data = make(map[interface{}]interface{})
@@ -52,7 +53,7 @@ func TestProductoGetAllWithoutDB(t *testing.T) {
 	queryProductosAll = func(o orm.Ormer, onlyActive bool, productos *[]models.Producto) (int64, error) {
 		return 0, errors.New("db error")
 	}
-	t.Cleanup(func(){ queryProductosAll = saved })
+	t.Cleanup(func() { queryProductosAll = saved })
 
 	c.GetAll()
 
@@ -69,6 +70,7 @@ func TestProductoGetAllSuccessFiltersImage(t *testing.T) {
 	w := httptest.NewRecorder()
 	ctx := context.NewContext()
 	ctx.Reset(w, r)
+	ctx.Request.ParseMultipartForm(32 << 20)
 	c := ProductoController{}
 	c.Ctx = ctx
 	c.Data = make(map[interface{}]interface{})
@@ -78,7 +80,7 @@ func TestProductoGetAllSuccessFiltersImage(t *testing.T) {
 		*productos = []models.Producto{{IMAGEN: "img", ESTADO_PRODUCTO: models.EstadoProductoDisponible}}
 		return 1, nil
 	}
-	t.Cleanup(func(){ queryProductosAll = saved })
+	t.Cleanup(func() { queryProductosAll = saved })
 
 	c.GetAll()
 	if w.Code != http.StatusOK {
@@ -94,6 +96,7 @@ func TestProductoGetByIdInvalidID(t *testing.T) {
 	w := httptest.NewRecorder()
 	ctx := context.NewContext()
 	ctx.Reset(w, r)
+	ctx.Request.ParseMultipartForm(32 << 20)
 	c := ProductoController{}
 	c.Ctx = ctx
 	c.Data = make(map[interface{}]interface{})
@@ -110,13 +113,14 @@ func TestProductoGetByIdNotFound(t *testing.T) {
 	w := httptest.NewRecorder()
 	ctx := context.NewContext()
 	ctx.Reset(w, r)
+	ctx.Request.ParseMultipartForm(32 << 20)
 	c := ProductoController{}
 	c.Ctx = ctx
 	c.Data = make(map[interface{}]interface{})
 
 	savedRead := readProductoFn
 	readProductoFn = func(o orm.Ormer, p *models.Producto) error { return orm.ErrNoRows }
-	t.Cleanup(func(){ readProductoFn = savedRead })
+	t.Cleanup(func() { readProductoFn = savedRead })
 
 	c.GetById()
 
@@ -129,20 +133,25 @@ func TestProductoGetByIdNotFound(t *testing.T) {
 }
 
 func TestProductoGetByIdOtherError(t *testing.T) {
-    r := httptest.NewRequest(http.MethodGet, "/productos/search?id=2", nil)
-    w := httptest.NewRecorder()
-    ctx := context.NewContext(); ctx.Reset(w, r)
-    c := ProductoController{}; c.Ctx = ctx; c.Data = make(map[interface{}]interface{})
+	r := httptest.NewRequest(http.MethodGet, "/productos/search?id=2", nil)
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	c := ProductoController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
 
-    savedRead := readProductoFn
-    readProductoFn = func(o orm.Ormer, p *models.Producto) error { return errors.New("boom") }
-    t.Cleanup(func(){ readProductoFn = savedRead })
+	savedRead := readProductoFn
+	readProductoFn = func(o orm.Ormer, p *models.Producto) error { return errors.New("boom") }
+	t.Cleanup(func() { readProductoFn = savedRead })
 
-    c.GetById()
-    if w.Code != http.StatusOK { t.Fatalf("expected status 200, got %d", w.Code) }
-    if !strings.Contains(strings.ToLower(w.Body.String()), "error al buscar el producto") {
-        t.Errorf("unexpected body: %s", w.Body.String())
-    }
+	c.GetById()
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+	if !strings.Contains(strings.ToLower(w.Body.String()), "error al buscar el producto") {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
 }
 
 func TestProductoPostMissingNombre(t *testing.T) {
@@ -168,118 +177,125 @@ func TestProductoPostMissingNombre(t *testing.T) {
 }
 
 func TestProductoPostSuccess(t *testing.T) {
-    body := bytes.NewBufferString(`{"nombre":"A","estadoProducto":"DISPONIBLE","precio":10}`)
-    r := httptest.NewRequest(http.MethodPost, "/productos", body)
-    r.Header.Set("Content-Type", "application/json")
-    w := httptest.NewRecorder()
-    ctx := context.NewContext()
-    ctx.Reset(w, r)
-    ctx.Input.RequestBody = body.Bytes()
-    c := ProductoController{}
-    c.Ctx = ctx
-    c.Data = make(map[interface{}]interface{})
+	body := bytes.NewBufferString(`{"nombre":"A","estadoProducto":"DISPONIBLE","precio":10}`)
+	r := httptest.NewRequest(http.MethodPost, "/productos", body)
+	r.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	ctx.Input.RequestBody = body.Bytes()
+	c := ProductoController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
 
-    savedInsert := insertProductoFn
-    savedInsertHist := insertPrecioHistFn
-    insertProductoFn = func(o orm.Ormer, p *models.Producto) (int64, error) { return 1, nil }
-    insertPrecioHistFn = func(o orm.Ormer, h *models.PrecioProductoHist) (int64, error) { return 1, nil }
-    t.Cleanup(func(){ insertProductoFn = savedInsert; insertPrecioHistFn = savedInsertHist })
+	savedInsert := insertProductoFn
+	savedInsertHist := insertPrecioHistFn
+	insertProductoFn = func(o orm.Ormer, p *models.Producto) (int64, error) { return 1, nil }
+	insertPrecioHistFn = func(o orm.Ormer, h *models.PrecioProductoHist) (int64, error) { return 1, nil }
+	t.Cleanup(func() { insertProductoFn = savedInsert; insertPrecioHistFn = savedInsertHist })
 
-    c.Post()
-    if w.Code == http.StatusInternalServerError {
-        t.Fatalf("unexpected 500 status in multipart post")
-    }
+	c.Post()
+	if w.Code == http.StatusInternalServerError {
+		t.Fatalf("unexpected 500 status in multipart post")
+	}
 }
 
 func TestProductoPostMultipartSuccess(t *testing.T) {
-    var buf bytes.Buffer
-    mw := multipart.NewWriter(&buf)
-    _ = mw.WriteField("nombre", "A")
-    _ = mw.WriteField("descripcion", "desc")
-    _ = mw.WriteField("precio", "10")
-    _ = mw.WriteField("estadoProducto", "DISPONIBLE")
-    _ = mw.WriteField("cantidad", "2")
-    _ = mw.WriteField("calorias", "100")
-    _ = mw.WriteField("subcategoriaId", "1")
-    fw, _ := mw.CreateFormFile("imagen", "a.txt")
-    _, _ = io.Copy(fw, strings.NewReader("imgdata"))
-    _ = mw.Close()
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+	_ = mw.WriteField("nombre", "A")
+	_ = mw.WriteField("descripcion", "desc")
+	_ = mw.WriteField("precio", "10")
+	_ = mw.WriteField("estadoProducto", "DISPONIBLE")
+	_ = mw.WriteField("cantidad", "2")
+	_ = mw.WriteField("calorias", "100")
+	_ = mw.WriteField("subcategoriaId", "1")
+	fw, _ := mw.CreateFormFile("imagen", "a.txt")
+	_, _ = io.Copy(fw, strings.NewReader("imgdata"))
+	_ = mw.Close()
 
-    r := httptest.NewRequest(http.MethodPost, "/productos", &buf)
-    r.Header.Set("Content-Type", mw.FormDataContentType())
-    w := httptest.NewRecorder()
-    ctx := context.NewContext()
-    ctx.Reset(w, r)
+	r := httptest.NewRequest(http.MethodPost, "/productos", &buf)
+	r.Header.Set("Content-Type", mw.FormDataContentType())
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	ctx.Request.ParseMultipartForm(32 << 20)
 
-    c := ProductoController{}
-    c.Ctx = ctx
-    c.Data = make(map[interface{}]interface{})
+	c := ProductoController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
 
-    savedInsert := insertProductoFn
-    savedInsertHist := insertPrecioHistFn
-    insertProductoFn = func(o orm.Ormer, p *models.Producto) (int64, error) { return 1, nil }
-    insertPrecioHistFn = func(o orm.Ormer, h *models.PrecioProductoHist) (int64, error) { return 1, nil }
-    t.Cleanup(func(){ insertProductoFn = savedInsert; insertPrecioHistFn = savedInsertHist })
+	savedInsert := insertProductoFn
+	savedInsertHist := insertPrecioHistFn
+	insertProductoFn = func(o orm.Ormer, p *models.Producto) (int64, error) { return 1, nil }
+	insertPrecioHistFn = func(o orm.Ormer, h *models.PrecioProductoHist) (int64, error) { return 1, nil }
+	t.Cleanup(func() { insertProductoFn = savedInsert; insertPrecioHistFn = savedInsertHist })
 
-    c.Post()
-    if w.Code == http.StatusInternalServerError {
-        t.Fatalf("unexpected 500 status in multipart post")
-    }
+	c.Post()
+	if w.Code == http.StatusInternalServerError {
+		t.Fatalf("unexpected 500 status in multipart post")
+	}
 }
 
 func TestProductoPutMultipartSuccessWithPriceChange(t *testing.T) {
-    var buf bytes.Buffer
-    mw := multipart.NewWriter(&buf)
-    _ = mw.WriteField("nombre", "B")
-    _ = mw.WriteField("descripcion", "desc2")
-    _ = mw.WriteField("precio", "11")
-    _ = mw.WriteField("estadoProducto", "DISPONIBLE")
-    _ = mw.WriteField("cantidad", "3")
-    _ = mw.WriteField("calorias", "150")
-    _ = mw.WriteField("subcategoriaId", "2")
-    fw, _ := mw.CreateFormFile("imagen", "b.txt")
-    _, _ = io.Copy(fw, strings.NewReader("imgdata2"))
-    _ = mw.Close()
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+	_ = mw.WriteField("nombre", "B")
+	_ = mw.WriteField("descripcion", "desc2")
+	_ = mw.WriteField("precio", "11")
+	_ = mw.WriteField("estadoProducto", "DISPONIBLE")
+	_ = mw.WriteField("cantidad", "3")
+	_ = mw.WriteField("calorias", "150")
+	_ = mw.WriteField("subcategoriaId", "2")
+	fw, _ := mw.CreateFormFile("imagen", "b.txt")
+	_, _ = io.Copy(fw, strings.NewReader("imgdata2"))
+	_ = mw.Close()
 
-    r := httptest.NewRequest(http.MethodPut, "/productos?id=1", &buf)
-    r.Header.Set("Content-Type", mw.FormDataContentType())
-    w := httptest.NewRecorder()
-    ctx := context.NewContext()
-    ctx.Reset(w, r)
+	r := httptest.NewRequest(http.MethodPut, "/productos?id=1", &buf)
+	r.Header.Set("Content-Type", mw.FormDataContentType())
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	ctx.Request.ParseMultipartForm(32 << 20)
 
-    c := ProductoController{}
-    c.Ctx = ctx
-    c.Data = make(map[interface{}]interface{})
+	c := ProductoController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
 
-    origRead := readProductoFn
-    origUpdate := updateProductoFn
-    origInsertHist := insertPrecioHistFn
-    readProductoFn = func(o orm.Ormer, p *models.Producto) error { p.NOMBRE = "A"; p.PRECIO = 10; p.ESTADO_PRODUCTO = models.EstadoProductoDisponible; return nil }
-    updateProductoFn = func(o orm.Ormer, p *models.Producto, cols ...string) (int64, error) { return 1, nil }
-    insertPrecioHistFn = func(o orm.Ormer, h *models.PrecioProductoHist) (int64, error) { return 1, nil }
-    t.Cleanup(func(){ readProductoFn = origRead; updateProductoFn = origUpdate; insertPrecioHistFn = origInsertHist })
+	origRead := readProductoFn
+	origUpdate := updateProductoFn
+	origInsertHist := insertPrecioHistFn
+	readProductoFn = func(o orm.Ormer, p *models.Producto) error {
+		p.NOMBRE = "A"
+		p.PRECIO = 10
+		p.ESTADO_PRODUCTO = models.EstadoProductoDisponible
+		return nil
+	}
+	updateProductoFn = func(o orm.Ormer, p *models.Producto, cols ...string) (int64, error) { return 1, nil }
+	insertPrecioHistFn = func(o orm.Ormer, h *models.PrecioProductoHist) (int64, error) { return 1, nil }
+	t.Cleanup(func() { readProductoFn = origRead; updateProductoFn = origUpdate; insertPrecioHistFn = origInsertHist })
 
-    c.Put()
+	c.Put()
 
-    if w.Code != http.StatusOK {
-        t.Fatalf("expected status 200, got %d", w.Code)
-    }
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
 }
 
 func TestProductoDeleteInvalidID(t *testing.T) {
-    r := httptest.NewRequest(http.MethodDelete, "/productos", nil)
-    w := httptest.NewRecorder()
-    ctx := context.NewContext()
-    ctx.Reset(w, r)
-    c := ProductoController{}
-    c.Ctx = ctx
-    c.Data = make(map[interface{}]interface{})
+	r := httptest.NewRequest(http.MethodDelete, "/productos", nil)
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	c := ProductoController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
 
-    c.Delete()
+	c.Delete()
 
-    if w.Code != http.StatusBadRequest {
-        t.Fatalf("expected status 400, got %d", w.Code)
-    }
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d", w.Code)
+	}
 }
 
 func TestProductoPostInsertError(t *testing.T) {
@@ -295,7 +311,7 @@ func TestProductoPostInsertError(t *testing.T) {
 
 	savedInsert := insertProductoFn
 	insertProductoFn = func(o orm.Ormer, p *models.Producto) (int64, error) { return 0, errors.New("db") }
-	t.Cleanup(func(){ insertProductoFn = savedInsert })
+	t.Cleanup(func() { insertProductoFn = savedInsert })
 
 	c.Post()
 	if w.Code != http.StatusInternalServerError {
@@ -304,81 +320,153 @@ func TestProductoPostInsertError(t *testing.T) {
 }
 
 func TestProductoPostInvalidEstado(t *testing.T) {
-    body := bytes.NewBufferString(`{"nombre":"A","estadoProducto":"OTRO","precio":10}`)
-    r := httptest.NewRequest(http.MethodPost, "/productos", body)
-    r.Header.Set("Content-Type", "application/json")
-    w := httptest.NewRecorder()
-    ctx := context.NewContext()
-    ctx.Reset(w, r)
-    ctx.Input.RequestBody = body.Bytes()
-    c := ProductoController{}
-    c.Ctx = ctx
-    c.Data = make(map[interface{}]interface{})
+	body := bytes.NewBufferString(`{"nombre":"A","estadoProducto":"OTRO","precio":10}`)
+	r := httptest.NewRequest(http.MethodPost, "/productos", body)
+	r.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	ctx.Input.RequestBody = body.Bytes()
+	c := ProductoController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
 
-    c.Post()
-    if w.Code != http.StatusBadRequest { t.Fatalf("expected status 400, got %d", w.Code) }
+	c.Post()
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d", w.Code)
+	}
 }
 
 func TestProductoPostJSONWithImageBase64(t *testing.T) {
-    body := bytes.NewBufferString(`{"nombre":"A","estadoProducto":"DISPONIBLE","precio":10,"imagen":"aW1nZGF0YQ=="}`)
-    r := httptest.NewRequest(http.MethodPost, "/productos", body)
-    r.Header.Set("Content-Type", "application/json")
-    w := httptest.NewRecorder()
-    ctx := context.NewContext(); ctx.Reset(w, r); ctx.Input.RequestBody = body.Bytes()
-    c := ProductoController{}; c.Ctx = ctx; c.Data = make(map[interface{}]interface{})
+	body := bytes.NewBufferString(`{"nombre":"A","estadoProducto":"DISPONIBLE","precio":10,"imagen":"aW1nZGF0YQ=="}`)
+	r := httptest.NewRequest(http.MethodPost, "/productos", body)
+	r.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	ctx.Input.RequestBody = body.Bytes()
+	c := ProductoController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
 
-    savedInsert := insertProductoFn
-    savedInsertHist := insertPrecioHistFn
-    insertProductoFn = func(o orm.Ormer, p *models.Producto) (int64, error) { return 1, nil }
-    insertPrecioHistFn = func(o orm.Ormer, h *models.PrecioProductoHist) (int64, error) { return 1, nil }
-    t.Cleanup(func(){ insertProductoFn = savedInsert; insertPrecioHistFn = savedInsertHist })
+	savedInsert := insertProductoFn
+	savedInsertHist := insertPrecioHistFn
+	insertProductoFn = func(o orm.Ormer, p *models.Producto) (int64, error) { return 1, nil }
+	insertPrecioHistFn = func(o orm.Ormer, h *models.PrecioProductoHist) (int64, error) { return 1, nil }
+	t.Cleanup(func() { insertProductoFn = savedInsert; insertPrecioHistFn = savedInsertHist })
 
-    c.Post()
-    if w.Code != http.StatusCreated && w.Code != http.StatusOK { t.Fatalf("unexpected status %d", w.Code) }
+	c.Post()
+	if w.Code != http.StatusCreated && w.Code != http.StatusOK {
+		t.Fatalf("unexpected status %d", w.Code)
+	}
 }
 
 func TestProductoPostMultipartMissingNombre(t *testing.T) {
-    var buf bytes.Buffer
-    mw := multipart.NewWriter(&buf)
-    _ = mw.WriteField("precio", "10")
-    _ = mw.WriteField("estadoProducto", "DISPONIBLE")
-    _ = mw.Close()
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+	_ = mw.WriteField("precio", "10")
+	_ = mw.WriteField("estadoProducto", "DISPONIBLE")
+	_ = mw.Close()
 
-    r := httptest.NewRequest(http.MethodPost, "/productos", &buf)
-    r.Header.Set("Content-Type", mw.FormDataContentType())
-    w := httptest.NewRecorder()
-    ctx := context.NewContext(); ctx.Reset(w, r)
-    c := ProductoController{}; c.Ctx = ctx; c.Data = make(map[interface{}]interface{})
+	r := httptest.NewRequest(http.MethodPost, "/productos", &buf)
+	r.Header.Set("Content-Type", mw.FormDataContentType())
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	c := ProductoController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
 
-    c.Post()
-    if w.Code != http.StatusBadRequest { t.Fatalf("expected 400, got %d", w.Code) }
+	c.Post()
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
 }
 
 func TestProductoPostPrecioHistInsertError(t *testing.T) {
-    body := bytes.NewBufferString(`{"nombre":"A","estadoProducto":"DISPONIBLE","precio":10}`)
-    r := httptest.NewRequest(http.MethodPost, "/productos", body)
-    r.Header.Set("Content-Type", "application/json")
-    w := httptest.NewRecorder()
-    ctx := context.NewContext()
-    ctx.Reset(w, r)
-    ctx.Input.RequestBody = body.Bytes()
-    c := ProductoController{}
-    c.Ctx = ctx
-    c.Data = make(map[interface{}]interface{})
+	body := bytes.NewBufferString(`{"nombre":"A","estadoProducto":"DISPONIBLE","precio":10}`)
+	r := httptest.NewRequest(http.MethodPost, "/productos", body)
+	r.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	ctx.Input.RequestBody = body.Bytes()
+	c := ProductoController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
 
-    savedInsert := insertProductoFn
-    savedInsertHist := insertPrecioHistFn
-    insertProductoFn = func(o orm.Ormer, p *models.Producto) (int64, error) { return 1, nil }
-    insertPrecioHistFn = func(o orm.Ormer, h *models.PrecioProductoHist) (int64, error) { return 0, errors.New("hist fail") }
-    t.Cleanup(func(){ insertProductoFn = savedInsert; insertPrecioHistFn = savedInsertHist })
+	savedInsert := insertProductoFn
+	savedInsertHist := insertPrecioHistFn
+	insertProductoFn = func(o orm.Ormer, p *models.Producto) (int64, error) { return 1, nil }
+	insertPrecioHistFn = func(o orm.Ormer, h *models.PrecioProductoHist) (int64, error) { return 0, errors.New("hist fail") }
+	t.Cleanup(func() { insertProductoFn = savedInsert; insertPrecioHistFn = savedInsertHist })
 
-    c.Post()
-    if w.Code != http.StatusInternalServerError {
-        t.Fatalf("expected status 500, got %d", w.Code)
-    }
+	c.Post()
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected status 500, got %d", w.Code)
+	}
+}
+
+func TestProductoPostInvalidJSON(t *testing.T) {
+	r := httptest.NewRequest(http.MethodPost, "/productos", strings.NewReader("{invalid"))
+	r.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	ctx.Input.RequestBody = []byte("{invalid")
+	c := ProductoController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	c.Post()
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d", w.Code)
+	}
+}
+
+func TestProductoPostMultipartInvalidNumericFields(t *testing.T) {
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+	_ = mw.WriteField("nombre", "A")
+	_ = mw.WriteField("descripcion", "desc")
+	_ = mw.WriteField("precio", "abc")
+	_ = mw.WriteField("estadoProducto", "DISPONIBLE")
+	_ = mw.WriteField("cantidad", "xyz")
+	_ = mw.WriteField("calorias", "abc")
+	_ = mw.WriteField("subcategoriaId", "xyz")
+	_ = mw.Close()
+
+	r := httptest.NewRequest(http.MethodPost, "/productos", &buf)
+	r.Header.Set("Content-Type", mw.FormDataContentType())
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	c := ProductoController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	c.Post()
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d", w.Code)
+	}
 }
 
 // PUT cases
+func TestProductoPutInvalidID(t *testing.T) {
+	r := httptest.NewRequest(http.MethodPut, "/productos", nil)
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	c := ProductoController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	c.Put()
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d", w.Code)
+	}
+}
+
 func TestProductoPutJSONInvalido(t *testing.T) {
 	r := httptest.NewRequest(http.MethodPut, "/productos?id=1", strings.NewReader("notjson"))
 	w := httptest.NewRecorder()
@@ -391,7 +479,7 @@ func TestProductoPutJSONInvalido(t *testing.T) {
 
 	savedRead := readProductoFn
 	readProductoFn = func(o orm.Ormer, p *models.Producto) error { return nil }
-	t.Cleanup(func(){ readProductoFn = savedRead })
+	t.Cleanup(func() { readProductoFn = savedRead })
 
 	c.Put()
 	if w.Code != http.StatusBadRequest {
@@ -417,7 +505,7 @@ func TestProductoPutNoCambios(t *testing.T) {
 		p.ESTADO_PRODUCTO = models.EstadoProductoDisponible
 		return nil
 	}
-	t.Cleanup(func(){ readProductoFn = origRead })
+	t.Cleanup(func() { readProductoFn = origRead })
 
 	c.Put()
 	if w.Code != http.StatusNotModified {
@@ -438,9 +526,14 @@ func TestProductoPutUpdateError(t *testing.T) {
 
 	origRead := readProductoFn
 	origUpdate := updateProductoFn
-	readProductoFn = func(o orm.Ormer, p *models.Producto) error { p.NOMBRE = "A"; p.PRECIO = 10; p.ESTADO_PRODUCTO = models.EstadoProductoDisponible; return nil }
+	readProductoFn = func(o orm.Ormer, p *models.Producto) error {
+		p.NOMBRE = "A"
+		p.PRECIO = 10
+		p.ESTADO_PRODUCTO = models.EstadoProductoDisponible
+		return nil
+	}
 	updateProductoFn = func(o orm.Ormer, p *models.Producto, cols ...string) (int64, error) { return 0, errors.New("db") }
-	t.Cleanup(func(){ readProductoFn = origRead; updateProductoFn = origUpdate })
+	t.Cleanup(func() { readProductoFn = origRead; updateProductoFn = origUpdate })
 
 	c.Put()
 	if w.Code != http.StatusInternalServerError {
@@ -462,10 +555,15 @@ func TestProductoPutHistorialError(t *testing.T) {
 	origRead := readProductoFn
 	origUpdate := updateProductoFn
 	origInsertHist := insertPrecioHistFn
-	readProductoFn = func(o orm.Ormer, p *models.Producto) error { p.NOMBRE = "A"; p.PRECIO = 10; p.ESTADO_PRODUCTO = models.EstadoProductoDisponible; return nil }
+	readProductoFn = func(o orm.Ormer, p *models.Producto) error {
+		p.NOMBRE = "A"
+		p.PRECIO = 10
+		p.ESTADO_PRODUCTO = models.EstadoProductoDisponible
+		return nil
+	}
 	updateProductoFn = func(o orm.Ormer, p *models.Producto, cols ...string) (int64, error) { return 1, nil }
 	insertPrecioHistFn = func(o orm.Ormer, h *models.PrecioProductoHist) (int64, error) { return 0, errors.New("db") }
-	t.Cleanup(func(){ readProductoFn = origRead; updateProductoFn = origUpdate; insertPrecioHistFn = origInsertHist })
+	t.Cleanup(func() { readProductoFn = origRead; updateProductoFn = origUpdate; insertPrecioHistFn = origInsertHist })
 
 	c.Put()
 	if w.Code != http.StatusInternalServerError {
@@ -487,10 +585,15 @@ func TestProductoPutSuccess(t *testing.T) {
 	origRead := readProductoFn
 	origUpdate := updateProductoFn
 	origInsertHist := insertPrecioHistFn
-	readProductoFn = func(o orm.Ormer, p *models.Producto) error { p.NOMBRE = "A"; p.PRECIO = 10; p.ESTADO_PRODUCTO = models.EstadoProductoDisponible; return nil }
+	readProductoFn = func(o orm.Ormer, p *models.Producto) error {
+		p.NOMBRE = "A"
+		p.PRECIO = 10
+		p.ESTADO_PRODUCTO = models.EstadoProductoDisponible
+		return nil
+	}
 	updateProductoFn = func(o orm.Ormer, p *models.Producto, cols ...string) (int64, error) { return 1, nil }
 	insertPrecioHistFn = func(o orm.Ormer, h *models.PrecioProductoHist) (int64, error) { return 1, nil }
-	t.Cleanup(func(){ readProductoFn = origRead; updateProductoFn = origUpdate; insertPrecioHistFn = origInsertHist })
+	t.Cleanup(func() { readProductoFn = origRead; updateProductoFn = origUpdate; insertPrecioHistFn = origInsertHist })
 
 	c.Put()
 	if w.Code != http.StatusOK {
@@ -499,128 +602,275 @@ func TestProductoPutSuccess(t *testing.T) {
 }
 
 func TestProductoPutNotFound(t *testing.T) {
-    body := `{"nombre":"A","precio":10,"estadoProducto":"DISPONIBLE"}`
-    r := httptest.NewRequest(http.MethodPut, "/productos?id=99", strings.NewReader(body))
-    w := httptest.NewRecorder()
-    ctx := context.NewContext()
-    ctx.Reset(w, r)
-    ctx.Input.RequestBody = []byte(body)
-    c := ProductoController{}
-    c.Ctx = ctx
-    c.Data = make(map[interface{}]interface{})
+	body := `{"nombre":"A","precio":10,"estadoProducto":"DISPONIBLE"}`
+	r := httptest.NewRequest(http.MethodPut, "/productos?id=99", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	ctx.Input.RequestBody = []byte(body)
+	c := ProductoController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
 
-    origRead := readProductoFn
-    readProductoFn = func(o orm.Ormer, p *models.Producto) error { return orm.ErrNoRows }
-    t.Cleanup(func(){ readProductoFn = origRead })
+	origRead := readProductoFn
+	readProductoFn = func(o orm.Ormer, p *models.Producto) error { return orm.ErrNoRows }
+	t.Cleanup(func() { readProductoFn = origRead })
 
-    c.Put()
-    if w.Code != http.StatusOK { t.Fatalf("expected status 200, got %d", w.Code) }
-    if !strings.Contains(w.Body.String(), "Producto no encontrado") { t.Errorf("unexpected body: %s", w.Body.String()) }
+	c.Put()
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "Producto no encontrado") {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
 }
 
 func TestProductoPutPriceChangeHistSuccess_JSON(t *testing.T) {
-    body := `{"nombre":"B","precio":12,"estadoProducto":"DISPONIBLE"}`
-    r := httptest.NewRequest(http.MethodPut, "/productos?id=1", strings.NewReader(body))
-    w := httptest.NewRecorder()
-    ctx := context.NewContext(); ctx.Reset(w, r); ctx.Input.RequestBody = []byte(body)
-    c := ProductoController{}; c.Ctx = ctx; c.Data = make(map[interface{}]interface{})
+	body := `{"nombre":"B","precio":12,"estadoProducto":"DISPONIBLE"}`
+	r := httptest.NewRequest(http.MethodPut, "/productos?id=1", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	ctx.Input.RequestBody = []byte(body)
+	c := ProductoController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
 
-    origRead, origUpdate, origHist := readProductoFn, updateProductoFn, insertPrecioHistFn
-    readProductoFn = func(o orm.Ormer, p *models.Producto) error { p.NOMBRE = "A"; p.PRECIO = 10; p.ESTADO_PRODUCTO = models.EstadoProductoDisponible; return nil }
-    updateProductoFn = func(o orm.Ormer, p *models.Producto, cols ...string) (int64, error) { return 1, nil }
-    insertPrecioHistFn = func(o orm.Ormer, h *models.PrecioProductoHist) (int64, error) { return 1, nil }
-    t.Cleanup(func(){ readProductoFn = origRead; updateProductoFn = origUpdate; insertPrecioHistFn = origHist })
+	origRead, origUpdate, origHist := readProductoFn, updateProductoFn, insertPrecioHistFn
+	readProductoFn = func(o orm.Ormer, p *models.Producto) error {
+		p.NOMBRE = "A"
+		p.PRECIO = 10
+		p.ESTADO_PRODUCTO = models.EstadoProductoDisponible
+		return nil
+	}
+	updateProductoFn = func(o orm.Ormer, p *models.Producto, cols ...string) (int64, error) { return 1, nil }
+	insertPrecioHistFn = func(o orm.Ormer, h *models.PrecioProductoHist) (int64, error) { return 1, nil }
+	t.Cleanup(func() { readProductoFn = origRead; updateProductoFn = origUpdate; insertPrecioHistFn = origHist })
 
-    c.Put()
-    if w.Code != http.StatusOK { t.Fatalf("expected status 200, got %d", w.Code) }
-    if !strings.Contains(w.Body.String(), "Producto actualizado") { t.Errorf("unexpected body: %s", w.Body.String()) }
+	c.Put()
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "Producto actualizado") {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
 }
 
 func TestProductoPutPriceChangeHistError_JSON(t *testing.T) {
-    body := `{"nombre":"B","precio":12,"estadoProducto":"DISPONIBLE"}`
-    r := httptest.NewRequest(http.MethodPut, "/productos?id=1", strings.NewReader(body))
-    w := httptest.NewRecorder()
-    ctx := context.NewContext(); ctx.Reset(w, r); ctx.Input.RequestBody = []byte(body)
-    c := ProductoController{}; c.Ctx = ctx; c.Data = make(map[interface{}]interface{})
+	body := `{"nombre":"B","precio":12,"estadoProducto":"DISPONIBLE"}`
+	r := httptest.NewRequest(http.MethodPut, "/productos?id=1", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	ctx.Input.RequestBody = []byte(body)
+	c := ProductoController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
 
-    origRead, origUpdate, origHist := readProductoFn, updateProductoFn, insertPrecioHistFn
-    readProductoFn = func(o orm.Ormer, p *models.Producto) error { p.NOMBRE = "A"; p.PRECIO = 10; p.ESTADO_PRODUCTO = models.EstadoProductoDisponible; return nil }
-    updateProductoFn = func(o orm.Ormer, p *models.Producto, cols ...string) (int64, error) { return 1, nil }
-    insertPrecioHistFn = func(o orm.Ormer, h *models.PrecioProductoHist) (int64, error) { return 0, errors.New("hist error") }
-    t.Cleanup(func(){ readProductoFn = origRead; updateProductoFn = origUpdate; insertPrecioHistFn = origHist })
+	origRead, origUpdate, origHist := readProductoFn, updateProductoFn, insertPrecioHistFn
+	readProductoFn = func(o orm.Ormer, p *models.Producto) error {
+		p.NOMBRE = "A"
+		p.PRECIO = 10
+		p.ESTADO_PRODUCTO = models.EstadoProductoDisponible
+		return nil
+	}
+	updateProductoFn = func(o orm.Ormer, p *models.Producto, cols ...string) (int64, error) { return 1, nil }
+	insertPrecioHistFn = func(o orm.Ormer, h *models.PrecioProductoHist) (int64, error) { return 0, errors.New("hist error") }
+	t.Cleanup(func() { readProductoFn = origRead; updateProductoFn = origUpdate; insertPrecioHistFn = origHist })
 
-    c.Put()
-    if w.Code != http.StatusInternalServerError { t.Fatalf("expected status 500, got %d", w.Code) }
+	c.Put()
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected status 500, got %d", w.Code)
+	}
 }
 
 func TestProductoPutValidationError_NegativeCalories(t *testing.T) {
-    body := `{"nombre":"A","precio":10,"estadoProducto":"DISPONIBLE","calorias":-1}`
-    r := httptest.NewRequest(http.MethodPut, "/productos?id=1", strings.NewReader(body))
-    w := httptest.NewRecorder()
-    ctx := context.NewContext(); ctx.Reset(w, r); ctx.Input.RequestBody = []byte(body)
-    c := ProductoController{}; c.Ctx = ctx; c.Data = make(map[interface{}]interface{})
+	body := `{"nombre":"A","precio":10,"estadoProducto":"DISPONIBLE","calorias":-1}`
+	r := httptest.NewRequest(http.MethodPut, "/productos?id=1", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	ctx.Input.RequestBody = []byte(body)
+	c := ProductoController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
 
-    origRead := readProductoFn
-    readProductoFn = func(o orm.Ormer, p *models.Producto) error { p.NOMBRE = "A"; p.PRECIO = 10; p.ESTADO_PRODUCTO = models.EstadoProductoDisponible; return nil }
-    t.Cleanup(func(){ readProductoFn = origRead })
+	origRead := readProductoFn
+	readProductoFn = func(o orm.Ormer, p *models.Producto) error {
+		p.NOMBRE = "A"
+		p.PRECIO = 10
+		p.ESTADO_PRODUCTO = models.EstadoProductoDisponible
+		return nil
+	}
+	t.Cleanup(func() { readProductoFn = origRead })
 
-    c.Put()
-    if w.Code != http.StatusBadRequest { t.Fatalf("expected 400, got %d", w.Code) }
+	c.Put()
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
 }
 
 func TestProductoPutInvalidEstadoJSON(t *testing.T) {
-    body := `{"nombre":"A","precio":10,"estadoProducto":"INVALIDO"}`
-    r := httptest.NewRequest(http.MethodPut, "/productos?id=1", strings.NewReader(body))
-    w := httptest.NewRecorder()
-    ctx := context.NewContext(); ctx.Reset(w, r); ctx.Input.RequestBody = []byte(body)
-    c := ProductoController{}; c.Ctx = ctx; c.Data = make(map[interface{}]interface{})
+	body := `{"nombre":"A","precio":10,"estadoProducto":"INVALIDO"}`
+	r := httptest.NewRequest(http.MethodPut, "/productos?id=1", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	ctx.Input.RequestBody = []byte(body)
+	c := ProductoController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
 
-    origRead := readProductoFn
-    readProductoFn = func(o orm.Ormer, p *models.Producto) error { p.NOMBRE = "A"; p.PRECIO = 10; p.ESTADO_PRODUCTO = models.EstadoProductoDisponible; return nil }
-    t.Cleanup(func(){ readProductoFn = origRead })
+	origRead := readProductoFn
+	readProductoFn = func(o orm.Ormer, p *models.Producto) error {
+		p.NOMBRE = "A"
+		p.PRECIO = 10
+		p.ESTADO_PRODUCTO = models.EstadoProductoDisponible
+		return nil
+	}
+	t.Cleanup(func() { readProductoFn = origRead })
 
-    c.Put()
-    if w.Code != http.StatusBadRequest { t.Fatalf("expected 400, got %d", w.Code) }
+	c.Put()
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
 }
 
+func TestProductoPutJSONWithImage(t *testing.T) {
+	body := `{"nombre":"B","precio":12,"estadoProducto":"DISPONIBLE","imagen":"aW1n"}`
+	r := httptest.NewRequest(http.MethodPut, "/productos?id=1", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	ctx.Input.RequestBody = []byte(body)
+	c := ProductoController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	origRead, origUpdate, origHist := readProductoFn, updateProductoFn, insertPrecioHistFn
+	readProductoFn = func(o orm.Ormer, p *models.Producto) error {
+		p.NOMBRE = "A"
+		p.PRECIO = 10
+		p.ESTADO_PRODUCTO = models.EstadoProductoDisponible
+		return nil
+	}
+	updateProductoFn = func(o orm.Ormer, p *models.Producto, cols ...string) (int64, error) { return 1, nil }
+	insertPrecioHistFn = func(o orm.Ormer, h *models.PrecioProductoHist) (int64, error) { return 1, nil }
+	t.Cleanup(func() { readProductoFn = origRead; updateProductoFn = origUpdate; insertPrecioHistFn = origHist })
+
+	c.Put()
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+}
 
 func TestProductoPutMultipartNoPriceChange(t *testing.T) {
-    var buf bytes.Buffer
-    mw := multipart.NewWriter(&buf)
-    _ = mw.WriteField("nombre", "A")
-    _ = mw.WriteField("descripcion", "desc")
-    _ = mw.WriteField("precio", "10")
-    _ = mw.WriteField("estadoProducto", "DISPONIBLE")
-    _ = mw.WriteField("cantidad", "2")
-    _ = mw.WriteField("calorias", "100")
-    _ = mw.WriteField("subcategoriaId", "1")
-    _ = mw.Close()
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+	_ = mw.WriteField("nombre", "A")
+	_ = mw.WriteField("descripcion", "desc")
+	_ = mw.WriteField("precio", "10")
+	_ = mw.WriteField("estadoProducto", "DISPONIBLE")
+	_ = mw.WriteField("cantidad", "2")
+	_ = mw.WriteField("calorias", "100")
+	_ = mw.WriteField("subcategoriaId", "1")
+	_ = mw.Close()
 
-    r := httptest.NewRequest(http.MethodPut, "/productos?id=1", &buf)
-    r.Header.Set("Content-Type", mw.FormDataContentType())
-    w := httptest.NewRecorder()
-    ctx := context.NewContext()
-    ctx.Reset(w, r)
+	r := httptest.NewRequest(http.MethodPut, "/productos?id=1", &buf)
+	r.Header.Set("Content-Type", mw.FormDataContentType())
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	ctx.Request.ParseMultipartForm(32 << 20)
 
-    c := ProductoController{}
-    c.Ctx = ctx
-    c.Data = make(map[interface{}]interface{})
+	c := ProductoController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
 
-    origRead := readProductoFn
-    origUpdate := updateProductoFn
-    origInsertHist := insertPrecioHistFn
-    readProductoFn = func(o orm.Ormer, p *models.Producto) error { p.NOMBRE = "A"; p.PRECIO = 10; p.ESTADO_PRODUCTO = models.EstadoProductoDisponible; return nil }
-    updateProductoFn = func(o orm.Ormer, p *models.Producto, cols ...string) (int64, error) { return 1, nil }
-    insertPrecioHistFn = func(o orm.Ormer, h *models.PrecioProductoHist) (int64, error) {
-        t.Fatalf("history should not be inserted when price does not change")
-        return 0, nil
-    }
-    t.Cleanup(func(){ readProductoFn = origRead; updateProductoFn = origUpdate; insertPrecioHistFn = origInsertHist })
+	origRead := readProductoFn
+	origUpdate := updateProductoFn
+	origInsertHist := insertPrecioHistFn
+	readProductoFn = func(o orm.Ormer, p *models.Producto) error {
+		p.NOMBRE = "A"
+		p.PRECIO = 10
+		p.ESTADO_PRODUCTO = models.EstadoProductoDisponible
+		return nil
+	}
+	updateProductoFn = func(o orm.Ormer, p *models.Producto, cols ...string) (int64, error) { return 1, nil }
+	insertPrecioHistFn = func(o orm.Ormer, h *models.PrecioProductoHist) (int64, error) {
+		t.Fatalf("history should not be inserted when price does not change")
+		return 0, nil
+	}
+	t.Cleanup(func() { readProductoFn = origRead; updateProductoFn = origUpdate; insertPrecioHistFn = origInsertHist })
 
-    c.Put()
-    if w.Code != http.StatusOK && w.Code != http.StatusNotModified {
-        t.Fatalf("expected status 200 or 304, got %d", w.Code)
-    }
+	c.Put()
+	if w.Code != http.StatusOK && w.Code != http.StatusNotModified {
+		t.Fatalf("expected status 200 or 304, got %d", w.Code)
+	}
+}
+
+func TestProductoPutMultipartMissingFields(t *testing.T) {
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+	_ = mw.Close()
+
+	r := httptest.NewRequest(http.MethodPut, "/productos?id=1", &buf)
+	r.Header.Set("Content-Type", mw.FormDataContentType())
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	c := ProductoController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	origRead := readProductoFn
+	readProductoFn = func(o orm.Ormer, p *models.Producto) error {
+		p.NOMBRE = "A"
+		p.PRECIO = 10
+		p.ESTADO_PRODUCTO = models.EstadoProductoDisponible
+		return nil
+	}
+	t.Cleanup(func() { readProductoFn = origRead })
+
+	c.Put()
+	if w.Code != http.StatusNotModified {
+		t.Fatalf("expected status 304, got %d", w.Code)
+	}
+}
+
+func TestProductoPutMultipartInvalidNumeric(t *testing.T) {
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+	_ = mw.WriteField("nombre", "A")
+	_ = mw.WriteField("precio", "abc")
+	_ = mw.WriteField("estadoProducto", "DISPONIBLE")
+	_ = mw.WriteField("cantidad", "xyz")
+	_ = mw.WriteField("calorias", "abc")
+	_ = mw.WriteField("subcategoriaId", "xyz")
+	_ = mw.Close()
+
+	r := httptest.NewRequest(http.MethodPut, "/productos?id=1", &buf)
+	r.Header.Set("Content-Type", mw.FormDataContentType())
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	c := ProductoController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	origRead := readProductoFn
+	readProductoFn = func(o orm.Ormer, p *models.Producto) error {
+		p.NOMBRE = "A"
+		p.PRECIO = 10
+		p.ESTADO_PRODUCTO = models.EstadoProductoDisponible
+		return nil
+	}
+	t.Cleanup(func() { readProductoFn = origRead })
+
+	c.Put()
+	if w.Code != http.StatusNotModified {
+		t.Fatalf("expected status 304, got %d", w.Code)
+	}
 }
 
 // DELETE cases
@@ -634,8 +884,11 @@ func TestProductoDeleteAlreadyDisabled(t *testing.T) {
 	c.Data = make(map[interface{}]interface{})
 
 	savedRead := readProductoFn
-	readProductoFn = func(o orm.Ormer, p *models.Producto) error { p.ESTADO_PRODUCTO = models.EstadoProductoNoDisponible; return nil }
-	t.Cleanup(func(){ readProductoFn = savedRead })
+	readProductoFn = func(o orm.Ormer, p *models.Producto) error {
+		p.ESTADO_PRODUCTO = models.EstadoProductoNoDisponible
+		return nil
+	}
+	t.Cleanup(func() { readProductoFn = savedRead })
 
 	c.Delete()
 	if w.Code != http.StatusBadRequest {
@@ -654,9 +907,12 @@ func TestProductoDeleteUpdateError(t *testing.T) {
 
 	savedRead := readProductoFn
 	savedUpdate := updateProductoFn
-	readProductoFn = func(o orm.Ormer, p *models.Producto) error { p.ESTADO_PRODUCTO = models.EstadoProductoDisponible; return nil }
+	readProductoFn = func(o orm.Ormer, p *models.Producto) error {
+		p.ESTADO_PRODUCTO = models.EstadoProductoDisponible
+		return nil
+	}
 	updateProductoFn = func(o orm.Ormer, p *models.Producto, cols ...string) (int64, error) { return 0, errors.New("db") }
-	t.Cleanup(func(){ readProductoFn = savedRead; updateProductoFn = savedUpdate })
+	t.Cleanup(func() { readProductoFn = savedRead; updateProductoFn = savedUpdate })
 
 	c.Delete()
 	if w.Code != http.StatusInternalServerError {
@@ -675,9 +931,12 @@ func TestProductoDeleteSuccess(t *testing.T) {
 
 	savedRead := readProductoFn
 	savedUpdate := updateProductoFn
-	readProductoFn = func(o orm.Ormer, p *models.Producto) error { p.ESTADO_PRODUCTO = models.EstadoProductoDisponible; return nil }
+	readProductoFn = func(o orm.Ormer, p *models.Producto) error {
+		p.ESTADO_PRODUCTO = models.EstadoProductoDisponible
+		return nil
+	}
 	updateProductoFn = func(o orm.Ormer, p *models.Producto, cols ...string) (int64, error) { return 1, nil }
-	t.Cleanup(func(){ readProductoFn = savedRead; updateProductoFn = savedUpdate })
+	t.Cleanup(func() { readProductoFn = savedRead; updateProductoFn = savedUpdate })
 
 	c.Delete()
 	if w.Code != http.StatusOK {
@@ -686,59 +945,73 @@ func TestProductoDeleteSuccess(t *testing.T) {
 }
 
 func TestProductoDeleteNotFound(t *testing.T) {
-    r := httptest.NewRequest(http.MethodDelete, "/productos?id=999", nil)
-    w := httptest.NewRecorder()
-    ctx := context.NewContext()
-    ctx.Reset(w, r)
-    c := ProductoController{}
-    c.Ctx = ctx
-    c.Data = make(map[interface{}]interface{})
+	r := httptest.NewRequest(http.MethodDelete, "/productos?id=999", nil)
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	c := ProductoController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
 
-    savedGet := readProductoFn
-    readProductoFn = func(o orm.Ormer, p *models.Producto) error { return orm.ErrNoRows }
-    t.Cleanup(func(){ readProductoFn = savedGet })
+	savedGet := readProductoFn
+	readProductoFn = func(o orm.Ormer, p *models.Producto) error { return orm.ErrNoRows }
+	t.Cleanup(func() { readProductoFn = savedGet })
 
-    c.Delete()
-    if w.Code != http.StatusOK { t.Fatalf("expected status 200, got %d", w.Code) }
-    if !strings.Contains(w.Body.String(), "producto no encontrado") && !strings.Contains(strings.ToLower(w.Body.String()), "no encontrado") {
-        t.Fatalf("unexpected body: %s", w.Body.String())
-    }
+	c.Delete()
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "producto no encontrado") && !strings.Contains(strings.ToLower(w.Body.String()), "no encontrado") {
+		t.Fatalf("unexpected body: %s", w.Body.String())
+	}
 }
 
 func TestProductoGetByIdSuccess(t *testing.T) {
-    r := httptest.NewRequest(http.MethodGet, "/productos/search?id=1", nil)
-    w := httptest.NewRecorder()
-    ctx := context.NewContext()
-    ctx.Reset(w, r)
-    c := ProductoController{}
-    c.Ctx = ctx
-    c.Data = make(map[interface{}]interface{})
+	r := httptest.NewRequest(http.MethodGet, "/productos/search?id=1", nil)
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	c := ProductoController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
 
-    savedRead := readProductoFn
-    readProductoFn = func(o orm.Ormer, p *models.Producto) error { p.NOMBRE = "P"; p.PRECIO = 10; p.ESTADO_PRODUCTO = models.EstadoProductoDisponible; p.IMAGEN = "img"; return nil }
-    t.Cleanup(func(){ readProductoFn = savedRead })
+	savedRead := readProductoFn
+	readProductoFn = func(o orm.Ormer, p *models.Producto) error {
+		p.NOMBRE = "P"
+		p.PRECIO = 10
+		p.ESTADO_PRODUCTO = models.EstadoProductoDisponible
+		p.IMAGEN = "img"
+		return nil
+	}
+	t.Cleanup(func() { readProductoFn = savedRead })
 
-    c.GetById()
-    if w.Code != http.StatusOK { t.Fatalf("expected status 200, got %d", w.Code) }
+	c.GetById()
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
 }
 
 func TestProductoGetAllIncludeImageTrue(t *testing.T) {
-    r := httptest.NewRequest(http.MethodGet, "/restaurante/v1/productos?includeImage=true", nil)
-    w := httptest.NewRecorder()
-    ctx := context.NewContext()
-    ctx.Reset(w, r)
-    c := ProductoController{}
-    c.Ctx = ctx
-    c.Data = make(map[interface{}]interface{})
+	r := httptest.NewRequest(http.MethodGet, "/restaurante/v1/productos?includeImage=true", nil)
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	c := ProductoController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
 
-    saved := queryProductosAll
-    queryProductosAll = func(o orm.Ormer, onlyActive bool, productos *[]models.Producto) (int64, error) {
-        *productos = []models.Producto{{IMAGEN: "img", ESTADO_PRODUCTO: models.EstadoProductoDisponible}}
-        return 1, nil
-    }
-    t.Cleanup(func(){ queryProductosAll = saved })
+	saved := queryProductosAll
+	queryProductosAll = func(o orm.Ormer, onlyActive bool, productos *[]models.Producto) (int64, error) {
+		*productos = []models.Producto{{IMAGEN: "img", ESTADO_PRODUCTO: models.EstadoProductoDisponible}}
+		return 1, nil
+	}
+	t.Cleanup(func() { queryProductosAll = saved })
 
-    c.GetAll()
-    if w.Code != http.StatusOK { t.Fatalf("expected 200, got %d", w.Code) }
-    if !strings.Contains(w.Body.String(), "\"imagen\":\"") { t.Errorf("expected image field present: %s", w.Body.String()) }
+	c.GetAll()
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "\"imagen\":\"") {
+		t.Errorf("expected image field present: %s", w.Body.String())
+	}
 }


### PR DESCRIPTION
## Summary
- expand ProductoController tests to cover invalid JSON and multipart edge cases
- add scenarios for malformed numeric fields, missing fields, and image handling

## Testing
- `go test ./controllers -run Producto -cover`

------
https://chatgpt.com/codex/tasks/task_e_68be2af0ee348325b1d2d9df55bb887f