### PR TITLE
test(productopedido): cover update error branches

### DIFF
--- a/controllers/productopedido/producto_pedido_update_commit_error_message_test.go
+++ b/controllers/productopedido/producto_pedido_update_commit_error_message_test.go
@@ -1,0 +1,92 @@
+package productopedido
+
+import (
+    stdctx "context"
+    "database/sql/driver"
+    "encoding/json"
+    "errors"
+    "net/http"
+    "net/http/httptest"
+    "strings"
+    "testing"
+
+    "restaurante/models"
+
+    "github.com/beego/beego/v2/client/orm"
+    "github.com/beego/beego/v2/server/web/context"
+)
+
+// Cubre la rama de error en tx.Commit durante Update validando el mensaje
+func TestProductoPedidoUpdate_CommitError_Message(t *testing.T) {
+    origQ, origE := MockQuery, MockExec
+    origDel := productoPedidoDeleteDetalles
+    origReq := productoPedidoRequeryDetalle
+    origBegin := productoPedidoBeginTx
+
+    // consultas necesarias para pasar hasta commit
+    step := 0
+    MockQuery = func(_ stdctx.Context, q string, _ []driver.NamedValue) (driver.Rows, error) {
+        lower := strings.ToLower(q)
+        if strings.Contains(lower, "detalle_pedido") {
+            if step == 0 {
+                step++
+                return &mockRows{columns: []string{"pk_id_pedido"}, values: [][]driver.Value{}}, nil
+            }
+            cols := []string{"pk_id_detalle", "pk_id_pedido", "pk_id_producto", "cantidad", "precio"}
+            vals := [][]driver.Value{{int64(1), int64(1), int64(1), int64(2), int64(1000)}}
+            return &mockRows{columns: cols, values: vals}, nil
+        }
+        if strings.Contains(lower, "select pk_id_producto, cantidad from producto") {
+            cols := []string{"pk_id_producto", "cantidad"}
+            vals := [][]driver.Value{{int64(1), int64(10)}}
+            return &mockRows{columns: cols, values: vals}, nil
+        }
+        return &mockRows{columns: []string{"ok"}, values: [][]driver.Value{{int64(1)}}}, nil
+    }
+    MockExec = func(_ stdctx.Context, _ string, _ []driver.NamedValue) (driver.Result, error) {
+        return mockResult{}, nil
+    }
+    productoPedidoDeleteDetalles = func(_ orm.TxOrmer, _ int64) error { return nil }
+    productoPedidoRequeryDetalle = func(_ orm.TxOrmer, pedidoID int64, productoID int64, out *models.DetallePedido) error {
+        *out = models.DetallePedido{PKIDPedido: &models.Pedido{PK_ID_PEDIDO: pedidoID}, PKIDProducto: &models.Producto{PK_ID_PRODUCTO: productoID}, Cantidad: 2, Precio: 1000}
+        return nil
+    }
+    productoPedidoBeginTx = func(o orm.Ormer) (orm.TxOrmer, error) {
+        baseTx, err := o.Begin()
+        if err != nil {
+            return nil, err
+        }
+        return commitFailTx{TxOrmer: baseTx}, nil
+    }
+
+    t.Cleanup(func() {
+        MockQuery, MockExec = origQ, origE
+        productoPedidoDeleteDetalles = origDel
+        productoPedidoRequeryDetalle = origReq
+        productoPedidoBeginTx = origBegin
+    })
+
+    body := `[{"productoId":1,"cantidad":2}]`
+    r := httptest.NewRequest(http.MethodPut, "/producto_pedido?pedido_id=1", strings.NewReader(body))
+    w := httptest.NewRecorder()
+    ctx := context.NewContext()
+    ctx.Reset(w, r)
+    ctx.Input.RequestBody = []byte(body)
+
+    c := &ProductoPedidoController{}
+    c.Ctx = ctx
+    c.Data = make(map[interface{}]interface{})
+
+    c.Update()
+    if w.Code != http.StatusInternalServerError {
+        t.Fatalf("expected 500, got %d. Body: %s", w.Code, w.Body.String())
+    }
+    var resp models.ApiResponse
+    if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+        t.Fatalf("invalid response: %v", err)
+    }
+    if resp.Message != "No fue posible confirmar transacción" {
+        t.Fatalf("unexpected message: %s", resp.Message)
+    }
+}
+

--- a/controllers/productopedido/producto_pedido_update_delete_detalles_error_branch_test.go
+++ b/controllers/productopedido/producto_pedido_update_delete_detalles_error_branch_test.go
@@ -1,0 +1,73 @@
+package productopedido
+
+import (
+    stdctx "context"
+    "database/sql/driver"
+    "encoding/json"
+    "errors"
+    "net/http"
+    "net/http/httptest"
+    "strings"
+    "testing"
+
+    "restaurante/models"
+
+    "github.com/beego/beego/v2/client/orm"
+    "github.com/beego/beego/v2/server/web/context"
+)
+
+// Cubre la rama de error en productoPedidoDeleteDetalles durante Update
+func TestProductoPedidoUpdate_DeleteDetallesError(t *testing.T) {
+    origQ, origE := MockQuery, MockExec
+    origDel := productoPedidoDeleteDetalles
+    origReq := productoPedidoRequeryDetalle
+
+    // actuales vacíos, inventario suficiente
+    MockQuery = func(_ stdctx.Context, q string, _ []driver.NamedValue) (driver.Rows, error) {
+        lower := strings.ToLower(q)
+        if strings.Contains(lower, "detalle_pedido") && !strings.Contains(lower, "insert into") {
+            return &mockRows{columns: []string{"pk_id_pedido"}, values: [][]driver.Value{}}, nil
+        }
+        if strings.Contains(lower, "select pk_id_producto, cantidad from producto") {
+            cols := []string{"pk_id_producto", "cantidad"}
+            vals := [][]driver.Value{{int64(1), int64(10)}}
+            return &mockRows{columns: cols, values: vals}, nil
+        }
+        return &mockRows{columns: []string{"ok"}, values: [][]driver.Value{{int64(1)}}}, nil
+    }
+    MockExec = func(_ stdctx.Context, _ string, _ []driver.NamedValue) (driver.Result, error) {
+        return mockResult{}, nil
+    }
+    productoPedidoDeleteDetalles = func(_ orm.TxOrmer, _ int64) error { return errors.New("delete fail") }
+    productoPedidoRequeryDetalle = func(_ orm.TxOrmer, _ int64, _ int64, _ *models.DetallePedido) error { return nil }
+
+    t.Cleanup(func() {
+        MockQuery, MockExec = origQ, origE
+        productoPedidoDeleteDetalles = origDel
+        productoPedidoRequeryDetalle = origReq
+    })
+
+    body := `[{"productoId":1,"cantidad":2}]`
+    r := httptest.NewRequest(http.MethodPut, "/producto_pedido?pedido_id=1", strings.NewReader(body))
+    w := httptest.NewRecorder()
+    ctx := context.NewContext()
+    ctx.Reset(w, r)
+    ctx.Input.RequestBody = []byte(body)
+
+    c := &ProductoPedidoController{}
+    c.Ctx = ctx
+    c.Data = make(map[interface{}]interface{})
+
+    c.Update()
+    if w.Code != http.StatusInternalServerError {
+        t.Fatalf("expected 500, got %d. Body: %s", w.Code, w.Body.String())
+    }
+    var resp models.ApiResponse
+    if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+        t.Fatalf("invalid response: %v", err)
+    }
+    if resp.Message != "Error al actualizar los productos del pedido" {
+        t.Fatalf("unexpected message: %s", resp.Message)
+    }
+}
+

--- a/controllers/productopedido/producto_pedido_update_insert_detalle_error_message_test.go
+++ b/controllers/productopedido/producto_pedido_update_insert_detalle_error_message_test.go
@@ -1,0 +1,75 @@
+package productopedido
+
+import (
+    stdctx "context"
+    "database/sql/driver"
+    "encoding/json"
+    "errors"
+    "net/http"
+    "net/http/httptest"
+    "strings"
+    "testing"
+
+    "restaurante/models"
+
+    "github.com/beego/beego/v2/client/orm"
+    "github.com/beego/beego/v2/server/web/context"
+)
+
+// Cubre la rama de error al insertar el detalle en Update validando el mensaje
+func TestProductoPedidoUpdate_InsertDetalleError_Message(t *testing.T) {
+    origQ, origE := MockQuery, MockExec
+    origDel := productoPedidoDeleteDetalles
+    origReq := productoPedidoRequeryDetalle
+
+    MockQuery = func(_ stdctx.Context, q string, _ []driver.NamedValue) (driver.Rows, error) {
+        lower := strings.ToLower(q)
+        switch {
+        case strings.Contains(lower, "select pk_id_producto, cantidad from producto"):
+            cols := []string{"pk_id_producto", "cantidad"}
+            vals := [][]driver.Value{{int64(1), int64(10)}}
+            return &mockRows{columns: cols, values: vals}, nil
+        case strings.Contains(lower, "insert into") && strings.Contains(lower, "detalle_pedido"):
+            return nil, errors.New("insert fail")
+        case strings.Contains(lower, "from detalle_pedido"):
+            return &mockRows{columns: []string{"pk_id_pedido"}, values: [][]driver.Value{}}, nil
+        default:
+            return &mockRows{columns: []string{"ok"}, values: [][]driver.Value{{int64(1)}}}, nil
+        }
+    }
+    MockExec = func(_ stdctx.Context, _ string, _ []driver.NamedValue) (driver.Result, error) {
+        return mockResult{}, nil
+    }
+    productoPedidoDeleteDetalles = func(_ orm.TxOrmer, _ int64) error { return nil }
+    productoPedidoRequeryDetalle = func(_ orm.TxOrmer, _ int64, _ int64, _ *models.DetallePedido) error { return nil }
+
+    t.Cleanup(func() {
+        MockQuery, MockExec = origQ, origE
+        productoPedidoDeleteDetalles = origDel
+        productoPedidoRequeryDetalle = origReq
+    })
+
+    body := `[{"productoId":1,"cantidad":2}]`
+    r := httptest.NewRequest(http.MethodPut, "/producto_pedido?pedido_id=1", strings.NewReader(body))
+    w := httptest.NewRecorder()
+    ctx := context.NewContext()
+    ctx.Reset(w, r)
+    ctx.Input.RequestBody = []byte(body)
+
+    c := &ProductoPedidoController{}
+    c.Ctx = ctx
+    c.Data = make(map[interface{}]interface{})
+
+    c.Update()
+    if w.Code != http.StatusInternalServerError {
+        t.Fatalf("expected 500, got %d. Body: %s", w.Code, w.Body.String())
+    }
+    var resp models.ApiResponse
+    if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+        t.Fatalf("invalid response: %v", err)
+    }
+    if resp.Message != "Error al actualizar los productos del pedido" {
+        t.Fatalf("unexpected message: %s", resp.Message)
+    }
+}
+

--- a/controllers/productopedido/producto_pedido_update_requery_hook_error_branch_test.go
+++ b/controllers/productopedido/producto_pedido_update_requery_hook_error_branch_test.go
@@ -1,0 +1,75 @@
+package productopedido
+
+import (
+    stdctx "context"
+    "database/sql/driver"
+    "encoding/json"
+    "errors"
+    "net/http"
+    "net/http/httptest"
+    "strings"
+    "testing"
+
+    "restaurante/models"
+
+    "github.com/beego/beego/v2/client/orm"
+    "github.com/beego/beego/v2/server/web/context"
+)
+
+// Cubre la rama de error en productoPedidoRequeryDetalle durante Update
+func TestProductoPedidoUpdate_RequeryHookError(t *testing.T) {
+    origQ, origE := MockQuery, MockExec
+    origDel := productoPedidoDeleteDetalles
+    origReq := productoPedidoRequeryDetalle
+
+    // configuraciones para pasar hasta la reconsulta
+    MockQuery = func(_ stdctx.Context, q string, _ []driver.NamedValue) (driver.Rows, error) {
+        lower := strings.ToLower(q)
+        if strings.Contains(lower, "detalle_pedido") && !strings.Contains(lower, "insert into") {
+            return &mockRows{columns: []string{"pk_id_pedido"}, values: [][]driver.Value{}}, nil
+        }
+        if strings.Contains(lower, "select pk_id_producto, cantidad from producto") {
+            cols := []string{"pk_id_producto", "cantidad"}
+            vals := [][]driver.Value{{int64(1), int64(10)}}
+            return &mockRows{columns: cols, values: vals}, nil
+        }
+        return &mockRows{columns: []string{"ok"}, values: [][]driver.Value{{int64(1)}}}, nil
+    }
+    MockExec = func(_ stdctx.Context, _ string, _ []driver.NamedValue) (driver.Result, error) {
+        return mockResult{}, nil
+    }
+    productoPedidoDeleteDetalles = func(_ orm.TxOrmer, _ int64) error { return nil }
+    productoPedidoRequeryDetalle = func(_ orm.TxOrmer, _ int64, _ int64, _ *models.DetallePedido) error {
+        return errors.New("requery fail")
+    }
+
+    t.Cleanup(func() {
+        MockQuery, MockExec = origQ, origE
+        productoPedidoDeleteDetalles = origDel
+        productoPedidoRequeryDetalle = origReq
+    })
+
+    body := `[{"productoId":1,"cantidad":2}]`
+    r := httptest.NewRequest(http.MethodPut, "/producto_pedido?pedido_id=1", strings.NewReader(body))
+    w := httptest.NewRecorder()
+    ctx := context.NewContext()
+    ctx.Reset(w, r)
+    ctx.Input.RequestBody = []byte(body)
+
+    c := &ProductoPedidoController{}
+    c.Ctx = ctx
+    c.Data = make(map[interface{}]interface{})
+
+    c.Update()
+    if w.Code != http.StatusInternalServerError {
+        t.Fatalf("expected 500, got %d. Body: %s", w.Code, w.Body.String())
+    }
+    var resp models.ApiResponse
+    if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+        t.Fatalf("invalid response: %v", err)
+    }
+    if resp.Message != "Error al obtener el precio del producto" {
+        t.Fatalf("unexpected message: %s", resp.Message)
+    }
+}
+

--- a/controllers/productopedido/producto_pedido_update_rows_affected_error_message_test.go
+++ b/controllers/productopedido/producto_pedido_update_rows_affected_error_message_test.go
@@ -1,0 +1,74 @@
+package productopedido
+
+import (
+    stdctx "context"
+    "database/sql/driver"
+    "encoding/json"
+    "net/http"
+    "net/http/httptest"
+    "strings"
+    "testing"
+
+    "restaurante/models"
+
+    "github.com/beego/beego/v2/client/orm"
+    "github.com/beego/beego/v2/server/web/context"
+)
+
+// Cubre la rama de error en RowsAffected durante Update con validación de mensaje
+func TestProductoPedidoUpdate_RowsAffectedError_Message(t *testing.T) {
+    origQ, origE := MockQuery, MockExec
+    origDel := productoPedidoDeleteDetalles
+    origReq := productoPedidoRequeryDetalle
+
+    MockQuery = func(_ stdctx.Context, q string, _ []driver.NamedValue) (driver.Rows, error) {
+        lower := strings.ToLower(q)
+        if strings.Contains(lower, "detalle_pedido") {
+            return &mockRows{columns: []string{"pk_id_pedido"}, values: [][]driver.Value{}}, nil
+        }
+        if strings.Contains(lower, "select pk_id_producto, cantidad from producto") {
+            cols := []string{"pk_id_producto", "cantidad"}
+            vals := [][]driver.Value{{int64(1), int64(10)}}
+            return &mockRows{columns: cols, values: vals}, nil
+        }
+        return &mockRows{columns: []string{"ok"}, values: [][]driver.Value{{int64(1)}}}, nil
+    }
+    MockExec = func(_ stdctx.Context, q string, _ []driver.NamedValue) (driver.Result, error) {
+        if strings.Contains(strings.ToLower(q), "update producto set cantidad = cantidad -") {
+            return errResult{}, nil
+        }
+        return mockResult{}, nil
+    }
+    productoPedidoDeleteDetalles = func(_ orm.TxOrmer, _ int64) error { return nil }
+    productoPedidoRequeryDetalle = func(_ orm.TxOrmer, _ int64, _ int64, _ *models.DetallePedido) error { return nil }
+
+    t.Cleanup(func() {
+        MockQuery, MockExec = origQ, origE
+        productoPedidoDeleteDetalles = origDel
+        productoPedidoRequeryDetalle = origReq
+    })
+
+    body := `[{"productoId":1,"cantidad":2}]`
+    r := httptest.NewRequest(http.MethodPut, "/producto_pedido?pedido_id=1", strings.NewReader(body))
+    w := httptest.NewRecorder()
+    ctx := context.NewContext()
+    ctx.Reset(w, r)
+    ctx.Input.RequestBody = []byte(body)
+
+    c := &ProductoPedidoController{}
+    c.Ctx = ctx
+    c.Data = make(map[interface{}]interface{})
+
+    c.Update()
+    if w.Code != http.StatusInternalServerError {
+        t.Fatalf("expected 500, got %d. Body: %s", w.Code, w.Body.String())
+    }
+    var resp models.ApiResponse
+    if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+        t.Fatalf("invalid response: %v", err)
+    }
+    if resp.Message != "Error al verificar actualización de inventario" {
+        t.Fatalf("unexpected message: %s", resp.Message)
+    }
+}
+

--- a/controllers/productopedido/producto_pedido_update_rows_affected_zero_branch_test.go
+++ b/controllers/productopedido/producto_pedido_update_rows_affected_zero_branch_test.go
@@ -1,0 +1,81 @@
+package productopedido
+
+import (
+    stdctx "context"
+    "database/sql/driver"
+    "encoding/json"
+    "net/http"
+    "net/http/httptest"
+    "strings"
+    "testing"
+
+    "restaurante/models"
+
+    "github.com/beego/beego/v2/client/orm"
+    "github.com/beego/beego/v2/server/web/context"
+)
+
+type zeroResult struct{}
+
+func (zeroResult) LastInsertId() (int64, error) { return 0, nil }
+func (zeroResult) RowsAffected() (int64, error) { return 0, nil }
+
+// Cubre la rama where RowsAffected == 0 tras actualizar inventario
+func TestProductoPedidoUpdate_RowsAffectedZero(t *testing.T) {
+    origQ, origE := MockQuery, MockExec
+    origDel := productoPedidoDeleteDetalles
+    origReq := productoPedidoRequeryDetalle
+
+    MockQuery = func(_ stdctx.Context, q string, _ []driver.NamedValue) (driver.Rows, error) {
+        lower := strings.ToLower(q)
+        switch {
+        case strings.Contains(lower, "detalle_pedido"):
+            // consulta inicial vacía para delta positivo
+            return &mockRows{columns: []string{"pk_id_pedido"}, values: [][]driver.Value{}}, nil
+        case strings.Contains(lower, "select pk_id_producto, cantidad from producto"):
+            cols := []string{"pk_id_producto", "cantidad"}
+            vals := [][]driver.Value{{int64(1), int64(10)}}
+            return &mockRows{columns: cols, values: vals}, nil
+        default:
+            return &mockRows{columns: []string{"ok"}, values: [][]driver.Value{{int64(1)}}}, nil
+        }
+    }
+    MockExec = func(_ stdctx.Context, q string, _ []driver.NamedValue) (driver.Result, error) {
+        if strings.Contains(strings.ToLower(q), "update producto set cantidad = cantidad -") {
+            return zeroResult{}, nil
+        }
+        return mockResult{}, nil
+    }
+    productoPedidoDeleteDetalles = func(_ orm.TxOrmer, _ int64) error { return nil }
+    productoPedidoRequeryDetalle = func(_ orm.TxOrmer, _ int64, _ int64, _ *models.DetallePedido) error { return nil }
+
+    t.Cleanup(func() {
+        MockQuery, MockExec = origQ, origE
+        productoPedidoDeleteDetalles = origDel
+        productoPedidoRequeryDetalle = origReq
+    })
+
+    body := `[{"productoId":1,"cantidad":2}]`
+    r := httptest.NewRequest(http.MethodPut, "/producto_pedido?pedido_id=1", strings.NewReader(body))
+    w := httptest.NewRecorder()
+    ctx := context.NewContext()
+    ctx.Reset(w, r)
+    ctx.Input.RequestBody = []byte(body)
+
+    c := &ProductoPedidoController{}
+    c.Ctx = ctx
+    c.Data = make(map[interface{}]interface{})
+
+    c.Update()
+    if w.Code != http.StatusBadRequest {
+        t.Fatalf("expected 400, got %d. Body: %s", w.Code, w.Body.String())
+    }
+    var resp models.ApiResponse
+    if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+        t.Fatalf("invalid response: %v", err)
+    }
+    if resp.Message != "Inventario insuficiente para uno o más productos" {
+        t.Fatalf("unexpected message: %s", resp.Message)
+    }
+}
+

--- a/controllers/productopedido/producto_pedido_update_stock_restore_error_branch_test.go
+++ b/controllers/productopedido/producto_pedido_update_stock_restore_error_branch_test.go
@@ -1,0 +1,73 @@
+package productopedido
+
+import (
+    stdctx "context"
+    "database/sql/driver"
+    "encoding/json"
+    "errors"
+    "net/http"
+    "net/http/httptest"
+    "strings"
+    "testing"
+
+    "restaurante/models"
+
+    "github.com/beego/beego/v2/client/orm"
+    "github.com/beego/beego/v2/server/web/context"
+)
+
+// Cubre la rama de error al restaurar inventario cuando delta < 0
+func TestProductoPedidoUpdate_StockRestoreError(t *testing.T) {
+    origQ, origE := MockQuery, MockExec
+    origDel := productoPedidoDeleteDetalles
+    origReq := productoPedidoRequeryDetalle
+
+    MockQuery = func(_ stdctx.Context, q string, _ []driver.NamedValue) (driver.Rows, error) {
+        lower := strings.ToLower(q)
+        if strings.Contains(lower, "detalle_pedido") {
+            // existentes con cantidad 3 para delta negativo
+            cols := []string{"pk_id_detalle", "pk_id_pedido", "pk_id_producto", "cantidad", "precio"}
+            vals := [][]driver.Value{{int64(1), int64(1), int64(1), int64(3), int64(1000)}}
+            return &mockRows{columns: cols, values: vals}, nil
+        }
+        return &mockRows{columns: []string{"ok"}, values: [][]driver.Value{{int64(1)}}}, nil
+    }
+    MockExec = func(_ stdctx.Context, q string, _ []driver.NamedValue) (driver.Result, error) {
+        if strings.Contains(strings.ToLower(q), "update producto set cantidad = cantidad +") {
+            return nil, errors.New("restore fail")
+        }
+        return mockResult{}, nil
+    }
+    productoPedidoDeleteDetalles = func(_ orm.TxOrmer, _ int64) error { return nil }
+    productoPedidoRequeryDetalle = func(_ orm.TxOrmer, _ int64, _ int64, _ *models.DetallePedido) error { return nil }
+
+    t.Cleanup(func() {
+        MockQuery, MockExec = origQ, origE
+        productoPedidoDeleteDetalles = origDel
+        productoPedidoRequeryDetalle = origReq
+    })
+
+    body := `[{"productoId":1,"cantidad":1}]` // antes 3 -> delta -2
+    r := httptest.NewRequest(http.MethodPut, "/producto_pedido?pedido_id=1", strings.NewReader(body))
+    w := httptest.NewRecorder()
+    ctx := context.NewContext()
+    ctx.Reset(w, r)
+    ctx.Input.RequestBody = []byte(body)
+
+    c := &ProductoPedidoController{}
+    c.Ctx = ctx
+    c.Data = make(map[interface{}]interface{})
+
+    c.Update()
+    if w.Code != http.StatusInternalServerError {
+        t.Fatalf("expected 500, got %d. Body: %s", w.Code, w.Body.String())
+    }
+    var resp models.ApiResponse
+    if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+        t.Fatalf("invalid response: %v", err)
+    }
+    if resp.Message != "Error al ajustar inventario" {
+        t.Fatalf("unexpected message: %s", resp.Message)
+    }
+}
+


### PR DESCRIPTION
## Summary
- add tests for ProductoPedidoController.Update covering error paths (rows affected zero, inventory restore fail, delete detalles fail, insert/requery detail failures, commit error)

## Testing
- `go test -count=1 -cover -coverpkg=restaurante/controllers/productopedido ./controllers/productopedido` *(fails: Forbidden module download)*
- `go test -count=1 -coverprofile productopedido.out -coverpkg restaurante/controllers/productopedido ./controllers/productopedido` *(fails: Forbidden module download)*
- `go tool cover -func productopedido.out`

------
https://chatgpt.com/codex/tasks/task_e_68c341874c108325a99ebd2ae4fdf812