### PR TITLE
Add test for reserva contacto ErrNoRows case

### DIFF
--- a/controllers/reservacontacto/reserva_contacto_controller_test.go
+++ b/controllers/reservacontacto/reserva_contacto_controller_test.go
@@ -104,6 +104,26 @@ func TestReservaContacto_GetById_NotFound(t *testing.T) {
 	}
 }
 
+func TestReservaContacto_GetById_NoRows(t *testing.T) {
+	orig := resContactoOrmNew
+	resContactoOrmNew = func() resContactoOrmer {
+		return fakeResContactoOrm{qs: fakeResContactoQS{oneErr: orm.ErrNoRows}}
+	}
+	t.Cleanup(func() { resContactoOrmNew = orig })
+
+	r := httptest.NewRequest(http.MethodGet, "/reserva_contacto/search?id=1", nil)
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	c := &ReservaContactoController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+	c.GetById()
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+}
+
 func TestReservaContacto_GetById_Success(t *testing.T) {
 	orig := resContactoOrmNew
 	resContactoOrmNew = func() resContactoOrmer {


### PR DESCRIPTION
## Summary
- add coverage for case when GetById returns orm.ErrNoRows

## Testing
- `GOPROXY=https://goproxy.cn,direct go test ./controllers/reservacontacto -coverprofile=coverage.out` *(fails: google.golang.org/protobuf@v1.36.9: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c1f591a0588325a6c7fc3e28581c1e