### PR TITLE
test: cover non-static path in setStaticHeaders

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -33,20 +33,34 @@ func TestSetStaticHeaders(t *testing.T) {
 }
 
 func TestSetStaticHeaders_StaticPath(t *testing.T) {
-	w := httptest.NewRecorder()
-	r := httptest.NewRequest("GET", "/static/app.js", nil)
-	ctx := context.NewContext()
-	ctx.Reset(w, r)
-	setStaticHeaders(ctx)
-	if got := w.Header().Get("Vary"); got != "Accept-Encoding" {
-		t.Fatalf("expected Vary header to be set, got %q", got)
-	}
+        w := httptest.NewRecorder()
+        r := httptest.NewRequest("GET", "/static/app.js", nil)
+        ctx := context.NewContext()
+        ctx.Reset(w, r)
+        setStaticHeaders(ctx)
+        if got := w.Header().Get("Vary"); got != "Accept-Encoding" {
+                t.Fatalf("expected Vary header to be set, got %q", got)
+        }
+}
+
+func TestSetStaticHeaders_NonStaticPath(t *testing.T) {
+        w := httptest.NewRecorder()
+        r := httptest.NewRequest("GET", "/api/data", nil)
+        ctx := context.NewContext()
+        ctx.Reset(w, r)
+        setStaticHeaders(ctx)
+        if got := w.Header().Get("Cache-Control"); got != "" {
+                t.Fatalf("did not expect Cache-Control header, got %q", got)
+        }
+        if got := w.Header().Get("Vary"); got != "" {
+                t.Fatalf("did not expect Vary header, got %q", got)
+        }
 }
 
 func TestSetStaticHeaders_FilterExecutes(t *testing.T) {
-	os.Setenv("SKIP_WEB_RUN", "1")
-	os.Setenv("SKIP_CRON", "1")
-	t.Cleanup(func() { os.Unsetenv("SKIP_WEB_RUN"); os.Unsetenv("SKIP_CRON") })
+        os.Setenv("SKIP_WEB_RUN", "1")
+        os.Setenv("SKIP_CRON", "1")
+        t.Cleanup(func() { os.Unsetenv("SKIP_WEB_RUN"); os.Unsetenv("SKIP_CRON") })
 
 	initBeegoApp(t)
 	beego.BConfig.RunMode = "dev"


### PR DESCRIPTION
## Summary
- cover non-static request path in setStaticHeaders to boost main.go test coverage

## Testing
- `go test ./... -coverprofile=coverage.out` (fails: Get "https://goproxy.cn/golang.org/x/sys/@v/v0.36.0.zip": Forbidden)

------
https://chatgpt.com/codex/tasks/task_e_68c1dcd4ad2483259d9f9d5399554d43