### PR TITLE
test: cover controlnomina edge cases

### DIFF
--- a/controllers/controlnomina/control_nomina_additional_test.go
+++ b/controllers/controlnomina/control_nomina_additional_test.go
@@ -91,3 +91,46 @@ func TestControlNomina_GetById_DBErrorLogsAndNotFound(t *testing.T) {
 		t.Fatalf("expected 200, got %d", w.Code)
 	}
 }
+
+func TestControlNomina_GetAll_WithFechaFilter(t *testing.T) {
+	orig := MockQuery
+	MockQuery = func(_ stdctx.Context, _ string, _ []driver.NamedValue) (driver.Rows, error) {
+		cols := []string{"pk_id_control_nomina", "fecha", "estado"}
+		vals := [][]driver.Value{{int64(1), "2024-01-01", "GENERADA"}}
+		return &mockRows{columns: cols, values: vals}, nil
+	}
+	t.Cleanup(func() { MockQuery = orig })
+
+	r := httptest.NewRequest(http.MethodGet, "/control_nomina?fecha=2024-01-01", nil)
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	c := &ControlNominaController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+	c.GetAll()
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+}
+
+func TestControlNomina_GetById_NotFound(t *testing.T) {
+	orig := MockQuery
+	MockQuery = func(_ stdctx.Context, _ string, _ []driver.NamedValue) (driver.Rows, error) {
+		cols := []string{"pk_id_control_nomina", "fecha", "estado"}
+		return &mockRows{columns: cols, values: [][]driver.Value{}}, nil
+	}
+	t.Cleanup(func() { MockQuery = orig })
+
+	r := httptest.NewRequest(http.MethodGet, "/control_nomina/search?id=99", nil)
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	c := &ControlNominaController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+	c.GetById()
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+}


### PR DESCRIPTION
## Summary
- add tests for ControlNominaController fecha filter
- add test for not-found scenario in GetById

## Testing
- `go test ./controllers/controlnomina -cover` *(fails: Get "https://proxy.golang.org/golang.org/x/sys/@v/v0.36.0.zip": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c1c7d85c9c83259eea2f8cf0dcb69a