### PR TITLE
test: cover GetById DB error

### DIFF
--- a/controllers/trabajador/trabajador_controller_test.go
+++ b/controllers/trabajador/trabajador_controller_test.go
@@ -202,6 +202,17 @@ func TestGetByIdSuccess(t *testing.T) {
 	}
 }
 
+func TestGetByIdDBError(t *testing.T) {
+	original := newTrabajadorOrm
+	newTrabajadorOrm = func() orm.Ormer { return &mockOrm{readErr: errors.New("db")} }
+	defer func() { newTrabajadorOrm = original }()
+	c, w := buildContext(http.MethodGet, "/trabajadores/search?id=1", "")
+	c.GetById()
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("%d", w.Code)
+	}
+}
+
 // Post tests
 func TestPostInvalidJSON(t *testing.T) {
 	c, w := buildContext(http.MethodPost, "/trabajadores", "notjson")


### PR DESCRIPTION
## Summary
- cover `GetById` database error branch in TrabajadorController

## Testing
- `go test ./controllers/trabajador -coverprofile=controllers/trabajador/coverage.out -covermode=atomic` *(fails: golang.org/x/sys v0.36.0 zip forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d56d17948325bec82265db204cc6