### PR TITLE
test: expand producto controller coverage

### DIFF
--- a/controllers/producto/producto_controller_test.go
+++ b/controllers/producto/producto_controller_test.go
@@ -451,6 +451,32 @@ func TestProductoPostMultipartInvalidNumericFields(t *testing.T) {
 	}
 }
 
+func TestProductoPostRawExecError(t *testing.T) {
+	savedOrm := ormNewProducto
+	ormNewProducto = func() orm.Ormer { return newExecErrOrmer("mockErrExecPost") }
+	t.Cleanup(func() { ormNewProducto = savedOrm })
+
+	body := bytes.NewBufferString(`{"nombre":"A","estadoProducto":"DISPONIBLE","precio":10}`)
+	r := httptest.NewRequest(http.MethodPost, "/productos", body)
+	r.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	ctx.Input.RequestBody = body.Bytes()
+	c := ProductoController{Ctx: ctx, Data: make(map[interface{}]interface{})}
+
+	savedInsert := insertProductoFn
+	savedHist := insertPrecioHistFn
+	insertProductoFn = func(o orm.Ormer, p *models.Producto) (int64, error) { return 1, nil }
+	insertPrecioHistFn = func(o orm.Ormer, h *models.PrecioProductoHist) (int64, error) { return 1, nil }
+	t.Cleanup(func() { insertProductoFn = savedInsert; insertPrecioHistFn = savedHist })
+
+	c.Post()
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected status 201, got %d", w.Code)
+	}
+}
+
 // PUT cases
 func TestProductoPutInvalidID(t *testing.T) {
 	r := httptest.NewRequest(http.MethodPut, "/productos", nil)
@@ -681,6 +707,38 @@ func TestProductoPutPriceChangeHistError_JSON(t *testing.T) {
 	c.Put()
 	if w.Code != http.StatusInternalServerError {
 		t.Fatalf("expected status 500, got %d", w.Code)
+	}
+}
+
+func TestProductoPutRawExecError(t *testing.T) {
+	savedOrm := ormNewProducto
+	ormNewProducto = func() orm.Ormer { return newExecErrOrmer("mockErrExecPut") }
+	t.Cleanup(func() { ormNewProducto = savedOrm })
+
+	body := `{"nombre":"B","precio":11,"estadoProducto":"DISPONIBLE"}`
+	r := httptest.NewRequest(http.MethodPut, "/productos?id=1", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	ctx.Input.RequestBody = []byte(body)
+	c := ProductoController{Ctx: ctx, Data: make(map[interface{}]interface{})}
+
+	origRead := readProductoFn
+	origUpdate := updateProductoFn
+	origHist := insertPrecioHistFn
+	readProductoFn = func(o orm.Ormer, p *models.Producto) error {
+		p.NOMBRE = "A"
+		p.PRECIO = 10
+		p.ESTADO_PRODUCTO = models.EstadoProductoDisponible
+		return nil
+	}
+	updateProductoFn = func(o orm.Ormer, p *models.Producto, cols ...string) (int64, error) { return 1, nil }
+	insertPrecioHistFn = func(o orm.Ormer, h *models.PrecioProductoHist) (int64, error) { return 1, nil }
+	t.Cleanup(func() { readProductoFn = origRead; updateProductoFn = origUpdate; insertPrecioHistFn = origHist })
+
+	c.Put()
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
 	}
 }
 
@@ -963,6 +1021,26 @@ func TestProductoDeleteNotFound(t *testing.T) {
 	}
 	if !strings.Contains(w.Body.String(), "producto no encontrado") && !strings.Contains(strings.ToLower(w.Body.String()), "no encontrado") {
 		t.Fatalf("unexpected body: %s", w.Body.String())
+	}
+}
+
+func TestProductoDeleteReadError(t *testing.T) {
+	r := httptest.NewRequest(http.MethodDelete, "/productos?id=1", nil)
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	c := ProductoController{Ctx: ctx, Data: make(map[interface{}]interface{})}
+
+	savedRead := readProductoFn
+	readProductoFn = func(o orm.Ormer, p *models.Producto) error { return errors.New("db err") }
+	t.Cleanup(func() { readProductoFn = savedRead })
+
+	c.Delete()
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+	if !strings.Contains(strings.ToLower(w.Body.String()), "error al buscar el producto") {
+		t.Errorf("unexpected body: %s", w.Body.String())
 	}
 }
 

--- a/controllers/producto/test_helpers_test.go
+++ b/controllers/producto/test_helpers_test.go
@@ -3,6 +3,7 @@ package producto
 import (
 	"database/sql"
 	"database/sql/driver"
+	"errors"
 	"io"
 	"os"
 	"testing"
@@ -25,6 +26,11 @@ type mockRows struct {
 	values  [][]driver.Value
 	idx     int
 }
+
+type execErrDriver struct{}
+type execErrConn struct{}
+type execErrStmt struct{}
+type execErrTx struct{}
 
 func (d mockDriver) Open(name string) (driver.Conn, error) { return &mockConn{}, nil }
 
@@ -57,6 +63,29 @@ func (r *mockRows) Next(dest []driver.Value) error {
 	}
 	r.idx++
 	return nil
+}
+
+func (d execErrDriver) Open(name string) (driver.Conn, error)    { return &execErrConn{}, nil }
+func (c *execErrConn) Prepare(query string) (driver.Stmt, error) { return &execErrStmt{}, nil }
+func (c *execErrConn) Close() error                              { return nil }
+func (c *execErrConn) Begin() (driver.Tx, error)                 { return &execErrTx{}, nil }
+func (s *execErrStmt) Close() error                              { return nil }
+func (s *execErrStmt) NumInput() int                             { return -1 }
+func (s *execErrStmt) Exec(args []driver.Value) (driver.Result, error) {
+	return nil, errors.New("exec fail")
+}
+func (s *execErrStmt) Query(args []driver.Value) (driver.Rows, error) {
+	return &mockRows{columns: []string{"ok"}, values: [][]driver.Value{{int64(1)}}}, nil
+}
+func (execErrTx) Commit() error   { return nil }
+func (execErrTx) Rollback() error { return nil }
+
+func newExecErrOrmer(alias string) orm.Ormer {
+	sql.Register(alias, execErrDriver{})
+	orm.RegisterDriver(alias, orm.DRPostgres)
+	_ = orm.RegisterDataBase(alias, alias, "")
+	o, _ := orm.NewOrmUsingDB(alias)
+	return o
 }
 
 func TestMain(m *testing.M) {


### PR DESCRIPTION
## Summary
- add helper ormer returning exec errors for raw queries
- cover producto controller branches for raw exec errors and DB read failures

## Testing
- `go test ./controllers/producto -cover` *(fails: unrecognized import path "google.golang.org/protobuf" - Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c2010361a48325ab19b862446b10cc