### PR TITLE
feat: ensure hash error branch coverage

### DIFF
--- a/controllers/trabajador/TrabajadorController.go
+++ b/controllers/trabajador/TrabajadorController.go
@@ -22,9 +22,12 @@ type TrabajadorController struct {
 	web.Controller
 }
 
+// generateFromPassword allows tests to stub bcrypt.GenerateFromPassword.
+var generateFromPassword = bcrypt.GenerateFromPassword
+
 // hashPassword allows tests to stub the hash function.
 var hashPassword = func(password string) (string, error) {
-	hashedPassword, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
+	hashedPassword, err := generateFromPassword([]byte(password), bcrypt.DefaultCost)
 	if err != nil {
 		return "", err
 	}

--- a/controllers/trabajador/trabajador_controller_test.go
+++ b/controllers/trabajador/trabajador_controller_test.go
@@ -104,6 +104,15 @@ func TestHashPassword(t *testing.T) {
 	}
 }
 
+func TestHashPasswordError(t *testing.T) {
+	original := generateFromPassword
+	generateFromPassword = func([]byte, int) ([]byte, error) { return nil, errors.New("fail") }
+	defer func() { generateFromPassword = original }()
+	if _, err := hashPassword("secret"); err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
 func TestValidateDates(t *testing.T) {
 	ingreso := time.Now()
 	retiroAntes := ingreso.Add(-time.Hour)


### PR DESCRIPTION
## Summary
- make password hashing pluggable for tests
- cover password hashing error scenario

## Testing
- `golangci-lint run` *(fails: the Go language version (go1.24) used to build golangci-lint is lower than the targeted Go version (1.25.0))*
- `powershell -ExecutionPolicy Bypass -File tools/cover.ps1 -Clean` *(fails: powershell: command not found)*
- `go test ./controllers/trabajador -cover` *(fails: Get "https://proxy.golang.org/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c3384e53bc8325acd8391d5ecc692e