### PR TITLE
test: cover pago delete error

### DIFF
--- a/controllers/pago/pago_controller_test.go
+++ b/controllers/pago/pago_controller_test.go
@@ -385,6 +385,12 @@ func TestPagoDeleteInvalidID(t *testing.T) {
 }
 
 func TestPagoDeleteNotFound(t *testing.T) {
+	orig := pagoNewOrm
+	pagoNewOrm = func() ormer {
+		return fakeOrmer{delete: func(m interface{}, cols ...string) (int64, error) { return 0, fmt.Errorf("fail") }}
+	}
+	t.Cleanup(func() { pagoNewOrm = orig })
+
 	r := httptest.NewRequest(http.MethodDelete, "/pagos?id=1", nil)
 	w := httptest.NewRecorder()
 	ctx := context.NewContext()
@@ -397,6 +403,9 @@ func TestPagoDeleteNotFound(t *testing.T) {
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "Pago no encontrado") {
+		t.Fatalf("unexpected body: %s", w.Body.String())
 	}
 }
 


### PR DESCRIPTION
## Summary
- ensure PagoController handles delete errors by covering not-found scenario in tests

## Testing
- `go test ./controllers/pago -cover` *(fails: Get "https://proxy.golang.com.cn/golang.org/x/sys/@v/v0.36.0.zip": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c1cad780e88325b44874b5f9378c5c