### PR TITLE
test: cover default getSQLPinger

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -432,6 +432,16 @@ type fakePinger struct{ err error }
 
 func (f fakePinger) Ping() error { return f.err }
 
+func TestGetSQLPinger_Default(t *testing.T) {
+	db, err := getSQLPinger()
+	if err == nil {
+		t.Fatalf("expected error when no default DB alias is registered")
+	}
+	if db != nil {
+		t.Fatalf("expected nil DB without default alias")
+	}
+}
+
 func TestReadyz_OK(t *testing.T) {
 	os.Setenv("SKIP_WEB_RUN", "1")
 	os.Setenv("SKIP_CRON", "1")


### PR DESCRIPTION
## Summary
- ensure default getSQLPinger uses database connection

## Testing
- `go test ./...` *(fails: unrecognized import path "google.golang.org/protobuf": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c221896e40832584745b160f7c826e