### PR TITLE
Increase NominaTrabajador coverage to 100%

### DIFF
--- a/controllers/nominatrabajador/NominaTrabajadorController.go
+++ b/controllers/nominatrabajador/NominaTrabajadorController.go
@@ -365,21 +365,30 @@ func (c *NominaTrabajadorController) GetByTrabajador() {
 	// Ejecutar la consulta
 	_, err := o.Raw(sql, params...).QueryRows(&relaciones)
 
-	// Validar si hay resultados
-	if err == orm.ErrNoRows || len(relaciones) == 0 {
+	if err != nil {
+		if err == orm.ErrNoRows {
+			c.Ctx.Output.SetStatus(http.StatusOK)
+			c.Data["json"] = models.ApiResponse{
+				Code:    http.StatusNotFound,
+				Message: "No se encontraron relaciones nómina-trabajador para los filtros aplicados.",
+			}
+		} else {
+			c.Ctx.Output.SetStatus(http.StatusInternalServerError)
+			c.Data["json"] = models.ApiResponse{
+				Code:    http.StatusInternalServerError,
+				Message: "Error al buscar las relaciones nómina-trabajador.",
+				Cause:   err.Error(),
+			}
+		}
+		_ = c.ServeJSON()
+		return
+	}
+
+	if len(relaciones) == 0 {
 		c.Ctx.Output.SetStatus(http.StatusOK)
 		c.Data["json"] = models.ApiResponse{
 			Code:    http.StatusNotFound,
 			Message: "No se encontraron relaciones nómina-trabajador para los filtros aplicados.",
-		}
-		_ = c.ServeJSON()
-		return
-	} else if err != nil {
-		c.Ctx.Output.SetStatus(http.StatusInternalServerError)
-		c.Data["json"] = models.ApiResponse{
-			Code:    http.StatusInternalServerError,
-			Message: "Error al buscar las relaciones nómina-trabajador.",
-			Cause:   err.Error(),
 		}
 		_ = c.ServeJSON()
 		return

--- a/controllers/nominatrabajador/nomina_trabajador_additional_cases_test.go
+++ b/controllers/nominatrabajador/nomina_trabajador_additional_cases_test.go
@@ -1,0 +1,95 @@
+package nominatrabajador
+
+import (
+	stdctx "context"
+	"database/sql/driver"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/beego/beego/v2/client/orm"
+	beegoCtx "github.com/beego/beego/v2/server/web/context"
+)
+
+func TestNominaTrabajadorGetByTrabajadorInvalidParams(t *testing.T) {
+	cases := []string{
+		"/nomina_trabajador/search?documento=1&actual=x",
+		"/nomina_trabajador/search?documento=1&pagas=x",
+		"/nomina_trabajador/search?documento=1&no_pagas=x",
+		"/nomina_trabajador/search?documento=1&mes=x",
+		"/nomina_trabajador/search?documento=1&anio=x",
+		"/nomina_trabajador/search?documento=0",
+	}
+	for _, u := range cases {
+		r := httptest.NewRequest(http.MethodGet, u, nil)
+		w := httptest.NewRecorder()
+		ctx := beegoCtx.NewContext()
+		ctx.Reset(w, r)
+		c := NominaTrabajadorController{}
+		c.Ctx = ctx
+		c.Data = make(map[interface{}]interface{})
+		c.GetByTrabajador()
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400 for %s, got %d", u, w.Code)
+		}
+	}
+}
+
+func TestNominaTrabajadorGetNominasByMesParseError(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/nomina_trabajador/mes?mes=bad&anio=2024", nil)
+	w := httptest.NewRecorder()
+	ctx := beegoCtx.NewContext()
+	ctx.Reset(w, r)
+	c := NominaTrabajadorController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+	c.GetNominasByMes()
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestNominaTrabajadorGetByTrabajadorDBError(t *testing.T) {
+	orig := MockQuery
+	MockQuery = func(_ stdctx.Context, _ string, _ []driver.NamedValue) (driver.Rows, error) {
+		return nil, fmt.Errorf("db error")
+	}
+	t.Cleanup(func() { MockQuery = orig })
+
+	r := httptest.NewRequest(http.MethodGet, "/nomina_trabajador/search?documento=1", nil)
+	w := httptest.NewRecorder()
+	ctx := beegoCtx.NewContext()
+	ctx.Reset(w, r)
+	c := NominaTrabajadorController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+	c.GetByTrabajador()
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", w.Code)
+	}
+}
+
+func TestNominaTrabajadorGetByTrabajadorErrNoRows(t *testing.T) {
+	orig := MockQuery
+	MockQuery = func(_ stdctx.Context, _ string, _ []driver.NamedValue) (driver.Rows, error) {
+		return nil, orm.ErrNoRows
+	}
+	t.Cleanup(func() { MockQuery = orig })
+
+	r := httptest.NewRequest(http.MethodGet, "/nomina_trabajador/search?documento=1", nil)
+	w := httptest.NewRecorder()
+	ctx := beegoCtx.NewContext()
+	ctx.Reset(w, r)
+	c := NominaTrabajadorController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+	c.GetByTrabajador()
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "No se encontraron") {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
+}

--- a/controllers/nominatrabajador/nomina_trabajador_controller_test.go
+++ b/controllers/nominatrabajador/nomina_trabajador_controller_test.go
@@ -414,6 +414,13 @@ func TestNominaTrabajadorCoverageHack(t *testing.T) {
 }
 
 func TestNominaTrabajadorGetByTrabajadorNoResultados(t *testing.T) {
+	orig := MockQuery
+	MockQuery = func(_ stdctx.Context, _ string, _ []driver.NamedValue) (driver.Rows, error) {
+		cols := []string{"pk_id_nomina_trabajador"}
+		return &mockRows{columns: cols, values: [][]driver.Value{}}, nil
+	}
+	t.Cleanup(func() { MockQuery = orig })
+
 	r := httptest.NewRequest(http.MethodGet, "/nomina_trabajador/search?documento=1", nil)
 	w := httptest.NewRecorder()
 	ctx := context.NewContext()


### PR DESCRIPTION
## Summary
- handle database errors before empty-result checks in NominaTrabajador controller
- add extensive tests for invalid parameters and database edge cases

## Testing
- `go test ./controllers/nominatrabajador -cover`
- `go test ./...` *(fails: github.com/golang-jwt/jwt/v5: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c1a7c455408325ba363a2a4cd0935a