### PR TITLE
Aumentar cobertura de producto_pedido

### DIFF
--- a/controllers/productopedido/producto_pedido_post_insert_detalle_error_test.go
+++ b/controllers/productopedido/producto_pedido_post_insert_detalle_error_test.go
@@ -1,0 +1,50 @@
+package productopedido
+
+import (
+	stdctx "context"
+	"database/sql/driver"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/beego/beego/v2/server/web/context"
+)
+
+// Cubre la rama de error al insertar el detalle en Post
+func TestProductoPedidoPost_InsertDetalleError(t *testing.T) {
+	origQ, origE := MockQuery, MockExec
+	MockQuery = func(_ stdctx.Context, q string, _ []driver.NamedValue) (driver.Rows, error) {
+		lower := strings.ToLower(q)
+		switch {
+		case strings.Contains(lower, "select pk_id_producto, cantidad from producto"):
+			cols := []string{"pk_id_producto", "cantidad"}
+			vals := [][]driver.Value{{int64(1), int64(10)}}
+			return &mockRows{columns: cols, values: vals}, nil
+		case strings.Contains(lower, "insert into") && strings.Contains(lower, "detalle_pedido"):
+			return nil, errors.New("insert fail")
+		default:
+			return &mockRows{columns: []string{"ok"}, values: [][]driver.Value{{int64(1)}}}, nil
+		}
+	}
+	MockExec = func(_ stdctx.Context, _ string, _ []driver.NamedValue) (driver.Result, error) {
+		return mockResult{}, nil
+	}
+	t.Cleanup(func() { MockQuery, MockExec = origQ, origE })
+
+	body := `{"pedidoId":1,"detalles":[{"productoId":1,"cantidad":2}]}`
+	r := httptest.NewRequest(http.MethodPost, "/producto_pedido", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	ctx.Input.RequestBody = []byte(body)
+	c := ProductoPedidoController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	c.Post()
+	if !strings.Contains(w.Body.String(), "Error al crear el pedido con productos") {
+		t.Fatalf("expected insert detalle error, body: %s", w.Body.String())
+	}
+}

--- a/controllers/productopedido/producto_pedido_update_insert_detalle_error_test.go
+++ b/controllers/productopedido/producto_pedido_update_insert_detalle_error_test.go
@@ -1,0 +1,52 @@
+package productopedido
+
+import (
+	stdctx "context"
+	"database/sql/driver"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/beego/beego/v2/server/web/context"
+)
+
+// Cubre la rama de error al insertar el detalle en Update
+func TestProductoPedidoUpdate_InsertDetalleError(t *testing.T) {
+	origQ, origE := MockQuery, MockExec
+	MockQuery = func(_ stdctx.Context, q string, _ []driver.NamedValue) (driver.Rows, error) {
+		lower := strings.ToLower(q)
+		switch {
+		case strings.Contains(lower, "select pk_id_producto, cantidad from producto"):
+			cols := []string{"pk_id_producto", "cantidad"}
+			vals := [][]driver.Value{{int64(1), int64(10)}}
+			return &mockRows{columns: cols, values: vals}, nil
+		case strings.Contains(lower, "insert into") && strings.Contains(lower, "detalle_pedido"):
+			return nil, errors.New("insert fail")
+		case strings.Contains(lower, "from detalle_pedido"):
+			return &mockRows{columns: []string{"pk_id_pedido"}, values: [][]driver.Value{}}, nil
+		default:
+			return &mockRows{columns: []string{"ok"}, values: [][]driver.Value{{int64(1)}}}, nil
+		}
+	}
+	MockExec = func(_ stdctx.Context, _ string, _ []driver.NamedValue) (driver.Result, error) {
+		return mockResult{}, nil
+	}
+	t.Cleanup(func() { MockQuery, MockExec = origQ, origE })
+
+	body := `[{"productoId":1,"cantidad":2}]`
+	r := httptest.NewRequest(http.MethodPut, "/producto_pedido?pedido_id=1", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	ctx.Input.RequestBody = []byte(body)
+	c := ProductoPedidoController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	c.Update()
+	if !strings.Contains(w.Body.String(), "Error al actualizar los productos del pedido") {
+		t.Fatalf("expected insert detalle error, body: %s", w.Body.String())
+	}
+}


### PR DESCRIPTION
## Summary
- Add tests for insert detail errors on create and update of producto_pedido

## Testing
- `go test -run TestProductoPedidoPost_InsertDetalleError ./controllers/productopedido` *(fails: Get "https://proxy.golang.org/...": Forbidden)*
- `go test -run TestProductoPedidoUpdate_InsertDetalleError ./controllers/productopedido` *(fails: Get "https://proxy.golang.org/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c1e708edc08325bc8705238bef5f7d