### PR TITLE
Add database error test for restaurant day controller

### DIFF
--- a/controllers/restaurantedia/restaurante_dia_notfound_error_test.go
+++ b/controllers/restaurantedia/restaurante_dia_notfound_error_test.go
@@ -32,6 +32,26 @@ func TestRestauranteDia_GetAll_DBError(t *testing.T) {
 	}
 }
 
+func TestRestauranteDia_GetById_DBError(t *testing.T) {
+	origQ := MockQuery
+	MockQuery = func(_ stdctx.Context, _ string, _ []driver.NamedValue) (driver.Rows, error) {
+		return nil, errors.New("db fail")
+	}
+	t.Cleanup(func() { MockQuery = origQ })
+
+	r := httptest.NewRequest(http.MethodGet, "/restaurante_dia/search?id=1", nil)
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	c := &RestauranteDiaController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+	c.GetById()
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 wrapper with error code, got %d", w.Code)
+	}
+}
+
 func TestRestauranteDia_GetById_NotFound_Explicit(t *testing.T) {
 	origQ := MockQuery
 	MockQuery = func(_ stdctx.Context, q string, _ []driver.NamedValue) (driver.Rows, error) {


### PR DESCRIPTION
## Summary
- test restaurant day GetById database error path for complete coverage

## Testing
- `go test ./controllers/restaurantedia -cover` *(fails: golang.org/x/sys@v0.36.0 zip: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d4824efc8325a0d73ce0c88be3be