### PR TITLE
test(productopedido): cover stock exec errors

### DIFF
--- a/controllers/productopedido/producto_pedido_update_stock_exec_error_test.go
+++ b/controllers/productopedido/producto_pedido_update_stock_exec_error_test.go
@@ -1,0 +1,98 @@
+package productopedido
+
+import (
+	stdctx "context"
+	"database/sql/driver"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/beego/beego/v2/server/web/context"
+)
+
+// Cubre la rama de error al ejecutar el descuento de inventario durante Update
+func TestProductoPedidoUpdate_StockUpdateExecError(t *testing.T) {
+	origQ, origE := MockQuery, MockExec
+	MockQuery = func(_ stdctx.Context, q string, _ []driver.NamedValue) (driver.Rows, error) {
+		lower := strings.ToLower(q)
+		switch {
+		case strings.Contains(lower, "detalle_pedido"):
+			// sin detalles actuales para generar delta positivo
+			return &mockRows{columns: []string{"pk_id_pedido"}, values: [][]driver.Value{}}, nil
+		case strings.Contains(lower, "select pk_id_producto, cantidad from producto"):
+			cols := []string{"pk_id_producto", "cantidad"}
+			vals := [][]driver.Value{{int64(1), int64(10)}}
+			return &mockRows{columns: cols, values: vals}, nil
+		default:
+			return &mockRows{columns: []string{"ok"}, values: [][]driver.Value{{int64(1)}}}, nil
+		}
+	}
+	MockExec = func(_ stdctx.Context, q string, _ []driver.NamedValue) (driver.Result, error) {
+		if strings.Contains(strings.ToLower(q), "update producto set cantidad = cantidad -") {
+			return nil, errors.New("exec fail")
+		}
+		return mockResult{}, nil
+	}
+	t.Cleanup(func() { MockQuery, MockExec = origQ, origE })
+
+	body := `[{"productoId":1,"cantidad":2}]`
+	r := httptest.NewRequest(http.MethodPut, "/producto_pedido?pedido_id=1", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	ctx.Input.RequestBody = []byte(body)
+
+	c := ProductoPedidoController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	c.Update()
+	if w.Code != http.StatusInternalServerError && w.Code != http.StatusOK {
+		t.Fatalf("expected 500 or 200, got %d. Body: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "Error al descontar inventario") {
+		t.Fatalf("unexpected body: %s", w.Body.String())
+	}
+}
+
+// Cubre la rama de error al restaurar inventario cuando el delta es negativo
+func TestProductoPedidoUpdate_StockRestoreExecError(t *testing.T) {
+	origQ, origE := MockQuery, MockExec
+	MockQuery = func(_ stdctx.Context, q string, _ []driver.NamedValue) (driver.Rows, error) {
+		lower := strings.ToLower(q)
+		if strings.Contains(lower, "detalle_pedido") {
+			cols := []string{"pk_id_detalle", "pk_id_pedido", "pk_id_producto", "cantidad", "precio"}
+			vals := [][]driver.Value{{int64(1), int64(1), int64(1), int64(2), int64(1000)}}
+			return &mockRows{columns: cols, values: vals}, nil
+		}
+		return &mockRows{columns: []string{"ok"}, values: [][]driver.Value{{int64(1)}}}, nil
+	}
+	MockExec = func(_ stdctx.Context, q string, _ []driver.NamedValue) (driver.Result, error) {
+		if strings.Contains(strings.ToLower(q), "update producto set cantidad = cantidad +") {
+			return nil, errors.New("exec fail")
+		}
+		return mockResult{}, nil
+	}
+	t.Cleanup(func() { MockQuery, MockExec = origQ, origE })
+
+	body := `[{"productoId":1,"cantidad":1}]`
+	r := httptest.NewRequest(http.MethodPut, "/producto_pedido?pedido_id=1", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	ctx.Input.RequestBody = []byte(body)
+
+	c := ProductoPedidoController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	c.Update()
+	if w.Code != http.StatusInternalServerError && w.Code != http.StatusOK {
+		t.Fatalf("expected 500 or 200, got %d. Body: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "Error al ajustar inventario") {
+		t.Fatalf("unexpected body: %s", w.Body.String())
+	}
+}


### PR DESCRIPTION
## Summary
- add tests for inventory decrement execution errors in ProductoPedido Update
- add tests for inventory restore execution errors in ProductoPedido Update

## Testing
- `GOPROXY=direct go test ./controllers/productopedido -cover` *(fails: unrecognized import path "golang.org/x/sys")*

------
https://chatgpt.com/codex/tasks/task_e_68c1e582c2408325ba50042185a67401