### PR TITLE
test: cover invalid JSON branch in subcategoria controller

### DIFF
--- a/controllers/subcategoria/subcategoria_put_badjson_test.go
+++ b/controllers/subcategoria/subcategoria_put_badjson_test.go
@@ -1,0 +1,33 @@
+package subcategoria
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/beego/beego/v2/server/web/context"
+	"restaurante/models"
+)
+
+// Cubre la rama de JSON inválido en el método Put
+func TestSubcategoriaController_Put_BadJSON(t *testing.T) {
+	m := newSubMockOrm()
+	m.Insert(&models.Subcategoria{NOMBRE: "X"})
+	orig := subcatOrmNew
+	subcatOrmNew = func() subcatOrmer { return m }
+	t.Cleanup(func() { subcatOrmNew = orig })
+
+	r := httptest.NewRequest(http.MethodPut, "/subcategorias?id=1", strings.NewReader("bad"))
+	w := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(w, r)
+	ctx.Input.RequestBody = []byte("bad")
+	c := &SubcategoriaController{}
+	c.Ctx = ctx
+	c.Data = make(map[interface{}]interface{})
+	c.Put()
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}


### PR DESCRIPTION
## Summary
- add test for invalid JSON in subcategoria PUT

## Testing
- `gofmt -s -w .`
- `golangci-lint run` *(fails: the Go language version (go1.24) used to build golangci-lint is lower than the targeted Go version (1.25.0))*
- `powershell -ExecutionPolicy Bypass -File tools/cover.ps1 -Clean` *(fails: command not found)*
- `GOPROXY=direct go test ./controllers/subcategoria -cover` *(fails: unable to access required modules: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c33af79a608325b8bfac8d8443f500