### PR TITLE
Add tests for product controller edge cases

### DIFF
--- a/controllers/producto/ProductoController.go
+++ b/controllers/producto/ProductoController.go
@@ -105,10 +105,14 @@ func (c *ProductoController) GetById() {
 	if err != nil || id == 0 {
 		logging.LogControllerError(c.Ctx, "productos.getbyid.bad_request", err, map[string]interface{}{"id": c.GetString("id")})
 		c.Ctx.Output.SetStatus(http.StatusBadRequest)
+		cause := ""
+		if err != nil {
+			cause = err.Error()
+		}
 		c.Data["json"] = models.ApiResponse{
 			Code:    http.StatusBadRequest,
 			Message: "El parámetro 'id' es inválido o está ausente",
-			Cause:   err.Error(),
+			Cause:   cause,
 		}
 		_ = c.ServeJSON()
 		return

--- a/controllers/producto/producto_controller_test.go
+++ b/controllers/producto/producto_controller_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"restaurante/models"
 
@@ -91,8 +92,48 @@ func TestProductoGetAllSuccessFiltersImage(t *testing.T) {
 	}
 }
 
+func TestProductoGetAllDBErrorIncludeImageTrue(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/restaurante/v1/productos?includeImage=true", nil)
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	ctx.Request.ParseMultipartForm(32 << 20)
+	c := ProductoController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	saved := queryProductosAll
+	queryProductosAll = func(o orm.Ormer, onlyActive bool, productos *[]models.Producto) (int64, error) {
+		return 0, errors.New("db error")
+	}
+	t.Cleanup(func() { queryProductosAll = saved })
+
+	c.GetAll()
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected status 500, got %d", w.Code)
+	}
+}
+
 func TestProductoGetByIdInvalidID(t *testing.T) {
 	r := httptest.NewRequest(http.MethodGet, "/productos/search", nil)
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	ctx.Request.ParseMultipartForm(32 << 20)
+	c := ProductoController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+
+	c.GetById()
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d", w.Code)
+	}
+}
+
+func TestProductoGetByIdZeroID(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/productos/search?id=0", nil)
 	w := httptest.NewRecorder()
 	ctx := context.NewContext()
 	ctx.Reset(w, r)
@@ -1097,5 +1138,47 @@ func TestProductoGetAllIncludeImageTrue(t *testing.T) {
 	}
 	if !strings.Contains(w.Body.String(), "\"imagen\":\"") {
 		t.Errorf("expected image field present: %s", w.Body.String())
+	}
+}
+func TestQueryProductosAllWrapper(t *testing.T) {
+	o := ormNewProducto()
+	var productos []models.Producto
+	if _, err := queryProductosAll(o, false, &productos); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, err := queryProductosAll(o, true, &productos); err != nil {
+		t.Fatalf("unexpected error with filter: %v", err)
+	}
+}
+
+func TestOrmWrapperFunctions(t *testing.T) {
+	o := ormNewProducto()
+	// read
+	if err := readProductoFn(o, &models.Producto{PK_ID_PRODUCTO: 1}); err != nil && err != orm.ErrNoRows {
+		t.Fatalf("readProductoFn returned unexpected error: %v", err)
+	}
+	// insert product
+	p := &models.Producto{
+		NOMBRE:             "A",
+		PRECIO:             10,
+		ESTADO_PRODUCTO:    models.EstadoProductoDisponible,
+		CANTIDAD:           1,
+		PK_ID_SUBCATEGORIA: &models.Subcategoria{PK_ID_SUBCATEGORIA: 1},
+	}
+	if _, err := insertProductoFn(o, p); err != nil {
+		t.Fatalf("insertProductoFn returned error: %v", err)
+	}
+	// insert price history
+	h := &models.PrecioProductoHist{
+		PKIDProducto:  p,
+		Precio:        10,
+		FechaVigencia: time.Now(),
+	}
+	if _, err := insertPrecioHistFn(o, h); err != nil {
+		t.Fatalf("insertPrecioHistFn returned error: %v", err)
+	}
+	// update product
+	if _, err := updateProductoFn(o, p, "NOMBRE"); err != nil {
+		t.Fatalf("updateProductoFn returned error: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- add test for database error when GetAll is requested with images
- cover GetById when id is zero
- avoid panic in GetById when the id parameter is missing or zero
- exercise queryProductosAll and ORM helper functions for read/insert/update operations

## Testing
- `GOPROXY=direct go test ./controllers/producto -coverprofile=coverage.out` *(fails: unrecognized import path "google.golang.org/protobuf": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c2332535e08325ac7f5a2874651d73