### PR TITLE
test: cover cliente controller limit offset parse errors

### DIFF
--- a/controllers/cliente/cliente_controller_test.go
+++ b/controllers/cliente/cliente_controller_test.go
@@ -174,6 +174,38 @@ func TestClienteGetAllLimitOffsetError(t *testing.T) {
 	}
 }
 
+func TestClienteGetAllLimitParseError(t *testing.T) {
+	ormNew = func() orm.Ormer { return nil }
+	t.Cleanup(resetMocks)
+	r := httptest.NewRequest(http.MethodGet, "/clientes?limit=abc", nil)
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	c := ClienteController{}
+	c.Ctx = ctx
+	c.Data = map[interface{}]interface{}{}
+	c.GetAll()
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestClienteGetAllOffsetParseError(t *testing.T) {
+	ormNew = func() orm.Ormer { return nil }
+	t.Cleanup(resetMocks)
+	r := httptest.NewRequest(http.MethodGet, "/clientes?offset=abc", nil)
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	c := ClienteController{}
+	c.Ctx = ctx
+	c.Data = map[interface{}]interface{}{}
+	c.GetAll()
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
 func TestClienteGetByIdScenarios(t *testing.T) {
 	db := map[int64]models.Cliente{1: {PK_DOCUMENTO_CLIENTE: 1, NOMBRE: "Foo", PASSWORD: "pwd"}}
 	ormNew = func() orm.Ormer { return nil }


### PR DESCRIPTION
## Summary
- test limit parse error scenario in cliente controller's GetAll
- test offset parse error scenario in cliente controller's GetAll

## Testing
- `go test ./controllers/cliente -coverprofile=controllers/cliente/coverage.out` *(fails: Get "https://goproxy.cn/golang.org/x/crypto/@v/v0.42.0.zip": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c1c6cb15608325918e31cb1a227747