### PR TITLE
test: cover invalid params for reserva contacto

### DIFF
--- a/controllers/reservacontacto/reserva_contacto_controller_test.go
+++ b/controllers/reservacontacto/reserva_contacto_controller_test.go
@@ -84,6 +84,26 @@ func TestReservaContacto_GetAll_Error(t *testing.T) {
 	}
 }
 
+func TestReservaContacto_GetAll_InvalidParams(t *testing.T) {
+	orig := resContactoOrmNew
+	resContactoOrmNew = func() resContactoOrmer {
+		return fakeResContactoOrm{qs: fakeResContactoQS{data: []models.ReservaContacto{{PKIDContacto: 1}}}}
+	}
+	t.Cleanup(func() { resContactoOrmNew = orig })
+
+	r := httptest.NewRequest(http.MethodGet, "/reserva_contacto?documento_contacto=abc&documento_cliente=xyz", nil)
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	c := &ReservaContactoController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+	c.GetAll()
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+}
+
 func TestReservaContacto_GetById_NotFound(t *testing.T) {
 	orig := resContactoOrmNew
 	resContactoOrmNew = func() resContactoOrmer {
@@ -132,6 +152,26 @@ func TestReservaContacto_GetById_Success(t *testing.T) {
 	t.Cleanup(func() { resContactoOrmNew = orig })
 
 	r := httptest.NewRequest(http.MethodGet, "/reserva_contacto/search?id=1", nil)
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	c := &ReservaContactoController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+	c.GetById()
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+}
+
+func TestReservaContacto_GetById_InvalidID(t *testing.T) {
+	orig := resContactoOrmNew
+	resContactoOrmNew = func() resContactoOrmer {
+		return fakeResContactoOrm{qs: fakeResContactoQS{oneErr: orm.ErrNoRows}}
+	}
+	t.Cleanup(func() { resContactoOrmNew = orig })
+
+	r := httptest.NewRequest(http.MethodGet, "/reserva_contacto/search?id=abc", nil)
 	w := httptest.NewRecorder()
 	ctx := context.NewContext()
 	ctx.Reset(w, r)


### PR DESCRIPTION
## Summary
- add test for invalid reserva contacto query parameters
- add test for invalid reserva contacto id

## Testing
- `go test ./controllers/reservacontacto -cover` *(fails: Get "https://proxy.golang.org/google.golang.org/protobuf/@v/v1.36.9.zip": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c230dcf5b08325be5825e769fb31d7