### PR TITLE
test: cover precio producto hist controllers

### DIFF
--- a/controllers/precioproductohist/precio_producto_hist_controller_test.go
+++ b/controllers/precioproductohist/precio_producto_hist_controller_test.go
@@ -1,18 +1,20 @@
 package precioproductohist
 
 import (
+	stdctx "context"
+	"database/sql/driver"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
-	"github.com/beego/beego/v2/server/web/context"
+	beegoCtx "github.com/beego/beego/v2/server/web/context"
 )
 
 // Usamos el hook pphOrmNew pero no ejecutamos QueryRows (no DB); sólo verificamos códigos en ausencia de datos
 func TestPPH_GetAll_EmptyOK(t *testing.T) {
 	r := httptest.NewRequest(http.MethodGet, "/precio_producto_hist?producto_id=1", nil)
 	w := httptest.NewRecorder()
-	ctx := context.NewContext()
+	ctx := beegoCtx.NewContext()
 	ctx.Reset(w, r)
 	c := &PrecioProductoHistController{}
 	c.Ctx = ctx
@@ -26,13 +28,21 @@ func TestPPH_GetAll_EmptyOK(t *testing.T) {
 func TestPPH_GetById_NotFound(t *testing.T) {
 	r := httptest.NewRequest(http.MethodGet, "/precio_producto_hist/search?id=999", nil)
 	w := httptest.NewRecorder()
-	ctx := context.NewContext()
+	orig := MockQuery
+	MockQuery = func(_ stdctx.Context, _ string, _ []driver.NamedValue) (driver.Rows, error) {
+		cols := []string{"nombre", "estado_producto", "precio", "fecha_vigencia"}
+		// sin valores para forzar orm.ErrNoRows
+		return &mockRows{columns: cols, values: [][]driver.Value{}}, nil
+	}
+	t.Cleanup(func() { MockQuery = orig })
+
+	ctx := beegoCtx.NewContext()
 	ctx.Reset(w, r)
 	c := &PrecioProductoHistController{}
 	c.Ctx = ctx
 	c.Data = make(map[interface{}]interface{})
 	c.GetById()
-	if w.Code != http.StatusOK && w.Code != http.StatusInternalServerError {
+	if w.Code != http.StatusOK {
 		t.Fatalf("unexpected status %d", w.Code)
 	}
 }

--- a/controllers/precioproductohist/precio_producto_hist_success_test.go
+++ b/controllers/precioproductohist/precio_producto_hist_success_test.go
@@ -193,3 +193,45 @@ func TestPPH_GetAll_SuccessWithFecha(t *testing.T) {
 		t.Fatalf("expected 200, got %d", w.Code)
 	}
 }
+
+func TestPPH_GetAll_InvalidFecha(t *testing.T) {
+	orig := MockQuery
+	MockQuery = func(_ stdctx.Context, _ string, _ []driver.NamedValue) (driver.Rows, error) {
+		cols := []string{"nombre", "estado_producto", "precio", "fecha_vigencia"}
+		vals := [][]driver.Value{{"Cafe", "DISPONIBLE", int64(1000), nil}}
+		return &mockRows{columns: cols, values: vals}, nil
+	}
+	t.Cleanup(func() { MockQuery = orig })
+
+	r := httptest.NewRequest(http.MethodGet, "/precio_producto_hist?fecha=invalid", nil)
+	w := httptest.NewRecorder()
+	ctx := beegoCtx.NewContext()
+	ctx.Reset(w, r)
+	c := &PrecioProductoHistController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+	c.GetAll()
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+}
+
+func TestPPH_GetById_DBError(t *testing.T) {
+	orig := MockQuery
+	MockQuery = func(_ stdctx.Context, _ string, _ []driver.NamedValue) (driver.Rows, error) {
+		return nil, driver.ErrBadConn
+	}
+	t.Cleanup(func() { MockQuery = orig })
+
+	r := httptest.NewRequest(http.MethodGet, "/precio_producto_hist/search?id=2", nil)
+	w := httptest.NewRecorder()
+	ctx := beegoCtx.NewContext()
+	ctx.Reset(w, r)
+	c := &PrecioProductoHistController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+	c.GetById()
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+}


### PR DESCRIPTION
## Summary
- improve PrecioProductoHist controller tests to cover missing branches
- add scenarios for invalid fecha and database errors

## Testing
- `go test ./controllers/precioproductohist -cover` *(fails: Get "https://proxy.golang.org/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c1ce708b688325a540de6f3bdf2b7d