### PR TITLE
Increase productopedido controller test coverage

### DIFF
--- a/controllers/productopedido/producto_pedido_post_all_invalid_items_test.go
+++ b/controllers/productopedido/producto_pedido_post_all_invalid_items_test.go
@@ -1,0 +1,40 @@
+package productopedido
+
+import (
+	stdctx "context"
+	"database/sql/driver"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/beego/beego/v2/server/web/context"
+)
+
+// Ensure that Post handles requests where all items are filtered out
+// (e.g., invalid product IDs or non-positive quantities) without failing
+// and skips the inventory validation block.
+func TestProductoPedidoPost_AllInvalidItems(t *testing.T) {
+	origQ := MockQuery
+	// Only the row lock is expected; return a dummy row for any query.
+	MockQuery = func(_ stdctx.Context, _ string, _ []driver.NamedValue) (driver.Rows, error) {
+		return &mockRows{columns: []string{"ok"}, values: [][]driver.Value{{int64(1)}}}, nil
+	}
+	t.Cleanup(func() { MockQuery = origQ })
+
+	body := `{"pedidoId":1,"detalles":[{"productoId":0,"cantidad":2},{"productoId":5,"cantidad":0}]}`
+	r := httptest.NewRequest(http.MethodPost, "/producto_pedido", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	ctx.Input.RequestBody = []byte(body)
+
+	c := ProductoPedidoController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	c.Post()
+	if w.Code != http.StatusCreated && w.Code != http.StatusOK {
+		t.Fatalf("unexpected status %d. Body: %s", w.Code, w.Body.String())
+	}
+}


### PR DESCRIPTION
## Summary
- test productopedido Post when all items are filtered out to cover empty inventory validation path

## Testing
- `go test ./controllers/productopedido -run TestProductoPedidoPost_AllInvalidItems -count=1` *(fails: golang.org/x/sys and golang.org/x/crypto fetch forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d2e72af08325a22cc1066b4451cf